### PR TITLE
Add iplotx to network drawing documentation

### DIFF
--- a/doc/reference/drawing.rst
+++ b/doc/reference/drawing.rst
@@ -24,8 +24,9 @@ GraphML format, and so, ``networkx.write_graphml(G, path)`` might be an appropri
 choice.
 
 .. tip::
+
    ``iplotx`` accepts NetworkX native data structures without exporting to a file.
-   An example is provided below. 
+   An example is provided below.
 
 More information on the features provided here are available at
  - matplotlib:  http://matplotlib.org/

--- a/doc/reference/drawing.rst
+++ b/doc/reference/drawing.rst
@@ -14,7 +14,8 @@ visualize their graphs with tools dedicated to that task. Notable examples of
 dedicated and fully-featured graph visualization tools are
 `Cytoscape <http://www.cytoscape.org/>`_,
 `Gephi <https://gephi.org/>`_,
-`Graphviz <http://www.graphviz.org/>`_ and, for
+`Graphviz <http://www.graphviz.org/>`_,
+`iplotx <https://iplotx.readthedocs.io/>`_ and, for
 `LaTeX <http://www.latex-project.org/>`_ typesetting,
 `PGF/TikZ <https://sourceforge.net/projects/pgf/>`_.
 To use these and other such tools, you should export your NetworkX graph into
@@ -22,10 +23,14 @@ a format that can be read by those tools. For example, Cytoscape can read the
 GraphML format, and so, ``networkx.write_graphml(G, path)`` might be an appropriate
 choice.
 
+.. tip::
+   ``iplotx`` accepts NetworkX native data structures without exporting to a file.
+   An example is provided below. 
+
 More information on the features provided here are available at
  - matplotlib:  http://matplotlib.org/
  - pygraphviz:  http://pygraphviz.github.io/
-
+ - iplotx: https://iplotx.readthedocs.io/
 
 Matplotlib
 ==========
@@ -50,6 +55,23 @@ Matplotlib
    draw_spring
    draw_shell
 
+Matplotlib with iplotx
+======================
+Draw networks with matplotlib, using ``iplotx`` for extended styling options.
+
+Examples
+--------
+.. code-block:: python
+
+  >>> import iplotx as ipx
+  >>> G = nx.cycle_graph(n=5, create_using=nx.DiGraph)
+  >>> layout = nx.layout.circular_layout(G)
+  >>> ipx.network(G, layout=layout, vertex_facecolor=["tomato", "gold"])
+
+See Also
+--------
+- `iplotx <https://iplotx.readthedocs.io/>`_
+- `iplotx.network <https://iplotx.readthedocs.io/en/latest/api/plotting.html#plotting-api>`_
 
 
 Graphviz AGraph (dot)

--- a/doc/reference/drawing.rst
+++ b/doc/reference/drawing.rst
@@ -64,8 +64,8 @@ Examples
 .. code-block:: python
 
   >>> import iplotx as ipx
-  >>> G = nx.cycle_graph(n=5, create_using=nx.DiGraph)
-  >>> layout = nx.layout.circular_layout(G)
+  >>> G = nx.cycle_graph(5, create_using=nx.DiGraph)
+  >>> layout = nx.circular_layout(G)
   >>> ipx.network(G, layout=layout, vertex_facecolor=["tomato", "gold"])
 
 See Also

--- a/examples/external/plot_iplotx.py
+++ b/examples/external/plot_iplotx.py
@@ -1,0 +1,57 @@
+"""
+======
+iplotx
+======
+
+``iplotx`` (https://iplotx.readthedocs.io/) is a network visualisation library
+designed to extend the styling options for native NetworkX objects. It uses
+``matplotlib`` behind the scenes, just like NetworkX's internal functions, so
+it is compatible with all examples in the gallery while offering additional
+choices to customise your visualisation.
+"""
+
+from collections import defaultdict
+import matplotlib.pyplot as plt
+import networkx as nx
+import iplotx as ipx
+
+G = nx.dense_gnm_random_graph(30, 40, seed=42)
+
+# Get largest connected component
+components = nx.connected_components(G)
+largest_component = max(components, key=len)
+H = G.subgraph(largest_component)
+
+# Compute layout
+layout = nx.kamada_kawai_layout(H)
+
+ipx.network(
+    H,
+    layout,
+    # Constant styling
+    vertex_marker="s",
+    vertex_edgecolor="black",
+    vertex_linewidth=1.5,
+    # Per-element styling, with fallback
+    vertex_size=defaultdict(lambda: 17, {0: 50, 1: 30, 2: 40}),
+    # Cycling styling
+    vertex_facecolor=["lightblue", "steelblue", "dodgerblue"],
+    vertex_label_color=["black", "white", "white"],
+    # Add vertex labels
+    vertex_labels=True,
+    # Edge styling
+    edge_alpha=0.7,
+    edge_padding=3,
+    # Custom drawing order (vertices on top)
+    edge_zorder=2,
+    vertex_zorder=3,
+    # Custom axes-level options
+    margins=0.1,
+    figsize=(8, 8),
+)
+plt.tight_layout()
+
+# %%
+# Below is a minimal example with default settings:
+
+ipx.network(H, layout)

--- a/examples/external/plot_iplotx.py
+++ b/examples/external/plot_iplotx.py
@@ -41,7 +41,7 @@ ipx.network(
     node_labels=True,
     # Edge styling
     edge_alpha=0.7,
-    edge_padding=3,
+    edge_shrink=3,
     # Custom drawing order (nodes on top)
     edge_zorder=2,
     node_zorder=3,

--- a/examples/external/plot_iplotx.py
+++ b/examples/external/plot_iplotx.py
@@ -29,22 +29,22 @@ ipx.network(
     H,
     layout,
     # Constant styling
-    vertex_marker="s",
-    vertex_edgecolor="black",
-    vertex_linewidth=1.5,
+    node_marker="s",
+    node_edgecolor="black",
+    node_linewidth=1.5,
     # Per-element styling, with fallback
-    vertex_size=defaultdict(lambda: 17, {0: 50, 1: 30, 2: 40}),
+    node_size=defaultdict(lambda: 17, {0: 50, 1: 30, 2: 40}),
     # Cycling styling
-    vertex_facecolor=["lightblue", "steelblue", "dodgerblue"],
-    vertex_label_color=["black", "white", "white"],
-    # Add vertex labels
-    vertex_labels=True,
+    node_facecolor=["lightblue", "steelblue", "dodgerblue"],
+    node_label_color=["black", "white", "white"],
+    # Add node labels
+    node_labels=True,
     # Edge styling
     edge_alpha=0.7,
     edge_padding=3,
-    # Custom drawing order (vertices on top)
+    # Custom drawing order (nodes on top)
     edge_zorder=2,
-    vertex_zorder=3,
+    node_zorder=3,
     # Custom axes-level options
     margins=0.1,
     figsize=(8, 8),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ example = [
     'cairocffi>=1.7',
     'igraph>=0.11',
     'scikit-learn>=1.5',
+    'iplotx>=0.6.8',
 ]
 extra = [
     'lxml>=4.6',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ example = [
     'cairocffi>=1.7',
     'igraph>=0.11',
     'scikit-learn>=1.5',
-    'iplotx>=0.6.8',
+    'iplotx>=0.9.0',
 ]
 extra = [
     'lxml>=4.6',

--- a/requirements/example.txt
+++ b/requirements/example.txt
@@ -7,3 +7,4 @@ seaborn>=0.13
 cairocffi>=1.7
 igraph>=0.11
 scikit-learn>=1.5
+iplotx>=0.9.0


### PR DESCRIPTION
After previous communication with @dschult and @tacaswell , the `iplotx` library (https://iplotx.readthedocs.org) was recently developed (by myself) to offer seamless network visualisation from both NetworkX and igraph:

- working with native data structures, with no need for file export/import
- expanding the range of styling options compared to internal NetworkX functions
- using well behaved matplotlib artists that can be animated or edited after the fact
- ensuring correct behaviour across backends, DPI resolutions, zoom/pan operations

This draft PR proposes to add specific mentions and examples of `iplotx` into NetworkX's documentation to let users know that option for network visualisation is available.

For starters, I added a mention in the drawing reference docs and an example in the "external" subgallery.

It would be great if one of you guys could take a quick look and share your thought on this. The iplotx API is slowly crystallising but currently still fluid enough that adjustments can be made to simplify life for end users.

After an initial round of feedback on the concept, I'm happy to fix CI issues, polish details, etc. etc. to meet your usual standards for PR acceptance.

THANK YOU!


