### PR TITLE
Install ffmpeg in circleci docs pipeline.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,14 +16,17 @@ jobs:
             sudo apt update
 
       - run:
+          # Optional dependency for more efficient matplotlib animation
+          name: Install ffmpeg
+          command: sudo apt install -y ffmpeg
+
+      - run:
           name: Install Graphviz
-          command: |
-            sudo apt install graphviz libgraphviz-dev
+          command: sudo apt install -y graphviz libgraphviz-dev
 
       - run:
           name: Install pysal dependencies
-          command: |
-            sudo apt install libspatialindex-dev
+          command: sudo apt install -y libspatialindex-dev
 
       - restore_cache:
           keys:


### PR DESCRIPTION
Something I noticed while looking through CI build logs trying to figure out what's going on with the pipelines for #8289. May improve matplotlib animation gallery example runtimes.