### PR TITLE
Fix sphinx build errors

### DIFF
--- a/doc/reference/algorithms/shortest_paths.rst
+++ b/doc/reference/algorithms/shortest_paths.rst
@@ -245,7 +245,7 @@ single-target query.
 :meth:`Graph.copy <networkx.Graph.copy>` to operate on a duplicate.
 
 Sentinel Node trick for Multi-Target Queries
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------
 
 To find the shortest path from a source node :math:`s` to the nearest of several
 target nodes :math:`\{t_1, t_2, \ldots, t_k\}`, you can:

--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -172,7 +172,7 @@ def edge_betweenness_centrality(G, k=None, normalized=True, weight=None, seed=No
 
     where $V$ is the set of nodes, $\sigma(s, t)$ is the number of
     shortest $(s, t)$-paths, and $\sigma(s, t|e)$ is the number of
-    those paths passing through edge $e$ [2]_.
+    those paths passing through edge $e$ [1]_.
 
     Parameters
     ----------

--- a/networkx/algorithms/centrality/betweenness_subset.py
+++ b/networkx/algorithms/centrality/betweenness_subset.py
@@ -133,7 +133,7 @@ def edge_betweenness_centrality_subset(
     where $S$ is the set of sources, $T$ is the set of targets,
     $\sigma(s, t)$ is the number of shortest $(s, t)$-paths,
     and $\sigma(s, t|e)$ is the number of those paths
-    passing through edge $e$ [2]_.
+    passing through edge $e$ [1]_.
 
     Parameters
     ----------


### PR DESCRIPTION
A couple new sphinx errors from a detailed look at the build logs.

The first is related to the whole mess of how rst handles headers. It didn't like `~~~~` as that hadn't been used yet (and therefore was assigned `h4`) while the preceding header was an `h1`. There are basically two options - force this to an `h1` (which I opted for in 8d28fe9), or change this to an `h3` (which maps to `^^^^^`) then modify the Example heading below to use `~~~~~`.

The second is related to missing references after the betweenness centrality docstring updates in #8256 .