### PR TITLE
DOC: add gallery example for metric_closure

### DIFF
--- a/examples/algorithms/plot_metric_closure.py
+++ b/examples/algorithms/plot_metric_closure.py
@@ -68,7 +68,7 @@ nx.draw(M, pos_mc, with_labels=True, ax=axes[1])
 nx.draw_networkx_edge_labels(
     M,
     pos,
-    edge_labels={(u, v): d["distance"] for u, v, d in M.edges(data=True)},
+    edge_labels={(u, v): d for u, v, d in M.edges(data="distance")},
     ax=axes[1],
 )
 axes[1].set_title("Metric Closure of Origin Graph")

--- a/examples/algorithms/plot_metric_closure.py
+++ b/examples/algorithms/plot_metric_closure.py
@@ -71,6 +71,6 @@ nx.draw_networkx_edge_labels(
     edge_labels={(u, v): d for u, v, d in M.edges(data="distance")},
     ax=axes[1],
 )
-axes[1].set_title("Metric Closure of Origin Graph")
+axes[1].set_title("Metric Closure of Original Graph")
 
 plt.show()

--- a/examples/algorithms/plot_metric_closure.py
+++ b/examples/algorithms/plot_metric_closure.py
@@ -41,7 +41,7 @@ for u, dist_dict in paths.items():
 # Visualize the G and metric closure of G
 fig, axes = plt.subplots(1, 2, figsize=(10, 4))
 
-pos = nx.circular_layout(G)
+pos = {0: (0, 0), 1: (1, 0), 2: (0, 1), 3: (1, 1), 4: (0.5, 2.0)}
 nx.draw(G, pos, with_labels=True, ax=axes[0])
 nx.draw_networkx_edge_labels(
     G,

--- a/examples/algorithms/plot_metric_closure.py
+++ b/examples/algorithms/plot_metric_closure.py
@@ -38,7 +38,7 @@ for u, dist_dict in paths.items():
     for v, d in dist_dict.items():
         if u != v:  # avoid self-loops
             M.add_edge(u, v, distance=d)
-# Visualize the G and metric closure of G
+# Visualize G and its metric closure
 fig, axes = plt.subplots(1, 2, figsize=(10, 4))
 
 pos = {0: (0, 0), 1: (1, 0), 2: (0, 1), 3: (1, 1), 4: (0.5, 2.0)}

--- a/examples/algorithms/plot_metric_closure.py
+++ b/examples/algorithms/plot_metric_closure.py
@@ -7,8 +7,14 @@ The *metric closure* of a graph is the complete graph in which
 each edge weight corresponds to the shortest-path distance
 between two nodes in the original graph.
 
-This example implements the *metric closure* of a given graph using
-:func:`networkx.all_pairs_dijkstra_path_length`.
+This example demonstrates the *unweighted* version of the metric closure,
+constructed using :func:`networkx.all_pairs_shortest_path_length`.
+Here, each edge is assumed to have weight 1, so distances correspond to
+the minimum number of hops between nodes.
+
+For weighted graphs, the metric closure can be obtained instead with
+:func:`networkx.all_pairs_dijkstra_path_length`, which computes distances
+using the minimum total edge weights along paths.
 """
 
 import networkx as nx
@@ -17,30 +23,33 @@ import matplotlib.pyplot as plt
 # Creating five nodes from index 0 to 4
 G = nx.Graph()
 G.add_nodes_from(range(5))
-G.add_edge(0, 1, weight=6)
-G.add_edge(0, 4, weight=3)
-G.add_edge(1, 3, weight=12)
-G.add_edge(1, 5, weight=5)
-G.add_edge(2, 3, weight=8)
-G.add_edge(2, 4, weight=10)
-G.add_edge(2, 5, weight=9)
-G.add_edge(3, 4, weight=2)
-G.add_edge(3, 5, weight=3)
-G.add_edge(4, 5, weight=7)
+G.add_edge(0, 1)
+G.add_edge(0, 4)
+G.add_edge(1, 3)
+G.add_edge(1, 5)
+G.add_edge(2, 3)
+G.add_edge(2, 4)
+G.add_edge(2, 5)
+G.add_edge(3, 4)
+G.add_edge(3, 5)
+G.add_edge(4, 5)
 
-# Find the all-pairs shortest distance(weight)
-# all_pairs_dijkstra_path_length returns a one-time generator,
+# Find the all-pairs shortest distance
+# all_pairs_shortest_path_length returns a one-time generator,
 # so wrap with dict() to materialize results for reuse.
-paths = dict(nx.all_pairs_dijkstra_path_length(G, weight="weight"))
+paths = dict(nx.all_pairs_shortest_path_length(G))
 for u, dist_dict in paths.items():
-    print(f"Weighted shortest path distances from node {u}: {dist_dict}")
+    print(
+        f"From node {u}, distances to all other nodes: {dist_dict} "
+        "(keys = target nodes, values = shortest-path distances)"
+    )
 
 # Metric closure of G
 M = nx.Graph()
 for u, dist_dict in paths.items():
     for v, d in dist_dict.items():
         if u != v:  # avoid self-loops
-            M.add_edge(u, v, weight=d)
+            M.add_edge(u, v, distance=d)
 # Visualize the G and metric closure of G
 fig, axes = plt.subplots(1, 2, figsize=(10, 4))
 
@@ -49,7 +58,7 @@ nx.draw(G, pos, with_labels=True, ax=axes[0])
 nx.draw_networkx_edge_labels(
     G,
     pos,
-    edge_labels={(u, v): d["weight"] for u, v, d in G.edges(data=True)},
+    edge_labels={(u, v): 1 for u, v, d in G.edges(data=True)},
     ax=axes[0],
 )
 axes[0].set_title("Original Graph")
@@ -59,7 +68,7 @@ nx.draw(M, pos_mc, with_labels=True, ax=axes[1])
 nx.draw_networkx_edge_labels(
     M,
     pos,
-    edge_labels={(u, v): d["weight"] for u, v, d in M.edges(data=True)},
+    edge_labels={(u, v): d["distance"] for u, v, d in M.edges(data=True)},
     ax=axes[1],
 )
 axes[1].set_title("Metric Closure of Origin Graph")

--- a/examples/algorithms/plot_metric_closure.py
+++ b/examples/algorithms/plot_metric_closure.py
@@ -63,7 +63,7 @@ nx.draw_networkx_edge_labels(
 )
 axes[0].set_title("Original Graph")
 
-pos_mc = nx.spring_layout(M, seed=2210)
+pos_mc = nx.circular_layout(M)
 nx.draw(M, pos_mc, with_labels=True, ax=axes[1])
 nx.draw_networkx_edge_labels(
     M,

--- a/examples/algorithms/plot_metric_closure.py
+++ b/examples/algorithms/plot_metric_closure.py
@@ -19,30 +19,19 @@ using the minimum total edge weights along paths.
 
 import networkx as nx
 import matplotlib.pyplot as plt
+from pprint import pprint
 
 # Creating five nodes from index 0 to 4
-G = nx.Graph()
-G.add_nodes_from(range(5))
-G.add_edge(0, 1)
-G.add_edge(0, 4)
-G.add_edge(1, 3)
-G.add_edge(1, 5)
-G.add_edge(2, 3)
-G.add_edge(2, 4)
-G.add_edge(2, 5)
-G.add_edge(3, 4)
-G.add_edge(3, 5)
-G.add_edge(4, 5)
+G = nx.house_graph()
 
 # Find the all-pairs shortest distance
 # all_pairs_shortest_path_length returns a one-time generator,
 # so wrap with dict() to materialize results for reuse.
 paths = dict(nx.all_pairs_shortest_path_length(G))
-for u, dist_dict in paths.items():
-    print(
-        f"From node {u}, distances to all other nodes: {dist_dict} "
-        "(keys = target nodes, values = shortest-path distances)"
-    )
+
+
+# Dictionary format: u: {v: d}, meaning "distance d from node u to node v"
+pprint(paths)
 
 # Metric closure of G
 M = nx.Graph()
@@ -53,7 +42,7 @@ for u, dist_dict in paths.items():
 # Visualize the G and metric closure of G
 fig, axes = plt.subplots(1, 2, figsize=(10, 4))
 
-pos = nx.spring_layout(G, seed=2210)
+pos = nx.circular_layout(G)
 nx.draw(G, pos, with_labels=True, ax=axes[0])
 nx.draw_networkx_edge_labels(
     G,

--- a/examples/algorithms/plot_metric_closure.py
+++ b/examples/algorithms/plot_metric_closure.py
@@ -55,7 +55,7 @@ pos_mc = nx.circular_layout(M)
 nx.draw(M, pos_mc, with_labels=True, ax=axes[1])
 nx.draw_networkx_edge_labels(
     M,
-    pos,
+    pos_mc,
     edge_labels={(u, v): d for u, v, d in M.edges(data="distance")},
     ax=axes[1],
 )

--- a/examples/algorithms/plot_metric_closure.py
+++ b/examples/algorithms/plot_metric_closure.py
@@ -26,7 +26,7 @@ G = nx.house_graph()
 
 # Find the all-pairs shortest distance
 # all_pairs_shortest_path_length returns a one-time generator,
-# so wrap with dict() to materialize results for reuse.
+# so wrap with dict() to materialize results for reuse
 paths = dict(nx.all_pairs_shortest_path_length(G))
 
 # Dictionary format: u: {v: d}, meaning "distance d from node u to node v"

--- a/examples/algorithms/plot_metric_closure.py
+++ b/examples/algorithms/plot_metric_closure.py
@@ -8,13 +8,14 @@ each edge weight corresponds to the shortest-path distance
 between two nodes in the original graph.
 
 This example demonstrates the *unweighted* version of the metric closure,
-constructed using :func:`networkx.all_pairs_shortest_path_length`.
+constructed using
+:func:`~networkx.algorithms.shortest_paths.unweighted.all_pairs_shortest_path_length`.
 Here, each edge is assumed to have weight 1, so distances correspond to
 the minimum number of hops between nodes.
 
 For weighted graphs, the metric closure can be obtained instead with
-:func:`networkx.all_pairs_dijkstra_path_length`, which computes distances
-using the minimum total edge weights along paths.
+:func:`~networkx.algorithms.shortest_paths.weighted.all_pairs_dijkstra_path_length`,
+which computes distances using the minimum total edge weights along paths.
 """
 
 import networkx as nx

--- a/examples/algorithms/plot_metric_closure.py
+++ b/examples/algorithms/plot_metric_closure.py
@@ -1,0 +1,67 @@
+"""
+==============
+Metric Closure
+==============
+
+The *metric closure* of a graph is the complete graph in which
+each edge weight corresponds to the shortest-path distance
+between two nodes in the original graph.
+
+This example implements the *metric closure* of a given graph using
+:func:`networkx.all_pairs_dijkstra_path_length`.
+"""
+
+import networkx as nx
+import matplotlib.pyplot as plt
+
+# Creating five nodes from index 0 to 4
+G = nx.Graph()
+G.add_nodes_from(range(5))
+G.add_edge(0, 1, weight=6)
+G.add_edge(0, 4, weight=3)
+G.add_edge(1, 3, weight=12)
+G.add_edge(1, 5, weight=5)
+G.add_edge(2, 3, weight=8)
+G.add_edge(2, 4, weight=10)
+G.add_edge(2, 5, weight=9)
+G.add_edge(3, 4, weight=2)
+G.add_edge(3, 5, weight=3)
+G.add_edge(4, 5, weight=7)
+
+# Find the all-pairs shortest distance(weight)
+# all_pairs_dijkstra_path_length returns a one-time generator,
+# so wrap with dict() to materialize results for reuse.
+paths = dict(nx.all_pairs_dijkstra_path_length(G, weight="weight"))
+for u, dist_dict in paths.items():
+    print(f"Weighted shortest path distances from node {u}: {dist_dict}")
+
+# Metric closure of G
+M = nx.Graph()
+for u, dist_dict in paths.items():
+    for v, d in dist_dict.items():
+        if u != v:  # avoid self-loops
+            M.add_edge(u, v, weight=d)
+# Visualize the G and metric closure of G
+fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+
+pos = nx.spring_layout(G, seed=2210)
+nx.draw(G, pos, with_labels=True, ax=axes[0])
+nx.draw_networkx_edge_labels(
+    G,
+    pos,
+    edge_labels={(u, v): d["weight"] for u, v, d in G.edges(data=True)},
+    ax=axes[0],
+)
+axes[0].set_title("Original Graph")
+
+pos_mc = nx.spring_layout(M, seed=2210)
+nx.draw(M, pos_mc, with_labels=True, ax=axes[1])
+nx.draw_networkx_edge_labels(
+    M,
+    pos,
+    edge_labels={(u, v): d["weight"] for u, v, d in M.edges(data=True)},
+    ax=axes[1],
+)
+axes[1].set_title("Metric Closure of Origin Graph")
+
+plt.show()

--- a/examples/algorithms/plot_metric_closure.py
+++ b/examples/algorithms/plot_metric_closure.py
@@ -29,7 +29,6 @@ G = nx.house_graph()
 # so wrap with dict() to materialize results for reuse.
 paths = dict(nx.all_pairs_shortest_path_length(G))
 
-
 # Dictionary format: u: {v: d}, meaning "distance d from node u to node v"
 pprint(paths)
 


### PR DESCRIPTION
This PR updates the new gallery example for the metric closure.

- Clarifies the definition of the metric closure for both weighted and unweighted graphs:
  - For weighted graphs, edge weights in the closure correspond to the minimum total
    weight along any path between two nodes.
  - For unweighted graphs, all edges are assumed to have weight 1, so closure weights
    correspond to the minimum number of hops.

- Adjusts the example to demonstrate the *unweighted* version using
  :func:`networkx.all_pairs_shortest_path_length`.

- Notes in the docstring that the weighted version can be obtained by using
  :func:`networkx.all_pairs_dijkstra_path_length` instead.

The goal is to reduce potential confusion around whether "shortest path" refers to hop
count or weighted distance, and to provide a clear demonstration in the simplest (unweighted)
case, with guidance for extending to weighted graphs.

closes to #8302 