### PR TITLE
DOC: Move deprecation procedure from contributing->dev guide.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -172,31 +172,9 @@ Development Workflow
    If your change introduces any API modifications including deprecations,
    please make sure the PR has the ``type: API`` label.
 
-   To set up a function for deprecation:
-
-   - Use a deprecation warning to warn users. For example::
-
-         msg = "curly_hair is deprecated and will be removed in v3.0. Use sum() instead."
-         warnings.warn(msg, DeprecationWarning)
-
-   - Add a warnings filter to ``networkx/conftest.py``::
-
-         warnings.filterwarnings(
-             "ignore", category=DeprecationWarning, message=<start of message>
-         )
-
-   - Add a reminder to ``doc/developer/deprecations.rst`` for the team
-     to remove the deprecated functionality in the future. For example:
-
-     .. code-block:: rst
-
-        * In ``utils/misc.py`` remove ``generate_unique_node`` and related tests.
-
-   .. note::
-
-      To reviewers: make sure the merge message has a brief description of the
-      change(s) and if the PR closes an issue add, for example, "Closes #123"
-      where 123 is the issue number.
+   See the
+   `deprecation policy <https://networkx.org/documentation/latest/developer/deprecations>`__
+   for a step-by-step guide to the deprecation procedure.
 
 
 Divergence from ``upstream main``

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -173,7 +173,7 @@ Development Workflow
    please make sure the PR has the ``type: API`` label.
 
    See the
-   `deprecation policy <https://networkx.org/documentation/latest/developer/deprecations>`__
+   `deprecation policy <https://networkx.org/documentation/latest/developer/deprecations#procedure>`__
    for a step-by-step guide to the deprecation procedure.
 
 

--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -36,6 +36,34 @@ releases is not a strict rule and in some cases, the developers can agree on a
 different procedure upon justification (like when we can't detect the change,
 or it involves moving or deleting an entire function for example).
 
+Procedure
+---------
+To set up a function for deprecation:
+
+- Use a deprecation warning to warn users. For example::
+
+      msg = "curly_hair is deprecated and will be removed in v3.0. Use sum() instead."
+      warnings.warn(msg, DeprecationWarning)
+
+- Add a warnings filter to ``networkx/conftest.py``::
+
+      warnings.filterwarnings(
+          "ignore", category=DeprecationWarning, message=<start of message>
+      )
+
+- Add a reminder to ``doc/developer/deprecations.rst`` for the team
+  to remove the deprecated functionality in the future. For example:
+
+  .. code-block:: rst
+
+     * In ``utils/misc.py`` remove ``generate_unique_node`` and related tests.
+
+.. note::
+
+   To reviewers: make sure the merge message has a brief description of the
+   change(s) and if the PR closes an issue add, for example, "Closes #123"
+   where 123 is the issue number.
+
 Todo
 ----
 


### PR DESCRIPTION
A minor doc refactor that reorganizes where the deprecation procedure is found. Currently it lives in [step 7 of the development workflow in the contributor guide](https://networkx.org/documentation/latest/developer/contribute.html#development-workflow). I have trouble finding it every time I look for it.

This PR moves it to the [Deprecations](https://networkx.org/documentation/latest/developer/deprecations.html) article which has a top-level heading in the developer guide (see the left side-bar on the linked page). Placing it here will also provide an anchor link to the section, making it easier to refer/link to elsewhere.

Note I didn't change the text of the deprecation procedure at all, just where it lives!