### PR TITLE
Fix node attributes on lattice graphs

### DIFF
--- a/networkx/generators/lattice.py
+++ b/networkx/generators/lattice.py
@@ -359,15 +359,16 @@ def hexagonal_lattice_graph(
         G.remove_node((n, M))
 
     # calc position in embedded space
-    ii = (i for i in cols for j in rows)
-    jj = (j for i in cols for j in rows)
-    xx = (0.5 + i + i // 2 + (j % 2) * ((i % 2) - 0.5) for i in cols for j in rows)
-    h = sqrt(3) / 2
-    if periodic:
-        yy = (h * j + 0.01 * i * i for i in cols for j in rows)
-    else:
-        yy = (h * j for i in cols for j in rows)
-    # exclude nodes not in G
-    pos = {(i, j): (x, y) for i, j, x, y in zip(ii, jj, xx, yy) if (i, j) in G}
-    set_node_attributes(G, pos, "pos")
+    if with_positions:
+        ii = (i for i in cols for j in rows)
+        jj = (j for i in cols for j in rows)
+        xx = (0.5 + i + i // 2 + (j % 2) * ((i % 2) - 0.5) for i in cols for j in rows)
+        h = sqrt(3) / 2
+        if periodic:
+            yy = (h * j + 0.01 * i * i for i in cols for j in rows)
+        else:
+            yy = (h * j for i in cols for j in rows)
+        # exclude nodes not in G
+        pos = {(i, j): (x, y) for i, j, x, y in zip(ii, jj, xx, yy) if (i, j) in G}
+        set_node_attributes(G, pos, "pos")
     return G

--- a/networkx/generators/lattice.py
+++ b/networkx/generators/lattice.py
@@ -347,15 +347,13 @@ def hexagonal_lattice_graph(
     G.remove_node((n, (M + 1) * (n % 2)))
 
     # identify boundary nodes if periodic
-    from networkx.algorithms.minors import contracted_nodes
-
     if periodic:
         for i in cols[:n]:
-            G = contracted_nodes(G, (i, 0), (i, M))
+            G = nx.contracted_nodes(G, (i, 0), (i, M))
         for i in cols[1:]:
-            G = contracted_nodes(G, (i, 1), (i, M + 1))
+            G = nx.contracted_nodes(G, (i, 1), (i, M + 1))
         for j in rows[1:M]:
-            G = contracted_nodes(G, (0, j), (n, j))
+            G = nx.contracted_nodes(G, (0, j), (n, j))
         G.remove_node((n, M))
 
     # calc position in embedded space

--- a/networkx/generators/lattice.py
+++ b/networkx/generators/lattice.py
@@ -250,14 +250,13 @@ def triangular_lattice_graph(
     # add diagonals
     H.add_edges_from(((i, j), (i + 1, j + 1)) for j in rows[1:m:2] for i in cols[:N])
     H.add_edges_from(((i + 1, j), (i, j + 1)) for j in rows[:m:2] for i in cols[:N])
-    # identify boundary nodes if periodic
-    from networkx.algorithms.minors import contracted_nodes
 
+    # identify boundary nodes if periodic
     if periodic is True:
         for i in cols:
-            H = contracted_nodes(H, (i, 0), (i, m))
+            H = nx.contracted_nodes(H, (i, 0), (i, m), store_contraction_as=None)
         for j in rows[:m]:
-            H = contracted_nodes(H, (0, j), (N, j))
+            H = nx.contracted_nodes(H, (0, j), (N, j), store_contraction_as=None)
     elif n % 2:
         # remove extra nodes
         H.remove_nodes_from((N, j) for j in rows[1::2])

--- a/networkx/generators/lattice.py
+++ b/networkx/generators/lattice.py
@@ -349,11 +349,11 @@ def hexagonal_lattice_graph(
     # identify boundary nodes if periodic
     if periodic:
         for i in cols[:n]:
-            G = nx.contracted_nodes(G, (i, 0), (i, M))
+            G = nx.contracted_nodes(G, (i, 0), (i, M), store_contraction_as=None)
         for i in cols[1:]:
-            G = nx.contracted_nodes(G, (i, 1), (i, M + 1))
+            G = nx.contracted_nodes(G, (i, 1), (i, M + 1), store_contraction_as=None)
         for j in rows[1:M]:
-            G = nx.contracted_nodes(G, (0, j), (n, j))
+            G = nx.contracted_nodes(G, (0, j), (n, j), store_contraction_as=None)
         G.remove_node((n, M))
 
     # calc position in embedded space

--- a/networkx/generators/tests/test_lattice.py
+++ b/networkx/generators/tests/test_lattice.py
@@ -14,11 +14,14 @@ def test_hexagonal_lattice_no_pos():
     assert all(pos is None for _, pos in G.nodes(data="pos"))
 
 
-def test_hexagonal_lattice_no_contraction_leftovers():
-    """hexagonal_lattice_graph uses nx.contracted_nodes under-the-hood when
-    periodic=True. Check that there are no leftover "contraction" node
-    attributes on the returned graph."""
-    G = nx.hexagonal_lattice_graph(6, 6, with_positions=False, periodic=True)
+@pytest.mark.parametrize(
+    "lattice_graph", (nx.triangular_lattice_graph, nx.hexagonal_lattice_graph)
+)
+def test_2D_lattice_no_contraction_leftovers(lattice_graph):
+    """hexagonal_lattice_graph and triangular_lattice_graph use nx.contracted_nodes
+    under-the-hood when periodic=True. Check that there are no leftover
+    "contraction" node attributes on the returned graph."""
+    G = lattice_graph(6, 6, with_positions=False, periodic=True)
     assert all(data == {} for _, data in G.nodes(data=True))
 
 

--- a/networkx/generators/tests/test_lattice.py
+++ b/networkx/generators/tests/test_lattice.py
@@ -8,6 +8,12 @@ import networkx as nx
 from networkx.utils import edges_equal
 
 
+def test_hexagonal_lattice_no_pos():
+    # Test positions are note computed/stored when with_positions=False
+    G = nx.hexagonal_lattice_graph(6, 6, with_positions=False)
+    assert all(pos is None for _, pos in G.nodes(data="pos"))
+
+
 class TestGrid2DGraph:
     """Unit tests for :func:`networkx.generators.lattice.grid_2d_graph`"""
 

--- a/networkx/generators/tests/test_lattice.py
+++ b/networkx/generators/tests/test_lattice.py
@@ -14,6 +14,14 @@ def test_hexagonal_lattice_no_pos():
     assert all(pos is None for _, pos in G.nodes(data="pos"))
 
 
+def test_hexagonal_lattice_no_contraction_leftovers():
+    """hexagonal_lattice_graph uses nx.contracted_nodes under-the-hood when
+    periodic=True. Check that there are no leftover "contraction" node
+    attributes on the returned graph."""
+    G = nx.hexagonal_lattice_graph(6, 6, with_positions=False, periodic=True)
+    assert all(data == {} for _, data in G.nodes(data=True))
+
+
 class TestGrid2DGraph:
     """Unit tests for :func:`networkx.generators.lattice.grid_2d_graph`"""
 


### PR DESCRIPTION
There are two minor fixes in this PR, a result of me taking a closer look at some of the lattice graphs for a maze-making application I'm thinking about.

1. `hexagonal_lattice_graph` has a `with_positions` boolean kwarg. It is `True` by default, so the positions of the nodes are computed and stored on a node attr named "pos". It turns out that `with_positions` is being ignored in `hexagonal_lattice_graph` - it's a very easy fix though, just move the existing position calculation under an `if with_positions` condition (this was already in place for `triangular_lattice_graph`

2. The second is more subtle - both `hexagonal_lattice_graph` and `triangular_lattice_graph` use `contracted_nodes` under-the-hood to identify boundary nodes when `periodic=True`. By default, `contracted_nodes` stores information about the contraction on the nodes/edges in the resultant graph. In this particular case, the contractions are an implementation detail - the information about the contraction itself shouldn't be stored on the resulting lattice graph. This PR adds tests for this and uses the new `store_contraction_as` kwarg (see #7902) to suppress this info on the final returned lattice graph.

Finally, one stylistic change: I removed the explicit import of `contracted_nodes` from `algorithms.minors` within the functions and simply call it from the top-level `nx` namespace instead!