### PR TITLE
MAINT: Remove unused sphinx extensions from conf.py

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,7 +17,6 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.autodoc",
     "sphinx.ext.coverage",
-    "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.todo",
@@ -124,8 +123,6 @@ pygments_style = "sphinx"
 
 # A list of prefixes that are ignored when creating the module index. (new in Sphinx 0.6)
 modindex_common_prefix = ["networkx."]
-
-doctest_global_setup = "import networkx as nx"
 
 # Options for HTML output
 # -----------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,7 +18,6 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
-    "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinx_gallery.gen_gallery",
     "texext",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,7 +16,6 @@ filterwarnings(
 extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.autodoc",
-    "sphinx.ext.coverage",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.todo",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,6 +68,8 @@ autosummary_generate = True
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
+# Ignore spurious warnings related to bad interactions between the texmath
+# and myst extensions
 suppress_warnings = ["ref.citation", "ref.footnote"]
 
 # The suffix of source filenames.


### PR DESCRIPTION
I noticed this while investigating #8313 

`conf.py` registers three extensions that are not used at all in the docs build process:
 1. [sphinx.ext.doctest](https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html)
 2. [sphinx.ext.coverage](https://www.sphinx-doc.org/en/master/usage/extensions/coverage.html)
 3. [sphinx.ext.todo](https://www.sphinx-doc.org/en/master/usage/extensions/todo.html)

The first two allow running the doctests (+coverage) *via sphinx*. Note that this is completely independent from `pytest --doctest-modules` and has no effect on the recommended testing workflow(s). What `sphinx.ext.doctest` allows you to do is run `make doctest` in the docs directory. However, we do not actually set up our docs to handle this, so if users do so they will get failures (e.g. from not having the `skip_numpy` stuff set up for sphinx doctests). In principle this could be set up, but the contributor guide recommends using `pytest` for running doctests and I think that is definitely the right thing to do. Removing this (and the coverage) extension simply disables the already non-working docs workflow.

The latter extension adds `.. todo::` and `.. todolist::` directives. I grepped through the codebase to confirm that these are not used anywhere (nor should they be IMO - that's what the issue tracker is for!). Therefore I think it is safe to remove this as well.

Finally, I added a comment to the `suppress_warnings` configuration because I tried removing it and ended up reminding myself why it's there in the first place!