### PR TITLE
Switch to the NumFOCUS Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.rst
+++ b/CODE_OF_CONDUCT.rst
@@ -21,7 +21,7 @@ understanding of a collaborative, shared environment and goals. Please try to
 follow this code in spirit as much as in letter, to create a friendly and
 productive environment that enriches the surrounding community.
 
-We have adapted the NumFOCUS Code of Conduct to allow people with some separation
+We have adopted the NumFOCUS Code of Conduct to allow people with some separation
 and some training to further the Code of Conduct goals.
 
 NetworkX uses the NumFOCUS Code of Conduct
@@ -35,7 +35,8 @@ The Short Version
 
 Be kind to others. Do not insult or put down others. Behave professionally.
 Remember that harassment and sexist, racist, or exclusionary jokes are not
-appropriate for NumFOCUS.
+appropriate for NumFOCUS. NetworkX uses the NumfOCUS Code of Conduct and this
+short version is language provided by their Code of Conduct Working Group.
 
 All communication should be appropriate for a professional audience including
 people of many different backgrounds. Sexual language and imagery is not
@@ -57,9 +58,15 @@ You can find the long version of the Code of Conduct on
 How To Report
 -------------
 
-If you feel that the Code of Conduct has been violated, feel free to submit a
-report, by using the `NumFOCUS Code of Conduct Reporting Form
-<https://numfocus.typeform.com/to/ynjGdT?typeform-source=numfocus.org>`_
+If you notice any behavior, incident, or situation that seems inappropriate
+or violates our Code of Conduct, we encourage you to report it via the
+`NumFOCUS Code of Conduct Reporting Form
+<https://numfocus.typeform.com/to/ynjGdT?typeform-source=numfocus.org>`_ .
+That report can be submitted anonymously if that feels more comfortable for you.
+
+Please note that the NumFOCUS Code of Conduct is not an exhaustive document
+and continues to evolve. Even if the incident you wish to report is not
+explicitly mentioned in the Code of Conduct, we still encourage you to report it.
 
 Who Will Receive Your Report
 ----------------------------
@@ -68,8 +75,50 @@ Your report will be received and handled by NumFOCUS Code of Conduct Working
 Group; trained, and experienced contributors with diverse backgrounds. The
 group is making decisions independently from the project, PyData, NumFOCUS or
 any other organization.
+The CoC Working Group will investigate and make recommendations to the
+NetworkX Community about appropriate responses. The NetworkX Community
+has the final decision about actions taken.
 
 You can learn more about the reporting procedure as well as the current group
 members at
 `the NumFOCUS Code of Conduct website <https://numfocus.org/code-of-conduct>`_
 (e.g. search that page for "current list of voting members")
+
+What Happens Next
+-----------------
+
+The CoC Working Group will investigate each report and make recommendations to the
+NetworkX Community about appropriate responses. The NetworkX Community, through
+the NetworkX Steering Council, makes final decisions about actions taken.
+Enforcement is enacted via transparent decision by the NetworkX Steering Council.
+
+In case of severe and obvious breaches, e.g., personal threat or violent, sexist
+or racist language, we will immediately disconnect the originator from NetworkX
+communication channels.
+
+Diversity Statement
+-------------------
+
+NumFOCUS and NetworkX are dedicated to providing a harassment-free community
+for everyone, regardless of gender, sexual orientation, gender identity and
+expression, disability, physical appearance, body size, race, or religion.
+We do not tolerate harassment of community members in any form.
+
+The NetworkX project welcomes and encourages participation by everyone. We are
+committed to being a community that everyone enjoys being part of. Although
+we may not always be able to accommodate each individual's preferences, we try
+our best to treat everyone kindly.
+
+No matter how you identify yourself or how others perceive you: we welcome you.
+Though no list can hope to be comprehensive, we explicitly honour diversity in:
+age, culture, ethnicity, genotype, gender identity or expression, language,
+national origin, neurotype, phenotype, political beliefs, profession, race,
+religion, sexual orientation, socioeconomic status, subculture and technical
+ability.
+
+Though we welcome people fluent in all languages, NetworkX development is
+conducted in English.
+
+Standards for behaviour in the NetworkX community are detailed in the Code of
+Conduct above. Participants in our community should uphold these standards
+in all their interactions and help others to do so as well (see next section).

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -523,7 +523,7 @@ Policies
       `Aditi Juneja <https://github.com/Schefflera-Arboricola>`_,
       or `Ross Barnowski <https://github.com/rossbar>`_ , OR
 
-  - Report the violation by using
+  - Report the violation either anonymously or with your name, using
     `the NumFOCUS Code of Conduct form <https://numfocus.typeform.com/to/ynjGdT>`_.
     The report goes to the independent NumFOCUS Code of Conduct Working Group.
     You can find more information about the group members and the procedure at


### PR DESCRIPTION
NetworkX met with some of the NumFOCUS Code of Conduct Onboarding Team to discuss our switch to using the NumFOCUS Code of Conduct (instead of our own Code of Conduct based roughly on the SciPy CoC about 5 years ago).

The main difference is that now violations can be reported to the NumFOCUS Code of Conduct Working Group. They provide more expertise and more separation from the community. They review the situation, gather information and make recommendations to the NetworkX community which we then decide whether to follow. We could have made our policy to have the Working Group make decisions which we would then promise to implement. 

This PR includes new language connecting our documentation to the NumFOCUS information and to the Working Group reporting form.