### PR TITLE
Adding floating point considerations to tutorial

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -592,7 +592,7 @@ supported.
 Many NetworkX algorithms work with numeric values, such as edge weights. Once
 your input contains floating point numbers,
 **all results are inherently approximate** due to the limited precision of
-floating point arithmetic.  This is especially true for algorithms such as
+floating point arithmetic. This is especially true for algorithms such as
 shortest-path, flows, cuts, minimum-spanning, etc. Basically any time a min or
 max value is computed.
 


### PR DESCRIPTION
## Floating Point Considerations

As discussed in previous issues and PRs (e.g., #4972, #4592, #8316), users sometimes face unexpected results when using floating point values such as edge weights or capacities. These issues are often caused by rounding errors, not bugs in the algorithms.

The moment floating point numbers are used, all results become approximate. So to avoid confusion, we update tutorial to clarify these considerations.