### PR TITLE
Utility functions for scaling floating-point edge weights to integers

### DIFF
--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -366,25 +366,6 @@ class TestMaxflowMinCutCommon:
         # }
         compare_flows_and_cuts(G, "s", "t", 4)
 
-    def test_float_capacities(self):
-        # Graph where incorrect float comparisons may fail
-        G = nx.DiGraph()
-        G.add_edge("s", "a", capacity=1)
-        G.add_edge("a", "b", capacity=1)
-        G.add_edge("b", "c", capacity=1)
-        G.add_edge("c", "t", capacity=0.1)
-        G.add_edge("s", "d", capacity=0.1)
-        G.add_edge("b", "d", capacity=0.2)
-        # flow solution
-        # {
-        #    "s": {"a": 0.1, "d": 0},
-        #    "a": {"b": 0.1},
-        #    "b": {"c": 0.1, "d": 0},
-        #    "c": {"t": 0.1},
-        #    "t": {}, "d": {}
-        # }
-        compare_flows_and_cuts(G, "s", "t", 0.1)
-
     def test_disconnected(self):
         G = nx.Graph()
         G.add_weighted_edges_from([(0, 1, 1), (1, 2, 1), (2, 3, 1)], weight="capacity")

--- a/networkx/algorithms/flow/utils.py
+++ b/networkx/algorithms/flow/utils.py
@@ -183,19 +183,12 @@ def detect_unboundedness(R, s, t):
 
 
 @nx._dispatchable(graphs={"G": 0, "R": 1}, preserve_edge_attrs={"R": {"flow": None}})
-def build_flow_dict(G, R, scale_factor=None):
+def build_flow_dict(G, R):
     """Build a flow dictionary from a residual network."""
     flow_dict = {}
     for u in G:
         flow_dict[u] = {v: 0 for v in G[u]}
-        if scale_factor is None:
-            flow_dict[u].update(
-                (v, attr["flow"]) for v, attr in R[u].items() if attr["flow"] > 0
-            )
-        else:
-            flow_dict[u].update(
-                (v, attr["flow"] / scale_factor)
-                for v, attr in R[u].items()
-                if attr["flow"] > 0
-            )
+        flow_dict[u].update(
+            (v, attr["flow"]) for v, attr in R[u].items() if attr["flow"] > 0
+        )
     return flow_dict

--- a/networkx/utils/tests/test_weights_to_int.py
+++ b/networkx/utils/tests/test_weights_to_int.py
@@ -1,3 +1,5 @@
+"""Test suite for functions related to scaling edge weights to integers."""
+
 import math
 from fractions import Fraction
 

--- a/networkx/utils/weights_to_int.py
+++ b/networkx/utils/weights_to_int.py
@@ -17,7 +17,37 @@ __all__ = [
 
 @nx._dispatchable(graphs="G")
 def needs_integerization(G, weight="weight"):
-    """Check if any of the edge weights may lead to floating-point rounding errors."""
+    """
+    Check if any of the edge weights may lead to floating-point rounding errors.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        The input graph.
+
+    weight : string
+        Name of the edge attribute to scale. Default value: 'weight'.
+
+    Returns
+    -------
+    bool
+        True if integerization is needed, False otherwise.
+
+    Examples
+    --------
+    >>> G = nx.DiGraph()
+    >>> G.add_edge("x", "y", capacity=0.1)
+    >>> G.add_edge("y", "z", capacity=1.0)
+    >>> G.add_edge("x", "z", capacity=2.5)
+    >>> needs_integerization(G, weight="capacity")
+    True
+
+    >>> H = nx.DiGraph()
+    >>> H.add_edge("a", "b", capacity=2)
+    >>> H.add_edge("b", "c", capacity=3.0)
+    >>> needs_integerization(H, weight="capacity")
+    False
+    """
     for _, _, w in G.edges(data=weight):
         if isinstance(w, (numbers.Real)) and not isinstance(w, (numbers.Rational)):
             if math.isfinite(w) and not float(w).is_integer():
@@ -30,8 +60,40 @@ def choose_scale_factor(
     G, weight="weight", max_denominator=10**12, max_scale_factor=10**12
 ):
     """
+    Choose a scale factor for converting edge weights to integers.
+
     Convert each edge weight w to Fraction(w).limit_denominator(max_denominator),
     then use scale_factor = LCM of denominators, capped by max_scale_factor.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        The input graph.
+
+    weight : string
+        Name of the edge attribute to scale. Default value: 'weight'.
+
+    max_denominator : integer
+        Maximum denominator for rational approximations of edge weights. Default value: 10**12.
+
+    max_scale_factor : integer
+        Maximum allowed scale factor. Default value: 10**12.
+
+    Returns
+    -------
+    scale_factor : integer
+        Factor by which to multiply each edge weight before rounding to
+        an integer.
+
+    Examples
+    --------
+    >>> G = nx.DiGraph()
+    >>> G.add_edge("x", "y", capacity=0.25)
+    >>> G.add_edge("y", "z", capacity=0.1)
+    >>> G.add_edge("x", "z", capacity=0.5)
+    >>> scale_factor = choose_scale_factor(G, weight="capacity")
+    >>> scale_factor
+    20
     """
     scale_factor = 1
     for _, _, w in G.edges(data=weight):
@@ -53,6 +115,41 @@ def scale_edge_weight_to_ints(G, weight="weight", scale_factor=1, default_value=
     `scale_factor` and rounded to integers.
 
     Missing weights are set to `default_value` before scaling if provided.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        The input graph.
+
+    weight : string
+        Name of the edge attribute to scale. Default value: 'weight'.
+
+    scale_factor : integer
+        Factor by which to multiply each edge weight before rounding to
+        an integer. Default value: 1.
+
+    default_value : integer, float, optional
+        Value to use for edges that do not have the specified weight
+        attribute before scaling. If not provided, edges without the
+        specified weight attribute are left unchanged.
+
+    Returns
+    -------
+    H : NetworkX graph
+        A copy of G with edge weights scaled to integers.
+
+    Examples
+    --------
+    >>> G = nx.DiGraph()
+    >>> G.add_edge("x", "y", capacity=0.5)
+    >>> G.add_edge("y", "z", capacity=1.5)
+    >>> G.add_edge("x", "z", capacity=2.5)
+    >>> scaled_G = scale_edge_weight_to_ints(G, weight="capacity", scale_factor=2)
+    >>> for u, v, c in scaled_G.edges(data="capacity"):
+    ...     print(f"({u}, {v}): {c}")
+    (x, y): 1
+    (x, z): 5
+    (y, z): 3
     """
 
     def _scale_to_int(data):


### PR DESCRIPTION
Fixes #4972.
Fixes #4592.
Replaces #8316 and is related to #8324.

As discussed in #8316 and other pull requests, since many algorithms may not work with inexact floating-point comparisons, the recommended solution for dealing with floating-point edge weights is to convert them to integers by scaling them with a suitable factor. 

This pull request adds three utility functions:
- `needs_integerization` for checking if any of the edge weights may lead to floating-point rounding errors,
- `choose_scale_factor` for finding a scaling factor to convert the weights to integers, and
- `scale_edge_weight_to_ints` for scaling the weights by a given factor and rounding them to integers.

These functions can then be used to preprocess the graphs for any algorithm that may have issues with floating-point numbers. I have updated the `maximum_flow` and `minimum_cut` functions to correctly scale the edge capacities when necessary, and then convert the resulting flow values to use the original capacities by again dividing by the scaling factor.

Note that I have only updated the main max flow and min cut wrappers so far. It is still possible to get errors by calling algorithms such as `preflow_push` directly while using floating-point capacities. In fact, the `test_pyramid` test in [`test_maxflow_large_graph.py`](https://github.com/networkx/networkx/blob/main/networkx/algorithms/flow/tests/test_maxflow_large_graph.py) currently does this, and although it works, other such cases may result in errors, and more checks and documentation are required.