### PR TITLE
TST: add tests for unsupported graph types in MST algorithms

### DIFF
--- a/networkx/algorithms/tree/tests/test_mst.py
+++ b/networkx/algorithms/tree/tests/test_mst.py
@@ -250,7 +250,7 @@ class TestBoruvka(MinimumSpanningTreeTestBase):
         with pytest.raises(nx.NetworkXNotImplemented):
             list(nx.minimum_spanning_edges(MG, algorithm=self.algo))
         with pytest.raises(nx.NetworkXNotImplemented):
-            list(nx.maximum_spanning_edges(DG, algorithm=self.algo))
+            list(nx.maximum_spanning_edges(MG, algorithm=self.algo))
 
 
 class MultigraphMSTTestBase(MinimumSpanningTreeTestBase):


### PR DESCRIPTION
### Summary

This PR adds tests to ensure that MST algorithms raise NetworkXNotImplemented on unsupported graph types.

### Motivation

While reviewing the MST code in mst.py, I noticed that if the @not_implemented_for("directed") decorator is accidentally removed, the entire MST test suite still passes. In that situation, MST functions silently accept DiGraph (or MultiGraph for Borůvka) and return results, even though the documented behavior specifies that these graph types are not supported.

Although it is unlikely that the decorator will be removed intentionally—and such a change would typically be caught during code review—the lack of test coverage means this would not be detected by automated testing. To prevent this silent regression scenario, I added tests that verify:

  - All MST algorithms (Kruskal, Prim, and Borůvka) raise NetworkXNotImplemented on DiGraph.
  
  - Borůvka raises NetworkXNotImplemented on MultiGraph.
  
  - Kruskal and Prim continue to accept MultiGraph, as expected.

These tests ensure that the intended API contract is explicitly validated.

### Notes

I am not entirely certain whether these tests are desirable or redundant, so I am submitting this PR to gather feedback. If the maintainers feel that these tests improve API contract coverage, they can be merged; otherwise, I am happy to revise or close the PR.

Thank you for reviewing!