### PR TITLE
DOC: Improve benchmarking readme

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,4 +1,4 @@
-## NetworkX ASV Benchmarks
+# NetworkX ASV Benchmarks
 
 NetworkX uses [`asv`](https://asv.readthedocs.io/en/latest/) to monitor for
 performance regressions and evaluate proposals for improved performance.
@@ -19,6 +19,60 @@ The two most generic sets of benchmarks are:
 
 There are many other algorithms captured in other files/benchmarking classes
 within the suite.
+
+## Setup and configuration
+
+Benchmarking runs are controlled by the `asv.conf.json` configuration file.
+For a full listing of configuration options, see
+[the `asv` documentation](https://asv.readthedocs.io/en/latest/asv.conf.json.html#conf-reference)
+
+Typically, the most important configuration options for a successful ASV
+configuration are:
+
+1. `environment_type` which controls the environment management tool used
+   by ASV,
+2. `pythons`, specifying which version(s) of Python will be used during
+   benchmarking, and
+3. `matrix` which dictates what dependencies (and their versions) will be
+   tested against.
+
+`environment_type` is set to `"conda"` by default - the `"virtualenv"` option
+is recommended for simpler building/setup.
+
+```{note}
+When using `environment_type: "virtualenv"`, it is recommended to limit the
+`pythons` field to only those versions of Python that are installed on the
+system.
+```
+
+The `matrix` field dictates which optional dependencies will be installed in the
+benchmarking environment.
+To get an accurate picture of NetworkX performance with "default" soft dependencies
+installed, be sure to include `numpy` and `scipy` in this listing.
+To evaluate pure-Python code branches, remove the dependencies from `matrix`.
+
+```{note}
+Some benchmarks themselves depend on `numpy`, `scipy` and/or `pandas`; so removing
+dependencies may cause some benchmarks to be skipped.
+```
+
+### Example configuration options
+
+The default configuration builds benchmarking environments for 3 different
+versions of Python, all with the latest stable version of default dependencies,
+using `conda` for managing the build environment and Python versions.
+
+To switch to built-in environment management:
+
+```yaml
+"environment_type": "virtualenv"
+```
+
+To limit the benchmarking run to a single version of Python:
+
+```yaml
+"pythons": ["3.13"]
+```
 
 ## Running the benchmark suite
 


### PR DESCRIPTION
Adds a bit more info re: benchmarking, particularly regarding setup/configuration. Crosslinks to the asv docs for the nitty-gritty details but highlights some of the IME more important config options.