### PR TITLE
pin python 3.14 to be version 3.14.0 until dataclasses are fixed

### DIFF
--- a/.github/workflows/nightly-release-test.yml
+++ b/.github/workflows/nightly-release-test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos]
-        python-version: ["3.11", "3.12", "3.13", "3.14.0"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Here's a PR to pin Python 3.14 to use only 3.14.0 until they fix `dataclasses`. 
The dataclasses currently breaks our "base" tests. See #8362

Once they merge a fix we can remove this minor version pin.
Perhaps there is a better approach though...
And I'm a little out of my wheelhouse here -- so if I'm doing too much or not enough let me know. :)