### PR TITLE
DOC: Fix underline lens in docstrings.

### DIFF
--- a/networkx/algorithms/bipartite/matrix.py
+++ b/networkx/algorithms/bipartite/matrix.py
@@ -146,13 +146,13 @@ def from_biadjacency_matrix(
         to 1. Must be the same length as the number of columns in `A`.
 
     Returns
-    ---------
+    -------
     G : NetworkX graph
         A bipartite graph with edges from the biadjacency matrix `A`, and
         nodes from `row_order` and `column_order`.
 
     Raises
-    --------
+    ------
     ValueError
         If `row_order` or `column_order` are provided and are not the same
         length as the number of rows or columns in `A`, respectively.

--- a/networkx/algorithms/community/bipartitions.py
+++ b/networkx/algorithms/community/bipartitions.py
@@ -195,7 +195,7 @@ def spectral_modularity_bipartition(G):
     G : NetworkX graph
 
     Returns
-    --------
+    -------
     C : tuple
         Pair of communities as two sets of nodes of ``G``, partitioned
         according to second largest eigenvalue of the modularity matrix.
@@ -264,7 +264,7 @@ def greedy_node_swap_bipartition(G, *, init_split=None, max_iter=10):
         node swap greedy modularity maximization algorithm.
 
     Raises
-    -------
+    ------
     NetworkXError
       if init_split is not a valid partition of the
       graph into two communities or if G is a MultiGraph


### PR DESCRIPTION
A few new warnings have cropped up in the doc build logs now that sphinx v9 is out.

This PR fixes the ones that come from NX's documentation - there are other warnings related to sphinx extensions relying on deprecated features (e.g. myst_nb and sphinx-gallery) but those will need to be handled upstream in the extensions themselves!