### PR TITLE
Rolling back shortest paths links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ doc/auto_examples
 doc/modules
 doc/reference/generated
 doc/reference/algorithms/generated
-doc/reference/algorithms/shortest_paths/generated
 doc/reference/classes/generated
 doc/reference/readwrite/generated
 doc/path.to.file

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -54,6 +54,11 @@ sphinx_gallery_conf = {
     "plot_gallery": "True",
     "reference_url": {"sphinx_gallery": None},
 }
+
+rst_epilog = """
+.. |dijkstra| replace:: :doc:`/reference/algorithms/shortest_paths/dijkstra`
+"""
+
 # Add pygraphviz png scraper, if available
 try:
     from pygraphviz.scraper import PNGScraper

--- a/doc/reference/algorithms/index.rst
+++ b/doc/reference/algorithms/index.rst
@@ -62,7 +62,7 @@ Algorithms
    reciprocity
    regular
    rich_club
-   shortest_paths/index
+   shortest_paths
    similarity
    simple_paths
    smallworld

--- a/doc/reference/algorithms/shortest_paths.rst
+++ b/doc/reference/algorithms/shortest_paths.rst
@@ -59,7 +59,7 @@ and their typical time complexities. Here, :math:`V` is the number of nodes and
 | Breadth–First Search | Unweighted  | Single-source,     | :math:`O(V + E)`          | Fastest choice for unweighted      |
 | (BFS)                | Only        | Single-pair        |                           | graphs; shortest path in hops      |
 +----------------------+-------------+--------------------+---------------------------+------------------------------------+
-| :doc:`dijkstra`      | Yes, both   | Single-source,     | :math:`O((V + E) \log V)` | General-purpose choice for         |
+| |dijkstra|           | Yes, both   | Single-source,     | :math:`O((V + E) \log V)` | General-purpose choice for         |
 |                      |             | Single-pair        |                           | non-negative weights               |
 +----------------------+-------------+--------------------+---------------------------+------------------------------------+
 | Bellman–Ford         | Yes, both   | Single-source,     | :math:`O(VE)`             | Graphs with negative edge weights  |
@@ -75,7 +75,7 @@ and their typical time complexities. Here, :math:`V` is the number of nodes and
 The **query type** determines whether the algorithm computes shortest paths
 from one node to all others (single-source), between two specified nodes
 (single-pair), or between all pairs of nodes (all-pairs). For example, BFS,
-:doc:`dijkstra`, and Bellman–Ford are commonly used for single-source
+|dijkstra|, and Bellman–Ford are commonly used for single-source
 or single-pair queries, while Floyd–Warshall and Johnson are designed for
 all-pairs shortest paths.
 
@@ -88,7 +88,7 @@ number of sources (:math:`V`).
 When the query is restricted to a single pair of nodes, bidirectional variants
 of some algorithms can be applied to improve efficiency. In NetworkX, both
 bidirectional breadth–first search and bidirectional
-:doc:`dijkstra` are available.
+|dijkstra| are available.
 
 A less common query type is the single-target shortest path, where the goal is
 to find paths from all nodes to a given target. This can be computed by
@@ -125,15 +125,15 @@ represents the all pairs shortest path query.
 +------------------+------------------+---------------------------------------------+
 
 By default, the simplified interface uses Breadth–First Search for unweighted
-graphs and :doc:`dijkstra` for weighted graphs (``weight`` parameter is not ``None``).
+graphs and |dijkstra| for weighted graphs (``weight`` parameter is not ``None``).
 
 The default algorithm can be overridden to select Bellman-Ford by specifying
 the ``method`` parameter to be "bellman-ford". Algorithms other than
-:doc:`dijkstra`, Bellman-Ford and Breadth–First Search are not
+|dijkstra|, Bellman-Ford and Breadth–First Search are not
 supported in the simplified interface.
 
 For the case of single-pair queries (both ``source`` and ``target`` specified),
-bidirectional variants of :doc:`dijkstra` and BFS are used when
+bidirectional variants of |dijkstra| and BFS are used when
 those methods are selected.
 
 
@@ -335,4 +335,4 @@ See Also
 .. toctree::
    :maxdepth: 1
 
-   dijkstra
+   shortest_paths/dijkstra

--- a/doc/reference/algorithms/shortest_paths/dijkstra.rst
+++ b/doc/reference/algorithms/shortest_paths/dijkstra.rst
@@ -9,7 +9,7 @@ is widely used in routing, network optimization, and pathfinding problems.
 Because Dijkstra's algorithm works only with non-negative edge weights,
 alternative algorithms such as Bellman-Ford or Johnson's algorithm are used
 for graphs with negative weights. For a general overview of the shortest path
-problem see :doc:`index`.
+problem see :doc:`/reference/algorithms/shortest_paths`.
 
 Problem Definition
 ------------------


### PR DESCRIPTION
Closes #8368. Fixes issue introduced in https://github.com/networkx/networkx/pull/8286 that unnecessarily changed our shortest path urls.
