### PR TITLE
Fix: Improve floating-point precision in group betweenness centrality

### DIFF
--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -100,6 +100,22 @@ class TestGroupBetweennessCentrality:
         b_answer = 5.0
         assert b == b_answer
 
+    def test_group_betweenness_floating_point_precision(self):
+        """
+        Group betweenness centrality handles floating-point precision correctly with weighted graphs
+        """
+        import random
+
+        random.seed(7)
+        G = nx.gnm_random_graph(10, 35, directed=True)
+        for u, v in G.edges():
+            G[u][v]["weight"] = random.uniform(0.1, 1.0)
+
+        C = [0, 1]
+        b = nx.group_betweenness_centrality(G, C, normalized=False, weight="weight")
+        b_answer = 10.0
+        assert abs(b - b_answer) < 1e-9
+
 
 class TestProminentGroup:
     np = pytest.importorskip("numpy")


### PR DESCRIPTION
Fixes #8366.

This PR fixes floating-point precision issues in `group_betweenness_centrality` that caused incorrect results for weighted graphs.

The function was using exact equality comparisons (`==`) for floating-point distance checks, which failed due to rounding errors. A helper function `_float_equal` with 1e-10 epsilon tolerance has been added, and 6 problematic comparisons have been updated to use it.

A regression test has been added, and documentation now includes a weight function workaround for users requiring custom precision control.