### PR TITLE
Relaxes check for undirected edge node ordering when backends are used for networkx tests

### DIFF
--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -351,8 +351,8 @@ class TestRelabel:
     def test_relabel_copy_false_undirected(self):
         G = nx.Graph([(0, 2), (0, 3), (1, 3)])
         nx.relabel_nodes(G, {0: "a", 1: "b"}, copy=False)
-        # Allow both edges and source/target nodes within edges to be arbitrarily ordered
-        # for undirected Graphs
-        actual = {tuple(sorted(e, key=str)) for e in G.edges}
-        expected = {tuple(sorted(e, key=str)) for e in [("a", 2), ("a", 3), ("b", 3)]}
+        # Use sets to allow both edges and source/target nodes within edges to be arbitrarily
+        # ordered for undirected Graphs
+        actual = {frozenset(e) for e in G.edges}
+        expected = {frozenset(e) for e in [("a", 2), ("a", 3), ("b", 3)]}
         assert actual == expected

--- a/networkx/utils/backends.py
+++ b/networkx/utils/backends.py
@@ -1848,14 +1848,8 @@ class _dispatchable:
                 else:
                     # Preserve position of the edge key for MultiGraphs.
                     if G1.is_multigraph():
-                        G1_edges = {
-                            (frozenset((u, v)), key)
-                            for u, v, key in G1.edges(keys=True)
-                        }
-                        G2_edges = {
-                            (frozenset((u, v)), key)
-                            for u, v, key in G2.edges(keys=True)
-                        }
+                        G1_edges = {(frozenset((u, v)), key) for u, v, key in G1.edges}
+                        G2_edges = {(frozenset((u, v)), key) for u, v, key in G2.edges}
                     else:
                         G1_edges = {frozenset(e) for e in G1.edges}
                         G2_edges = {frozenset(e) for e in G2.edges}


### PR DESCRIPTION
Adds a `relabel_nodes` test which exposed a problem with a backend graph check, and changes that check to allow node order within edges to differ when undirected backend graphs are compared to their networkx counterparts.

Prior to the changes here, using a backend when running the test would would result in an `AssertionError` if the backend preserved the node order within edges.  This was first seen from new tests added by [this PR](https://github.com/networkx/networkx/pull/7993), which resulted in test failures when run using the cugraph backend (see below).  


```python
>>> import networkx as nx
>>> import nx_cugraph as nxcg
>>>
>>> G = nx.Graph([(0, 2), (0, 3), (1, 3)])
>>> Gg = nxcg.Graph([(0, 2), (0, 3), (1, 3)])
>>> 
>>> nx.relabel_nodes(G, {0: "a", 1: "b"}, copy=False)
<networkx.classes.graph.Graph object at 0x744a4b908440>
>>> nx.relabel_nodes(Gg, {0: "a", 1: "b"}, copy=False)
<nx_cugraph.classes.graph.Graph object at 0x744a4b908590>
>>> 
>>> G.edges
EdgeView([(2, 'a'), (3, 'a'), (3, 'b')])
>>> Gg.edges
EdgeView([('a', 2), ('a', 3), (3, 'b')])
>>> 
>>> assert set(G.edges) == set(Gg.edges)
Traceback (most recent call last):
  File "<python-input-11>", line 1, in <module>
    assert set(G.edges) == set(Gg.edges)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```
