### PR TITLE
Betweenness documentation definitions should match default behavior

### DIFF
--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -35,8 +35,8 @@ def betweenness_centrality(
     `False`) [2]_.
     $P$ is a normalization factor representing the number of pairs of nodes
     that have counted shortest paths. Its value depends on the values of `normalized`
-    and `endpoints`, and on whether the graph is directed (see Notes). It can 
-    be set to `1` with `normalized=False`.
+    and `endpoints`, and on whether the graph is directed (see Notes). It can
+    be set to ``1`` with ``normalized=False``.
 
     Parameters
     ----------


### PR DESCRIPTION
The default behavior of betweenness functions in `NetworkX` returns normalized values. However the documentation defines betweenness parameters as unnormalized. This is confusing and I think leading to misreported values of betweenness in publications using `NetworkX`.

I suggest aligning the documentation definitions with the default function behaviors. Simplest fix is to change the documentation but changing default behavior for the next major release is also an option.

This pull request is a representative sample of what I had in mind for a documentation change. With further feedback from a reviewer, I can extend this to all betweenness functions.