### PR TITLE
Clarify decorator usage in backend implementations

### DIFF
--- a/doc/reference/backends.rst
+++ b/doc/reference/backends.rst
@@ -451,16 +451,9 @@ Creating a custom backend
 
     .. note::
 
-       Backend implementations of algorithms generally **should not reapply decorators**
-       such as ``@not_implemented_for``.
-
-       These decorators are expected to be applied at the NetworkX *frontend* level, and
-       their checks are performed before dispatching to a backend via ``@_dispatchable``.
-       As a result, backend implementations can assume that graph-type constraints have
+       Decorators such as ``@not_implemented_for`` in networkx are applied prior to dispatching.
+       Backend implementations can assume that graph-type constraints have
        already been validated.
-
-       This avoids duplication of logic and ensures consistent behavior across all
-       NetworkX backends.
 
     A backend graph instance may have a ``G.__networkx_cache__`` dict to enable
     caching, and care should be taken to clear the cache when appropriate.


### PR DESCRIPTION
This PR adds a clarification to the backend documentation explaining that backend implementations should not reapply decorators such as @not_implemented_for, since these checks occur at the NetworkX frontend before dispatch via @_dispatchable.

Closes networkx/nx-parallel#118