### PR TITLE
DOC: Warn that env vars must be set before importing networkx

### DIFF
--- a/doc/reference/backends.rst
+++ b/doc/reference/backends.rst
@@ -456,19 +456,6 @@ Creating a custom backend
     to determine whether a graph meets certain type constraints and to raise an error if the
     function is not applicable to that graph type.
 
-    .. note::
-
-       Backend implementations of algorithms generally **should not reapply decorators**
-       such as ``@not_implemented_for``.
-
-       These decorators are expected to be applied at the NetworkX *frontend* level, and
-       their checks are performed before dispatching to a backend via ``@_dispatchable``.
-       As a result, backend implementations can assume that graph-type constraints have
-       already been validated.
-
-       This avoids duplication of logic and ensures consistent behavior across all
-       NetworkX backends.
-
     A backend graph instance may have a ``G.__networkx_cache__`` dict to enable
     caching, and care should be taken to clear the cache when appropriate.
 


### PR DESCRIPTION
Fix: #8323

This PR adds an `.. important::` warning to the Backends documentation (`doc/reference/backends.rst`)