### PR TITLE
fix: handle empty graph in degree_pearson_correlation_coefficient (Fixes #6913)

### DIFF
--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -154,7 +154,9 @@ def degree_pearson_correlation_coefficient(G, x="out", y="in", weight=None, node
     """
     import scipy as sp
 
-    xy = node_degree_xy(G, x=x, y=y, nodes=nodes, weight=weight)
+    xy = list(node_degree_xy(G, x=x, y=y, nodes=nodes, weight=weight))
+    if len(xy) == 0:
+        return float("nan")
     x, y = zip(*xy)
     return float(sp.stats.pearsonr(x, y)[0])
 

--- a/networkx/algorithms/assortativity/tests/test_correlation.py
+++ b/networkx/algorithms/assortativity/tests/test_correlation.py
@@ -61,6 +61,12 @@ class TestDegreeMixingCorrelation(BaseTestDegreeMixing):
         r = nx.degree_assortativity_coefficient(self.DS)
         np.testing.assert_almost_equal(r, -0.9339, decimal=4)
 
+    def test_degree_pearson_assortativity_empty_graph(self):
+        G = nx.Graph()
+        G.add_nodes_from([0, 1])
+        r = nx.degree_pearson_correlation_coefficient(G)
+        assert r != r
+
 
 class TestAttributeMixingCorrelation(BaseTestAttributeMixing):
     def test_attribute_assortativity_undirected(self):


### PR DESCRIPTION
Fixes #6913