### PR TITLE
Fix circular_ladder_graph for n < 2 (fixes #8398)

### DIFF
--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -375,8 +375,9 @@ def circular_ladder_graph(n, create_using=None):
 
     """
     G = ladder_graph(n, create_using)
-    G.add_edge(0, n - 1)
-    G.add_edge(n, 2 * n - 1)
+    if(n > 1):
+        G.add_edge(0, n - 1)
+        G.add_edge(n, 2 * n - 1)
     return G
 
 


### PR DESCRIPTION
## Summary
This PR fixes `circular_ladder_graph` to handle edge cases for `n < 2` correctly.

## Fixes
Closes #8398

## Changes
- Added a conditional check `if n > 1` before adding the closing edges that connect the two cycles
- This prevents spurious nodes and self-loops for small values of `n`

## Behavior
### Before
- `circular_ladder_graph(0)` created nodes `[0, -1]` with an edge between them
- `circular_ladder_graph(1)` created self-loops `(0, 0)` and `(1, 1)` in addition to edge `(0, 1)`

### After
- `circular_ladder_graph(0)` now returns an empty graph (consistent with `ladder_graph(0)`)
- `circular_ladder_graph(1)` now returns a graph with 2 nodes and 1 edge without self-loops (consistent with `ladder_graph(1)`)

## Testing
The fix ensures behavior is consistent with `ladder_graph` for edge cases while maintaining correct functionality for `n >= 2`.