### PR TITLE
[ENH] Flow algorithms: Add support for callable capacity parameter

### DIFF
--- a/networkx/algorithms/flow/boykovkolmogorov.py
+++ b/networkx/algorithms/flow/boykovkolmogorov.py
@@ -11,7 +11,9 @@ from networkx.algorithms.flow.utils import build_residual_network
 __all__ = ["boykov_kolmogorov"]
 
 
-@nx._dispatchable(edge_attrs={"capacity": float("inf")}, returns_graph=True)
+@nx._dispatchable(
+    edge_attrs={"capacity": float("inf")}, returns_graph=True, preserve_edge_attrs=True
+)
 def boykov_kolmogorov(
     G, s, t, capacity="capacity", residual=None, value_only=False, cutoff=None
 ):

--- a/networkx/algorithms/flow/boykovkolmogorov.py
+++ b/networkx/algorithms/flow/boykovkolmogorov.py
@@ -39,11 +39,18 @@ def boykov_kolmogorov(
     t : node
         Sink node for the flow.
 
-    capacity : string
-        Edges of the graph G are expected to have an attribute capacity
-        that indicates how much flow the edge can support. If this
-        attribute is not present, the edge is considered to have
-        infinite capacity. Default value: 'capacity'.
+    capacity : string or function (default= 'capacity')
+        If this is a string, then edge capacity will be accessed via the
+        edge attribute with this key (that is, the capacity of the edge
+        joining `u` to `v` will be ``G.edges[u, v][capacity]``). If no
+        such edge attribute exists, the capacity of the edge is assumed to
+        be infinite.
+
+        If this is a function, the capacity of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number or None to indicate a hidden edge.
 
     residual : NetworkX graph
         Residual network on which the algorithm is to be executed. If None, a

--- a/networkx/algorithms/flow/dinitz_alg.py
+++ b/networkx/algorithms/flow/dinitz_alg.py
@@ -36,11 +36,18 @@ def dinitz(G, s, t, capacity="capacity", residual=None, value_only=False, cutoff
     t : node
         Sink node for the flow.
 
-    capacity : string
-        Edges of the graph G are expected to have an attribute capacity
-        that indicates how much flow the edge can support. If this
-        attribute is not present, the edge is considered to have
-        infinite capacity. Default value: 'capacity'.
+    capacity : string or function (default= 'capacity')
+        If this is a string, then edge capacity will be accessed via the
+        edge attribute with this key (that is, the capacity of the edge
+        joining `u` to `v` will be ``G.edges[u, v][capacity]``). If no
+        such edge attribute exists, the capacity of the edge is assumed to
+        be infinite.
+
+        If this is a function, the capacity of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number or None to indicate a hidden edge.
 
     residual : NetworkX graph
         Residual network on which the algorithm is to be executed. If None, a

--- a/networkx/algorithms/flow/dinitz_alg.py
+++ b/networkx/algorithms/flow/dinitz_alg.py
@@ -11,7 +11,9 @@ from networkx.utils import pairwise
 __all__ = ["dinitz"]
 
 
-@nx._dispatchable(edge_attrs={"capacity": float("inf")}, returns_graph=True)
+@nx._dispatchable(
+    edge_attrs={"capacity": float("inf")}, returns_graph=True, preserve_edge_attrs=True
+)
 def dinitz(G, s, t, capacity="capacity", residual=None, value_only=False, cutoff=None):
     """Find a maximum single-commodity flow using Dinitz' algorithm.
 

--- a/networkx/algorithms/flow/edmondskarp.py
+++ b/networkx/algorithms/flow/edmondskarp.py
@@ -144,11 +144,18 @@ def edmonds_karp(
     t : node
         Sink node for the flow.
 
-    capacity : string
-        Edges of the graph G are expected to have an attribute capacity
-        that indicates how much flow the edge can support. If this
-        attribute is not present, the edge is considered to have
-        infinite capacity. Default value: 'capacity'.
+    capacity : string or function (default= 'capacity')
+        If this is a string, then edge capacity will be accessed via the
+        edge attribute with this key (that is, the capacity of the edge
+        joining `u` to `v` will be ``G.edges[u, v][capacity]``). If no
+        such edge attribute exists, the capacity of the edge is assumed to
+        be infinite.
+
+        If this is a function, the capacity of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number or None to indicate a hidden edge.
 
     residual : NetworkX graph
         Residual network on which the algorithm is to be executed. If None, a

--- a/networkx/algorithms/flow/edmondskarp.py
+++ b/networkx/algorithms/flow/edmondskarp.py
@@ -117,7 +117,9 @@ def edmonds_karp_impl(G, s, t, capacity, residual, cutoff):
     return R
 
 
-@nx._dispatchable(edge_attrs={"capacity": float("inf")}, returns_graph=True)
+@nx._dispatchable(
+    edge_attrs={"capacity": float("inf")}, returns_graph=True, preserve_edge_attrs=True
+)
 def edmonds_karp(
     G, s, t, capacity="capacity", residual=None, value_only=False, cutoff=None
 ):

--- a/networkx/algorithms/flow/gomory_hu.py
+++ b/networkx/algorithms/flow/gomory_hu.py
@@ -14,7 +14,9 @@ __all__ = ["gomory_hu_tree"]
 
 
 @not_implemented_for("directed")
-@nx._dispatchable(edge_attrs={"capacity": float("inf")}, returns_graph=True)
+@nx._dispatchable(
+    edge_attrs={"capacity": float("inf")}, returns_graph=True, preserve_edge_attrs=True
+)
 def gomory_hu_tree(G, capacity="capacity", flow_func=None):
     r"""Returns the Gomory-Hu tree of an undirected graph G.
 

--- a/networkx/algorithms/flow/gomory_hu.py
+++ b/networkx/algorithms/flow/gomory_hu.py
@@ -41,11 +41,18 @@ def gomory_hu_tree(G, capacity="capacity", flow_func=None):
     G : NetworkX graph
         Undirected graph
 
-    capacity : string
-        Edges of the graph G are expected to have an attribute capacity
-        that indicates how much flow the edge can support. If this
-        attribute is not present, the edge is considered to have
-        infinite capacity. Default value: 'capacity'.
+    capacity : string or function (default= 'capacity')
+        If this is a string, then edge capacity will be accessed via the
+        edge attribute with this key (that is, the capacity of the edge
+        joining `u` to `v` will be ``G.edges[u, v][capacity]``). If no
+        such edge attribute exists, the capacity of the edge is assumed to
+        be infinite.
+
+        If this is a function, the capacity of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number or None to indicate a hidden edge.
 
     flow_func : function
         Function to perform the underlying flow computations. Default value

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -34,11 +34,18 @@ def maximum_flow(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     _t : node
         Sink node for the flow.
 
-    capacity : string
-        Edges of the graph G are expected to have an attribute capacity
-        that indicates how much flow the edge can support. If this
-        attribute is not present, the edge is considered to have
-        infinite capacity. Default value: 'capacity'.
+    capacity : string or function (default= 'capacity')
+        If this is a string, then edge capacity will be accessed via the
+        edge attribute with this key (that is, the capacity of the edge
+        joining `u` to `v` will be ``G.edges[u, v][capacity]``). If no
+        such edge attribute exists, the capacity of the edge is assumed to
+        be infinite.
+
+        If this is a function, the capacity of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number or None to indicate a hidden edge.
 
     flow_func : function
         A function for computing the maximum flow among a pair of nodes
@@ -185,11 +192,18 @@ def maximum_flow_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwa
     _t : node
         Sink node for the flow.
 
-    capacity : string
-        Edges of the graph G are expected to have an attribute capacity
-        that indicates how much flow the edge can support. If this
-        attribute is not present, the edge is considered to have
-        infinite capacity. Default value: 'capacity'.
+    capacity : string or function (default= 'capacity')
+        If this is a string, then edge capacity will be accessed via the
+        edge attribute with this key (that is, the capacity of the edge
+        joining `u` to `v` will be ``G.edges[u, v][capacity]``). If no
+        such edge attribute exists, the capacity of the edge is assumed to
+        be infinite.
+
+        If this is a function, the capacity of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number or None to indicate a hidden edge.
 
     flow_func : function
         A function for computing the maximum flow among a pair of nodes
@@ -316,11 +330,18 @@ def minimum_cut(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     _t : node
         Sink node for the flow.
 
-    capacity : string
-        Edges of the graph G are expected to have an attribute capacity
-        that indicates how much flow the edge can support. If this
-        attribute is not present, the edge is considered to have
-        infinite capacity. Default value: 'capacity'.
+    capacity : string or function (default= 'capacity')
+        If this is a string, then edge capacity will be accessed via the
+        edge attribute with this key (that is, the capacity of the edge
+        joining `u` to `v` will be ``G.edges[u, v][capacity]``). If no
+        such edge attribute exists, the capacity of the edge is assumed to
+        be infinite.
+
+        If this is a function, the capacity of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number or None to indicate a hidden edge.
 
     flow_func : function
         A function for computing the maximum flow among a pair of nodes
@@ -479,11 +500,18 @@ def minimum_cut_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwar
     _t : node
         Sink node for the flow.
 
-    capacity : string
-        Edges of the graph G are expected to have an attribute capacity
-        that indicates how much flow the edge can support. If this
-        attribute is not present, the edge is considered to have
-        infinite capacity. Default value: 'capacity'.
+    capacity : string or function (default= 'capacity')
+        If this is a string, then edge capacity will be accessed via the
+        edge attribute with this key (that is, the capacity of the edge
+        joining `u` to `v` will be ``G.edges[u, v][capacity]``). If no
+        such edge attribute exists, the capacity of the edge is assumed to
+        be infinite.
+
+        If this is a function, the capacity of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number or None to indicate a hidden edge.
 
     flow_func : function
         A function for computing the maximum flow among a pair of nodes

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -17,7 +17,9 @@ default_flow_func = preflow_push
 __all__ = ["maximum_flow", "maximum_flow_value", "minimum_cut", "minimum_cut_value"]
 
 
-@nx._dispatchable(graphs="flowG", edge_attrs={"capacity": float("inf")})
+@nx._dispatchable(
+    graphs="flowG", edge_attrs={"capacity": float("inf")}, preserve_edge_attrs=True
+)
 def maximum_flow(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     """Find a maximum single-commodity flow.
 
@@ -175,7 +177,9 @@ def maximum_flow(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     return (R.graph["flow_value"], flow_dict)
 
 
-@nx._dispatchable(graphs="flowG", edge_attrs={"capacity": float("inf")})
+@nx._dispatchable(
+    graphs="flowG", edge_attrs={"capacity": float("inf")}, preserve_edge_attrs=True
+)
 def maximum_flow_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     """Find the value of maximum single-commodity flow.
 
@@ -310,7 +314,9 @@ def maximum_flow_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwa
     return flow_value
 
 
-@nx._dispatchable(graphs="flowG", edge_attrs={"capacity": float("inf")})
+@nx._dispatchable(
+    graphs="flowG", edge_attrs={"capacity": float("inf")}, preserve_edge_attrs=True
+)
 def minimum_cut(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     """Compute the value and the node partition of a minimum (s, t)-cut.
 
@@ -480,7 +486,9 @@ def minimum_cut(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     return (R.graph["flow_value"], partition)
 
 
-@nx._dispatchable(graphs="flowG", edge_attrs={"capacity": float("inf")})
+@nx._dispatchable(
+    graphs="flowG", edge_attrs={"capacity": float("inf")}, preserve_edge_attrs=True
+)
 def minimum_cut_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     """Compute the value of a minimum (s, t)-cut.
 

--- a/networkx/algorithms/flow/preflowpush.py
+++ b/networkx/algorithms/flow/preflowpush.py
@@ -316,11 +316,18 @@ def preflow_push(
     t : node
         Sink node for the flow.
 
-    capacity : string
-        Edges of the graph G are expected to have an attribute capacity
-        that indicates how much flow the edge can support. If this
-        attribute is not present, the edge is considered to have
-        infinite capacity. Default value: 'capacity'.
+    capacity : string or function (default= 'capacity')
+        If this is a string, then edge capacity will be accessed via the
+        edge attribute with this key (that is, the capacity of the edge
+        joining `u` to `v` will be ``G.edges[u, v][capacity]``). If no
+        such edge attribute exists, the capacity of the edge is assumed to
+        be infinite.
+
+        If this is a function, the capacity of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number or None to indicate a hidden edge.
 
     residual : NetworkX graph
         Residual network on which the algorithm is to be executed. If None, a

--- a/networkx/algorithms/flow/preflowpush.py
+++ b/networkx/algorithms/flow/preflowpush.py
@@ -288,7 +288,9 @@ def preflow_push_impl(G, s, t, capacity, residual, global_relabel_freq, value_on
     return R
 
 
-@nx._dispatchable(edge_attrs={"capacity": float("inf")}, returns_graph=True)
+@nx._dispatchable(
+    edge_attrs={"capacity": float("inf")}, returns_graph=True, preserve_edge_attrs=True
+)
 def preflow_push(
     G, s, t, capacity="capacity", residual=None, global_relabel_freq=1, value_only=False
 ):

--- a/networkx/algorithms/flow/shortestaugmentingpath.py
+++ b/networkx/algorithms/flow/shortestaugmentingpath.py
@@ -163,7 +163,9 @@ def shortest_augmenting_path_impl(G, s, t, capacity, residual, two_phase, cutoff
     return R
 
 
-@nx._dispatchable(edge_attrs={"capacity": float("inf")}, returns_graph=True)
+@nx._dispatchable(
+    edge_attrs={"capacity": float("inf")}, returns_graph=True, preserve_edge_attrs=True
+)
 def shortest_augmenting_path(
     G,
     s,

--- a/networkx/algorithms/flow/shortestaugmentingpath.py
+++ b/networkx/algorithms/flow/shortestaugmentingpath.py
@@ -198,11 +198,18 @@ def shortest_augmenting_path(
     t : node
         Sink node for the flow.
 
-    capacity : string
-        Edges of the graph G are expected to have an attribute capacity
-        that indicates how much flow the edge can support. If this
-        attribute is not present, the edge is considered to have
-        infinite capacity. Default value: 'capacity'.
+    capacity : string or function (default= 'capacity')
+        If this is a string, then edge capacity will be accessed via the
+        edge attribute with this key (that is, the capacity of the edge
+        joining `u` to `v` will be ``G.edges[u, v][capacity]``). If no
+        such edge attribute exists, the capacity of the edge is assumed to
+        be infinite.
+
+        If this is a function, the capacity of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number or None to indicate a hidden edge.
 
     residual : NetworkX graph
         Residual network on which the algorithm is to be executed. If None, a

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -12,6 +12,7 @@ from networkx.algorithms.flow import (
     preflow_push,
     shortest_augmenting_path,
 )
+from networkx.algorithms.flow.utils import _capacity_function
 
 flow_funcs = {
     boykov_kolmogorov,
@@ -41,10 +42,12 @@ def validate_flows(G, s, t, flowDict, solnValue, capacity, flow_func):
     for u in G:
         assert set(G[u]) == set(flowDict[u]), errmsg
     excess = {u: 0 for u in flowDict}
+    capacity = _capacity_function(G, capacity)
     for u in flowDict:
         for v, flow in flowDict[u].items():
-            if capacity in G[u][v]:
-                assert flow <= G[u][v][capacity]
+            cap = capacity(u, v, G[u][v])
+            if cap is not None:
+                assert flow <= capacity(u, v, G[u][v])
             assert flow >= 0, errmsg
             excess[u] -= flow
             excess[v] += flow
@@ -63,7 +66,10 @@ def validate_cuts(G, s, t, solnValue, partition, capacity, flow_func):
     assert all(n in G for n in partition[1]), errmsg
     cutset = compute_cutset(G, partition)
     assert all(G.has_edge(u, v) for (u, v) in cutset), errmsg
-    assert solnValue == sum(G[u][v][capacity] for (u, v) in cutset), errmsg
+    capacity = _capacity_function(G, capacity)
+    assert solnValue == sum(
+        cap for (u, v) in cutset if (cap := capacity(u, v, G[u][v])) is not None
+    ), errmsg
     H = G.copy()
     H.remove_edges_from(cutset)
     if not G.is_directed():
@@ -373,6 +379,45 @@ class TestMaxflowMinCutCommon:
         # flow solution
         # {0: {}, 2: {3: 0}, 3: {2: 0}}
         compare_flows_and_cuts(G, 0, 3, 0)
+
+    def test_capacity_func(self):
+        G = nx.DiGraph()
+        # simple line graph 0--<1>--1--<10>--2
+        G.add_weighted_edges_from([(0, 1, 1 / 2), (1, 2, 1 / 8)], weight="spam")
+
+        # flow solution
+        # {
+        #     0: {1: 1/8},
+        #     1: {2: 1/8},
+        #     2: {},
+        # }
+        compare_flows_and_cuts(G, 0, 2, 1 / 8, capacity="spam")
+
+        # Now, define capacity function to be inverse of spam attribute
+        def my_cap(u, v, e_attr):
+            return 1 / e_attr["spam"]
+
+        # flow solution
+        # {
+        #     0: {1: 2},
+        #     1: {2: 2},
+        #     2: {},
+        # }
+        compare_flows_and_cuts(G, 0, 2, 2, capacity=my_cap)
+
+        # hide the direct edge 0--1, making G appear disconnected
+        def my_cap_01_hidden(u, v, e_attr):
+            if u == 0 and v == 1:
+                return None
+            return 1 / e_attr["spam"]
+
+        # flow solution
+        # {
+        #     0: {},
+        #     1: {2: 0},
+        #     2: {},
+        # }
+        compare_flows_and_cuts(G, 0, 2, 0, capacity=my_cap_01_hidden)
 
     def test_source_target_not_in_graph(self):
         G = nx.Graph()

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -383,19 +383,20 @@ class TestMaxflowMinCutCommon:
     def test_capacity_func(self):
         G = nx.DiGraph()
         # directed line graph: 0---->1---->2
-        G.add_weighted_edges_from([(0, 1, 1 / 2), (1, 2, 1 / 8)], weight="spam")
+        G.add_edge(0, 1, capacity=1 / 2)
+        G.add_edge(1, 2, capacity=1 / 8)
 
-        # flow solution using capacity="spam"
+        # flow solution using capacity="capacity"
         # {
         #     0: {1: 1/8},
         #     1: {2: 1/8},
         #     2: {},
         # }
-        compare_flows_and_cuts(G, 0, 2, 1 / 8, capacity="spam")
+        compare_flows_and_cuts(G, 0, 2, 1 / 8, capacity="capacity")
 
-        # Now, define capacity function to be inverse of spam attribute
+        # Now, define my_cap function to be inverse of "capacity" attribute
         def my_cap(u, v, e_attr):
-            return 1 / e_attr["spam"]
+            return 1 / e_attr["capacity"]
 
         # flow solution using capacity=my_cap
         # {
@@ -409,7 +410,7 @@ class TestMaxflowMinCutCommon:
         def my_cap_01_hidden(u, v, e_attr):
             if u == 0 and v == 1:
                 return None
-            return 1 / e_attr["spam"]
+            return 1 / e_attr["capacity"]
 
         # flow solution using capacity=my_cap_01_hidden
         # {

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -47,7 +47,7 @@ def validate_flows(G, s, t, flowDict, solnValue, capacity, flow_func):
         for v, flow in flowDict[u].items():
             cap = capacity(u, v, G[u][v])
             if cap is not None:
-                assert flow <= capacity(u, v, G[u][v])
+                assert flow <= cap
             assert flow >= 0, errmsg
             excess[u] -= flow
             excess[v] += flow

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -382,10 +382,10 @@ class TestMaxflowMinCutCommon:
 
     def test_capacity_func(self):
         G = nx.DiGraph()
-        # simple line graph 0--<1>--1--<10>--2
+        # directed line graph: 0---->1---->2
         G.add_weighted_edges_from([(0, 1, 1 / 2), (1, 2, 1 / 8)], weight="spam")
 
-        # flow solution
+        # flow solution using capacity="spam"
         # {
         #     0: {1: 1/8},
         #     1: {2: 1/8},
@@ -397,7 +397,7 @@ class TestMaxflowMinCutCommon:
         def my_cap(u, v, e_attr):
             return 1 / e_attr["spam"]
 
-        # flow solution
+        # flow solution using capacity=my_cap
         # {
         #     0: {1: 2},
         #     1: {2: 2},
@@ -411,7 +411,7 @@ class TestMaxflowMinCutCommon:
                 return None
             return 1 / e_attr["spam"]
 
-        # flow solution
+        # flow solution using capacity=my_cap_01_hidden
         # {
         #     0: {},
         #     1: {2: 0},

--- a/networkx/algorithms/flow/utils.py
+++ b/networkx/algorithms/flow/utils.py
@@ -109,13 +109,14 @@ def build_residual_network(G, capacity):
     R = nx.DiGraph()
     R.__networkx_cache__ = None  # Disable caching
     R.add_nodes_from(G)
+
     inf = float("inf")
     capacity = _capacity_function(G, capacity)
     # Extract edges with positive capacities. Self loops excluded.
     edge_list = []
     for u, v, attr in G.edges(data=True):
         cap = capacity(u, v, attr)  # returns None for hidden edge
-        if cap is not None and cap > 0 and u != v:  # avoids hidden edge too
+        if cap > 0 and u != v and cap is not None:  # avoids hidden edge
             edge_list.append((u, v, cap))
 
     # Simulate infinity with three times the sum of the finite edge capacities

--- a/networkx/algorithms/flow/utils.py
+++ b/networkx/algorithms/flow/utils.py
@@ -77,7 +77,9 @@ class GlobalRelabelThreshold:
         self._work = 0
 
 
-@nx._dispatchable(edge_attrs={"capacity": float("inf")}, returns_graph=True)
+@nx._dispatchable(
+    edge_attrs={"capacity": float("inf")}, returns_graph=True, preserve_edge_attrs=True
+)
 def build_residual_network(G, capacity):
     """Build a residual network and initialize a zero flow.
 

--- a/networkx/algorithms/flow/utils.py
+++ b/networkx/algorithms/flow/utils.py
@@ -113,13 +113,11 @@ def build_residual_network(G, capacity):
     inf = float("inf")
     capacity = _capacity_function(G, capacity)
     # Extract edges with positive capacities. Self loops excluded.
-    edge_list = []
-    for u, v, attr in G.edges(data=True):
-        cap = capacity(u, v, attr)  # returns None for hidden edge
-        if cap is None:  # avoids hidden edge
-            continue
-        if cap > 0 and u != v:
-            edge_list.append((u, v, cap))
+    edge_list = [
+        (u, v, cap)
+        for u, v, attr in G.edges(data=True)
+        if u != v and (cap := capacity(u, v, attr)) is not None and cap > 0
+    ]
 
     # Simulate infinity with three times the sum of the finite edge capacities
     # or any positive value if the sum is zero. This allows the

--- a/networkx/algorithms/flow/utils.py
+++ b/networkx/algorithms/flow/utils.py
@@ -112,7 +112,6 @@ def build_residual_network(G, capacity):
     R.__networkx_cache__ = None  # Disable caching
     R.add_nodes_from(G)
 
-    inf = float("inf")
     capacity = _capacity_function(G, capacity)
     # Extract edges with positive capacities. Self loops excluded.
     edge_list = [
@@ -131,6 +130,7 @@ def build_residual_network(G, capacity):
     # finite-capacity edge is at most 1/3 of inf, if an operation moves more
     # than 1/3 of inf units of flow to t, there must be an infinite-capacity
     # s-t path in G.
+    inf = float("inf")
     inf = 3 * sum(cap for u, v, cap in edge_list if cap != inf) or 1
     if G.is_directed():
         for u, v, cap in edge_list:
@@ -191,7 +191,7 @@ def build_flow_dict(G, R):
 
 
 def _capacity_function(G, capacity):
-    """Returns a function that returns the capacity of an edge.
+    """Returns a callable that returns the capacity of an edge.
 
     Parameters
     ----------
@@ -204,21 +204,22 @@ def _capacity_function(G, capacity):
         an edge and ``edge_attrs`` is the corresponding edge attribute
         dictionary. The callable must return a numeric capacity, or None
         to indicate that the edge is hidden.
+        In this case, the callable is returned unchanged.
 
         If string, it is interpreted as the key of an edge attribute storing
-        the capacity. In this case, a function is returned that accepts
+        the capacity. In this case, a new callable is returned that accepts
         ``(u, v, edge_attrs)`` and returns ``edge_attrs[capacity]``.
 
     Returns
     -------
     callable
-        A function with signature ``(u, v, edge_attrs)`` that returns the
+        A callable with signature ``(u, v, edge_attrs)`` that returns the
         capacity of the edge joining nodes `u` and `v`.
 
     Notes
     -----
-    If the specified capacity attribute is not present on an edge, that
-    edge is assumed to have infinite capacity.
+    If `capacity` is a string and the specified attribute is not present on
+    an edge, that edge is assumed to have infinite capacity.
     """
 
     inf = float("inf")

--- a/networkx/algorithms/flow/utils.py
+++ b/networkx/algorithms/flow/utils.py
@@ -199,12 +199,12 @@ def _capacity_function(G, capacity):
         MultiGraph and MultiDiGraph are not supported.
 
     capacity : string or callable
-        If callable, it must accept exactly three positional arguments
+        If callable, the callable is returned unchanged. For it to work
+        it must accept exactly three positional arguments
         ``(u, v, edge_attrs)``, where `u` and `v` are the endpoints of
         an edge and ``edge_attrs`` is the corresponding edge attribute
-        dictionary. The callable must return a numeric capacity, or None
-        to indicate that the edge is hidden.
-        In this case, the callable is returned unchanged.
+        dictionary. The callable must return either None (to hide an edge)
+        or a number representing the capacity.
 
         If string, it is interpreted as the key of an edge attribute storing
         the capacity. In this case, a new callable is returned that accepts

--- a/networkx/algorithms/flow/utils.py
+++ b/networkx/algorithms/flow/utils.py
@@ -209,7 +209,7 @@ def _capacity_function(G, capacity):
         dictionary for the eedge joining those nodes. That function returns
         a number representing the capcity of an edge.
 
-    If any edge does not have an attribute with key `weight`, it is assumed to
+    If any edge does not have an attribute with key `capacity`, it is assumed to
     have infinite capacity.
 
     """
@@ -217,7 +217,7 @@ def _capacity_function(G, capacity):
     inf = float("inf")
     if callable(capacity):
         return capacity
-    # If the weight keyword argument is not callable, we assume it is a
-    # string representing the edge attribute containing the weight of
+    # If the capacity keyword argument is not callable, we assume it is a
+    # string representing the edge attribute containing the capacity of
     # the edge.
     return lambda u, v, data: data.get(capacity, inf)

--- a/networkx/algorithms/flow/utils.py
+++ b/networkx/algorithms/flow/utils.py
@@ -193,25 +193,30 @@ def _capacity_function(G, capacity):
 
     Parameters
     ----------
-    G : NetworkX graph (not MultiGraph)
+    G : NetworkX graph
+        MultiGraph and MultiDiGraph are not supported.
 
-    capacity : string or function
-        If it is callable, `capacity` itself is returned. If it is a string,
-        it is assumed to be the name of the edge attribute that represents
-        the capcity of an edge. In that case, a function is returned that
-        gets the edge capcity according to the specified edge attribute.
+    capacity : string or callable
+        If callable, it must accept exactly three positional arguments
+        ``(u, v, edge_attrs)``, where `u` and `v` are the endpoints of
+        an edge and ``edge_attrs`` is the corresponding edge attribute
+        dictionary. The callable must return a numeric capacity, or None
+        to indicate that the edge is hidden.
+
+        If string, it is interpreted as the key of an edge attribute storing
+        the capacity. In this case, a function is returned that accepts
+        ``(u, v, edge_attrs)`` and returns ``edge_attrs[capacity]``.
 
     Returns
     -------
-    function
-        This function returns a callable that accepts exactly three inputs:
-        a node, an node adjacent to the first one, and the edge attribute
-        dictionary for the eedge joining those nodes. That function returns
-        a number representing the capcity of an edge.
+    callable
+        A function with signature ``(u, v, edge_attrs)`` that returns the
+        capacity of the edge joining nodes `u` and `v`.
 
-    If any edge does not have an attribute with key `capacity`, it is assumed to
-    have infinite capacity.
-
+    Notes
+    -----
+    If the specified capacity attribute is not present on an edge, that
+    edge is assumed to have infinite capacity.
     """
 
     inf = float("inf")

--- a/networkx/algorithms/flow/utils.py
+++ b/networkx/algorithms/flow/utils.py
@@ -116,7 +116,7 @@ def build_residual_network(G, capacity):
     edge_list = []
     for u, v, attr in G.edges(data=True):
         cap = capacity(u, v, attr)  # returns None for hidden edge
-        if cap > 0 and u != v and cap is not None:  # avoids hidden edge
+        if cap is not None and cap > 0 and u != v:  # avoids hidden edge
             edge_list.append((u, v, cap))
 
     # Simulate infinity with three times the sum of the finite edge capacities

--- a/networkx/algorithms/flow/utils.py
+++ b/networkx/algorithms/flow/utils.py
@@ -116,7 +116,9 @@ def build_residual_network(G, capacity):
     edge_list = []
     for u, v, attr in G.edges(data=True):
         cap = capacity(u, v, attr)  # returns None for hidden edge
-        if cap is not None and cap > 0 and u != v:  # avoids hidden edge
+        if cap is None:  # avoids hidden edge
+            continue
+        if cap > 0 and u != v:
             edge_list.append((u, v, cap))
 
     # Simulate infinity with three times the sum of the finite edge capacities


### PR DESCRIPTION
Fix: #8390 

Similar to shortest path algorithms, flow algorithms can now accept a callable capacity function.

`_capacity_function` is similar to `_weight_function` of shortest path algorithms, except: Since `build_residual_network` is not supported for Multigraphs, I have removed that portion.

---

will update docs and add test after the initial reviews.