### PR TITLE
DOC: Add nx-guides cross-link to plot_lca example

### DIFF
--- a/examples/algorithms/plot_lca.py
+++ b/examples/algorithms/plot_lca.py
@@ -10,6 +10,10 @@ ancestors are computed for certain node pairs. These node
 pairs and their LCA are then visualized with a chosen
 color scheme.
 
+.. seealso::
+
+    :external+nx-guides:doc:`content/algorithms/lca/LCA`
+        A more in-depth guide on lowest common ancestor algorithms in NetworkX.
 """
 
 import networkx as nx


### PR DESCRIPTION
## Summary

Adds a cross-reference link from the `plot_lca.py` gallery example to the corresponding nx-guides tutorial on Lowest Common Ancestors.

## Related Issue

Addresses #7984 - Improving visibility and access to nx-guides

## Changes Made

- Added a `.. seealso::` section in `examples/algorithms/plot_lca.py` docstring
- Links to the nx-guides LCA tutorial for users who want more in-depth information

## Additional Notes

This is my first contribution to NetworkX! Happy to make any changes based on feedback.

More cross-links for other gallery examples (like DAG, flow algorithms) can be added in follow-up PRs if this approach looks good.