### PR TITLE
Added deprecation warnings to maximum_flow_value() and minimum_cut_value

### DIFF
--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -172,6 +172,8 @@ def maximum_flow(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
 def maximum_flow_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     """Find the value of maximum single-commodity flow.
 
+    Use `flow_value, _ = maximum_flow(...)` instead.
+
     Parameters
     ----------
     flowG : NetworkX graph
@@ -292,6 +294,14 @@ def maximum_flow_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwa
     True
 
     """
+    import warnings
+
+    warnings.warn(
+        "Use `flow_value, _ = maximum_flow(...)` instead.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
     flow_value, _ = maximum_flow(flowG, _s, _t, capacity, flow_func, **kwargs)
     return flow_value
 
@@ -463,6 +473,8 @@ def minimum_cut(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
 def minimum_cut_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     """Compute the value of a minimum (s, t)-cut.
 
+    Use `cut_value, _ = minimum_cut(...)` instead.
+    
     Use the max-flow min-cut theorem, i.e., the capacity of a minimum
     capacity cut is equal to the flow value of a maximum flow.
 
@@ -580,5 +592,13 @@ def minimum_cut_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwar
     True
 
     """
+    import warnings
+
+    warnings.warn(
+        "Use `cut_value, _ = minimum_cut(...)` instead.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    
     value, _ = minimum_cut(flowG, _s, _t, capacity, flow_func, **kwargs)
     return value


### PR DESCRIPTION
## Description

This PR addresses issue #8393 by deprecating `maximum_flow_value()` and `minimum_cut_value()` functions in favor of argument unpacking from their main counterparts.

## Changes

- Added deprecation warnings to `maximum_flow_value()` and `minimum_cut_value()`
- Updated docstrings to recommend using argument unpacking instead:
  - `flow_value, _ = maximum_flow(...)` instead of `maximum_flow_value(...)`
  - `cut_value, _ = minimum_cut(...)` instead of `minimum_cut_value(...)`

Closes #8393