### PR TITLE
Fix min_edge_cover to return consistent edge count for all matching algorithms

### DIFF
--- a/networkx/algorithms/bipartite/covering.py
+++ b/networkx/algorithms/bipartite/covering.py
@@ -37,8 +37,8 @@ def min_edge_cover(G, matching_algorithm=None):
     -------
     set
         A set of the edges in a minimum edge cover of the graph, given as
-        pairs of nodes. It contains both the edges `(u, v)` and `(v, u)`
-        for given nodes `u` and `v` among the edges of minimum edge cover.
+        pairs of nodes. It contains only one of the equivalent 2-tuples
+        `(u, v)` and `(v, u)` for each edge.
 
     Notes
     -----

--- a/networkx/algorithms/bipartite/tests/test_covering.py
+++ b/networkx/algorithms/bipartite/tests/test_covering.py
@@ -12,7 +12,10 @@ class TestMinEdgeCover:
     def test_graph_single_edge(self):
         G = nx.Graph()
         G.add_edge(0, 1)
-        assert bipartite.min_edge_cover(G) == {(0, 1), (1, 0)}
+        # Should return one tuple per edge, not both directions
+        result = bipartite.min_edge_cover(G)
+        assert result == {(0, 1)} or result == {(1, 0)}
+        assert len(result) == 1
 
     def test_bipartite_default(self):
         G = nx.Graph()
@@ -21,7 +24,8 @@ class TestMinEdgeCover:
         G.add_edges_from([(1, "a"), (1, "b"), (2, "b"), (2, "c"), (3, "c"), (4, "a")])
         min_cover = bipartite.min_edge_cover(G)
         assert nx.is_edge_cover(G, min_cover)
-        assert len(min_cover) == 8
+        # Fixed: Should be 4 edges, not 8 (was counting both directions)
+        assert len(min_cover) == 4
 
     def test_bipartite_explicit(self):
         G = nx.Graph()
@@ -30,4 +34,5 @@ class TestMinEdgeCover:
         G.add_edges_from([(1, "a"), (1, "b"), (2, "b"), (2, "c"), (3, "c"), (4, "a")])
         min_cover = bipartite.min_edge_cover(G, bipartite.eppstein_matching)
         assert nx.is_edge_cover(G, min_cover)
-        assert len(min_cover) == 8
+        # Fixed: Should be 4 edges, not 8 (was counting both directions)
+        assert len(min_cover) == 4

--- a/networkx/algorithms/covering.py
+++ b/networkx/algorithms/covering.py
@@ -4,6 +4,7 @@ from functools import partial
 from itertools import chain
 
 import networkx as nx
+from networkx.algorithms.matching import matching_dict_to_set
 from networkx.utils import arbitrary_element, not_implemented_for
 
 __all__ = ["min_edge_cover", "is_edge_cover"]
@@ -19,10 +20,8 @@ def min_edge_cover(G, matching_algorithm=None):
     a maximum matching and extending it greedily so that all nodes
     are covered. This function follows that process. A maximum matching
     algorithm can be specified for the first step of the algorithm.
-    The resulting set may return a set with one 2-tuple for each edge,
-    (the usual case) or with both 2-tuples `(u, v)` and `(v, u)` for
-    each edge. The latter is only done when a bipartite matching algorithm
-    is specified as `matching_algorithm`.
+    The resulting set contains one 2-tuple `(u, v)` for each edge in the
+    minimum edge cover.
 
     Parameters
     ----------
@@ -43,12 +42,9 @@ def min_edge_cover(G, matching_algorithm=None):
     Returns
     -------
     min_cover : set
-
         A set of the edges in a minimum edge cover in the form of tuples.
         It contains only one of the equivalent 2-tuples `(u, v)` and `(v, u)`
-        for each edge. If a bipartite method is used to compute the matching,
-        the returned set contains both the 2-tuples `(u, v)` and `(v, u)`
-        for each edge of a minimum edge cover.
+        for each edge.
 
     Examples
     --------
@@ -74,34 +70,32 @@ def min_edge_cover(G, matching_algorithm=None):
     if len(G) == 0:
         return set()
     if nx.number_of_isolates(G) > 0:
-        # ``min_cover`` does not exist as there is an isolated node
         raise nx.NetworkXException(
             "Graph has a node with no edge incident on it, so no edge cover exists."
         )
     if matching_algorithm is None:
         matching_algorithm = partial(nx.max_weight_matching, maxcardinality=True)
     maximum_matching = matching_algorithm(G)
-    # ``min_cover`` is superset of ``maximum_matching``
-    try:
-        # bipartite matching algs return dict so convert if needed
-        min_cover = set(maximum_matching.items())
-        bipartite_cover = True
-    except AttributeError:
-        min_cover = maximum_matching
-        bipartite_cover = False
-    # iterate for uncovered nodes
-    uncovered_nodes = set(G) - {v for u, v in min_cover} - {u for u, v in min_cover}
+
+    # Normalize the matching to a set of edges (one tuple per edge)
+    # Bipartite matching algorithms return dict, non-bipartite return set
+    if isinstance(maximum_matching, dict):
+        min_cover = matching_dict_to_set(maximum_matching)
+    else:
+        min_cover = set(maximum_matching)
+
+    # Find uncovered nodes
+    covered_nodes = set()
+    for u, v in min_cover:
+        covered_nodes.add(u)
+        covered_nodes.add(v)
+
+    # Add edges to cover remaining nodes
+    uncovered_nodes = set(G) - covered_nodes
     for v in uncovered_nodes:
-        # Since `v` is uncovered, each edge incident to `v` will join it
-        # with a covered node (otherwise, if there were an edge joining
-        # uncovered nodes `u` and `v`, the maximum matching algorithm
-        # would have found it), so we can choose an arbitrary edge
-        # incident to `v`. (This applies only in a simple graph, not a
-        # multigraph.)
         u = arbitrary_element(G[v])
         min_cover.add((u, v))
-        if bipartite_cover:
-            min_cover.add((v, u))
+
     return min_cover
 
 

--- a/networkx/algorithms/tests/test_covering.py
+++ b/networkx/algorithms/tests/test_covering.py
@@ -40,16 +40,21 @@ class TestMinEdgeCover:
         G.add_nodes_from([1, 2, 3, 4], bipartite=0)
         G.add_nodes_from(["a", "b", "c"], bipartite=1)
         G.add_edges_from([(1, "a"), (1, "b"), (2, "b"), (2, "c"), (3, "c"), (4, "a")])
-        # Use bipartite method by prescribing the algorithm
+
+        # Use bipartite method
         min_cover = nx.min_edge_cover(
             G, nx.algorithms.bipartite.matching.eppstein_matching
         )
         assert nx.is_edge_cover(G, min_cover)
-        assert len(min_cover) == 8
-        # Use the default method which is not specialized for bipartite
+        assert len(min_cover) == 4  # Fixed: was incorrectly 8
+
+        # Use the default method
         min_cover2 = nx.min_edge_cover(G)
         assert nx.is_edge_cover(G, min_cover2)
         assert len(min_cover2) == 4
+
+        # Both methods should return same size
+        assert len(min_cover) == len(min_cover2)
 
     def test_complete_graph_even(self):
         G = nx.complete_graph(10)
@@ -62,6 +67,20 @@ class TestMinEdgeCover:
         min_cover = nx.min_edge_cover(G)
         assert nx.is_edge_cover(G, min_cover)
         assert len(min_cover) == 6
+
+    def test_bipartite_and_nonbipartite_consistency(self):
+        """Test that bipartite and non-bipartite matching give same cover size."""
+        G = nx.Graph()
+        G.add_edges_from([(0, 3), (1, 3), (1, 4), (2, 3)])
+
+        cover1 = nx.min_edge_cover(G)
+        cover2 = nx.min_edge_cover(
+            G, nx.algorithms.bipartite.matching.hopcroft_karp_matching
+        )
+
+        assert nx.is_edge_cover(G, cover1)
+        assert nx.is_edge_cover(G, cover2)
+        assert len(cover1) == len(cover2)
 
 
 class TestIsEdgeCover:


### PR DESCRIPTION
## Summary

Fixes #5823

`min_edge_cover()` was returning doubled edges when using bipartite matching algorithms (e.g., `eppstein_matching`, `hopcroft_karp_matching`) because these return a dict format `{u: v, v: u}` while non-bipartite algorithms return a set format `{(u, v)}`.

## Changes

- Use `matching_dict_to_set()` to normalize bipartite matching output
- Update tests to expect consistent behavior (4 edges instead of 8)
- Add new test `test_bipartite_and_nonbipartite_consistency`

## Before

```python
>>> nx.min_edge_cover(G, eppstein_matching)
{(1, 'a'), ('a', 1), (2, 'c'), ('c', 2), ...}  # 8 edges (doubled)
```

## After

```python
>>> nx.min_edge_cover(G, eppstein_matching)
{(1, 'a'), (2, 'c'), ...}  # 4 edges (correct)
```