### PR TITLE
ENH: Add has_self_loops to classes/function.py

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -1355,7 +1355,31 @@ def selfloop_edges(G, data=False, keys=False, default=None):
                 )
         else:
             return ((n, n) for n, nbrs in G._adj.items() if n in nbrs)
+@nx._dispatchable
+def has_self_loops(G):
+    """Returns True if the graph has any self-loops.
 
+    This is more efficient than checking if `number_of_selfloops` > 0,
+    as it returns immediately upon finding the first self-loop.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    Returns
+    -------
+    bool
+        True if the graph has any self-loops, False otherwise.
+
+    See Also
+    --------
+    number_of_selfloops
+    nodes_with_selfloops
+    """
+    # We use the existing generator but stop at the first item
+    for _ in nodes_with_selfloops(G):
+        return True
+    return False
 
 @nx._dispatchable
 def number_of_selfloops(G):


### PR DESCRIPTION
Added has_self_loops(G) to networkx/classes/function.py. Currently, users check number_of_selfloops(G) > 0, which iterates the entire graph. This new function is an O(1) (best-case) alternative that returns early, improving performance for existence checks.

<!--
Please use pre-commit to lint your code.
For more details check out step 1 and 4 of
https://networkx.org/documentation/latest/developer/contribute.html
-->

If you are using a LLM or any other AI model (ChatGPT, llama, mistral, claude ...),
please read and follow the guidelines in the
[Contributor Guide](https://networkx.org/documentation/latest/developer/contribute.html)
before submitting your PR.

Remove these comments from the description before opening the Pull Request.
