### PR TITLE
Bug: Floyd Warshall: resolved self positive loop bug introduced in #8386

### DIFF
--- a/networkx/algorithms/shortest_paths/dense.py
+++ b/networkx/algorithms/shortest_paths/dense.py
@@ -25,12 +25,12 @@ def _init_pred_dist(G, weight):
     # also set the distance to self to 0 (zero diagonal)
     weight = _weight_function(G, weight)
     for u, unbr in G._adj.items():
-        dist[u][u] = 0
         for v, e_attr in unbr.items():
             cost = weight(u, v, e_attr)
             if cost is not None:  # for hidden edge, weight() returns None
                 dist[u][v] = cost
                 pred[u][v] = u
+        dist[u][u] = 0
     return pred, dist
 
 

--- a/networkx/algorithms/shortest_paths/tests/test_dense.py
+++ b/networkx/algorithms/shortest_paths/tests/test_dense.py
@@ -186,6 +186,7 @@ class TestFloyd:
                 ("x", "y", 2),
                 ("y", "s", 7),
                 ("y", "v", 6),
+                ("x", "x", 3),  # added a positive self loop
             ]
         )
         path, dist = floyd_fn(XG)


### PR DESCRIPTION
Sorry, this error is due to my change in #8386.

---

Earlier:
```
G = nx.Graph()
G.add_edge(0,0, weight=5)
pred, dist = floyd_warshall_predecessor_and_distance(G)
assert dist[0][0] == 0
```
ASSERTION FAILED: 5 != 0

Now:
```
G = nx.Graph()
G.add_edge(0,0, weight=5)
pred, dist = floyd_warshall_predecessor_and_distance(G)
assert dist[0][0] == 0
```
ASSERTION SUCCESSFUL

---

From now on, I will keep just 1 PR active at a time.
Thank You!