### PR TITLE
ENH: Move tree_broadcast_center and tree_broadcast_time to nx.tree

### DIFF
--- a/networkx/algorithms/broadcasting.py
+++ b/networkx/algorithms/broadcasting.py
@@ -12,6 +12,8 @@ following constraints:
 - Each call only involves two adjacent nodes: a sender and a receiver.
 """
 
+import warnings
+
 import networkx as nx
 from networkx.utils import not_implemented_for
 
@@ -21,22 +23,15 @@ __all__ = [
 ]
 
 
-def _get_max_broadcast_value(G, U, v, values):
-    adj = sorted(set(G.neighbors(v)) & U, key=values.get, reverse=True)
-    return max(values[u] + i for i, u in enumerate(adj, start=1))
-
-
-def _get_broadcast_centers(G, v, values, target):
-    adj = sorted(G.neighbors(v), key=values.get, reverse=True)
-    j = next(i for i, u in enumerate(adj, start=1) if values[u] + i == target)
-    return set([v] + adj[:j])
-
-
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
 @nx._dispatchable
 def tree_broadcast_center(G):
     """Return the broadcast center of a tree.
+
+    .. deprecated:: 3.6
+       tree_broadcast_center is deprecated and will be removed in NetworkX 3.8.
+       Use ``nx.tree.broadcast_center`` instead.
 
     The broadcast center of a graph `G` denotes the set of nodes having
     minimum broadcast time [1]_. This function implements a linear algorithm
@@ -67,44 +62,15 @@ def tree_broadcast_center(G):
     .. [1] Slater, P.J., Cockayne, E.J., Hedetniemi, S.T,
        Information dissemination in trees. SIAM J.Comput. 10(4), 692–701 (1981)
     """
-    # Assert that the graph G is a tree
+    warnings.warn(
+        "tree_broadcast_center is deprecated and will be removed in NetworkX 3.8.\n"
+        "Use `nx.tree.broadcast_center` instead.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
     if not nx.is_tree(G):
         raise nx.NotATree("G is not a tree")
-    # step 0
-    if (n := len(G)) < 3:
-        return n - 1, set(G)
-
-    # step 1
-    U = {node for node, deg in G.degree if deg == 1}
-    values = {n: 0 for n in U}
-    T = G.copy()
-    T.remove_nodes_from(U)
-
-    # step 2
-    W = {node for node, deg in T.degree if deg == 1}
-    values.update((w, G.degree[w] - 1) for w in W)
-
-    # step 3
-    while len(T) >= 2:
-        # step 4
-        w = min(W, key=values.get)
-        v = next(T.neighbors(w))
-
-        # step 5
-        U.add(w)
-        W.remove(w)
-        T.remove_node(w)
-
-        # step 6
-        if T.degree(v) == 1:
-            # update t(v)
-            values.update({v: _get_max_broadcast_value(G, U, v, values)})
-            W.add(v)
-
-    # step 7
-    v = nx.utils.arbitrary_element(T)
-    b_T = _get_max_broadcast_value(G, U, v, values)
-    return b_T, _get_broadcast_centers(G, v, values, b_T)
+    return nx.tree.broadcast_center(G)
 
 
 @not_implemented_for("directed")
@@ -112,6 +78,10 @@ def tree_broadcast_center(G):
 @nx._dispatchable
 def tree_broadcast_time(G, node=None):
     """Return the minimum broadcast time of a (node in a) tree.
+
+    .. deprecated:: 3.6
+       tree_broadcast_time is deprecated and will be removed in NetworkX 3.8.
+       Use ``nx.tree.broadcast_time`` instead.
 
     The minimum broadcast time of a node is defined as the minimum amount
     of time required to complete broadcasting starting from that node.
@@ -153,12 +123,12 @@ def tree_broadcast_time(G, node=None):
         In Computing and Combinatorics. COCOON 2019
         (Ed. D. Z. Du and C. Tian.) Springer, pp. 240-253, 2019.
     """
-    if node is not None and node not in G:
-        err = f"node {node} not in G"
-        raise nx.NodeNotFound(err)
-    b_T, b_C = tree_broadcast_center(G)
-    if node is None:
-        return b_T + sum(1 for _ in nx.bfs_layers(G, b_C)) - 1
-    return b_T + next(
-        d for d, layer in enumerate(nx.bfs_layers(G, b_C)) if node in layer
+    warnings.warn(
+        "tree_broadcast_time is deprecated and will be removed in NetworkX 3.8.\n"
+        "Use `nx.tree.broadcast_time` instead.",
+        category=DeprecationWarning,
+        stacklevel=2,
     )
+    if not nx.is_tree(G):
+        raise nx.NotATree("G is not a tree")
+    return nx.tree.broadcast_time(G, node=node)

--- a/networkx/algorithms/tree/distance_measures.py
+++ b/networkx/algorithms/tree/distance_measures.py
@@ -5,6 +5,8 @@ Algorithms for computing distance measures on trees.
 import networkx as nx
 
 __all__ = [
+    "broadcast_center",
+    "broadcast_time",
     "center",
     "centroid",
 ]
@@ -217,3 +219,158 @@ def centroid(G):
     return [root] + [
         x for x in G.neighbors(root) if x != prev and sizes[x] == total_size / 2
     ]
+
+
+def _get_max_broadcast_value(G, U, v, values):
+    adj = sorted(set(G.neighbors(v)) & U, key=values.get, reverse=True)
+    return max(values[u] + i for i, u in enumerate(adj, start=1))
+
+
+def _get_broadcast_centers(G, v, values, target):
+    adj = sorted(G.neighbors(v), key=values.get, reverse=True)
+    j = next(i for i, u in enumerate(adj, start=1) if values[u] + i == target)
+    return set([v] + adj[:j])
+
+
+@nx.utils.not_implemented_for("directed")
+@nx.utils.not_implemented_for("multigraph")
+@nx._dispatchable
+def broadcast_center(G):
+    """Return the broadcast center of a tree.
+
+    The broadcast center of a graph `G` denotes the set of nodes having
+    minimum broadcast time [1]_. This function implements a linear algorithm
+    for determining the broadcast center of a tree with ``n`` nodes. As a
+    by-product, it also determines the broadcast time from the broadcast center.
+
+    Parameters
+    ----------
+    G : Graph
+        An undirected tree graph.
+
+    Returns
+    -------
+    b_T, b_C : (int, set) tuple
+        Minimum broadcast time of the broadcast center in `G`, set of nodes
+        in the broadcast center.
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If `G` is directed or is a multigraph.
+
+    Examples
+    --------
+    >>> G = nx.path_graph(5)
+    >>> nx.tree.broadcast_center(G)
+    (3, {1, 2, 3})
+
+    See Also
+    --------
+    broadcast_time
+
+    References
+    ----------
+    .. [1] Slater, P.J., Cockayne, E.J., Hedetniemi, S.T,
+       Information dissemination in trees. SIAM J.Comput. 10(4), 692–701 (1981)
+    """
+    # step 0
+    if (n := len(G)) < 3:
+        return n - 1, set(G)
+
+    # step 1
+    U = {node for node, deg in G.degree if deg == 1}
+    values = {n: 0 for n in U}
+    T = G.copy()
+    T.remove_nodes_from(U)
+
+    # step 2
+    W = {node for node, deg in T.degree if deg == 1}
+    values.update((w, G.degree[w] - 1) for w in W)
+
+    # step 3
+    while len(T) >= 2:
+        # step 4
+        w = min(W, key=values.get)
+        v = next(T.neighbors(w))
+
+        # step 5
+        U.add(w)
+        W.remove(w)
+        T.remove_node(w)
+
+        # step 6
+        if T.degree(v) == 1:
+            # update t(v)
+            values.update({v: _get_max_broadcast_value(G, U, v, values)})
+            W.add(v)
+
+    # step 7
+    v = nx.utils.arbitrary_element(T)
+    b_T = _get_max_broadcast_value(G, U, v, values)
+    return b_T, _get_broadcast_centers(G, v, values, b_T)
+
+
+@nx.utils.not_implemented_for("directed")
+@nx.utils.not_implemented_for("multigraph")
+@nx._dispatchable
+def broadcast_time(G, node=None):
+    """Return the minimum broadcast time of a (node in a) tree.
+
+    The minimum broadcast time of a node is defined as the minimum amount
+    of time required to complete broadcasting starting from that node.
+    The broadcast time of a graph is the maximum over
+    all nodes of the minimum broadcast time from that node [1]_.
+    This function returns the minimum broadcast time of `node`.
+    If `node` is `None`, the broadcast time for the graph is returned.
+
+    Parameters
+    ----------
+    G : Graph
+        An undirected tree graph.
+
+    node : node, optional (default=None)
+        Starting node for the broadcasting. If `None`, the algorithm
+        returns the broadcast time of the graph instead.
+
+    Returns
+    -------
+    int
+        Minimum broadcast time of `node` in `G`, or broadcast time of `G`
+        if no node is provided.
+
+    Raises
+    ------
+    NetworkXNotImplemented
+        If `G` is directed or is a multigraph.
+
+    NodeNotFound
+        If `node` is not a node in `G`.
+
+    Examples
+    --------
+    >>> G = nx.path_graph(5)
+    >>> nx.tree.broadcast_time(G)
+    4
+    >>> nx.tree.broadcast_time(G, node=0)
+    4
+
+    See Also
+    --------
+    broadcast_center
+
+    References
+    ----------
+    .. [1] Harutyunyan, H. A. and Li, Z.
+        "A Simple Construction of Broadcast Graphs."
+        In Computing and Combinatorics. COCOON 2019
+        (Ed. D. Z. Du and C. Tian.) Springer, pp. 240-253, 2019.
+    """
+    if node is not None and node not in G:
+        raise nx.NodeNotFound(f"node {node} not in G")
+    b_T, b_C = broadcast_center(G)
+    if node is None:
+        return b_T + sum(1 for _ in nx.bfs_layers(G, b_C)) - 1
+    return b_T + next(
+        d for d, layer in enumerate(nx.bfs_layers(G, b_C)) if node in layer
+    )

--- a/networkx/algorithms/tree/tests/test_distance_measures.py
+++ b/networkx/algorithms/tree/tests/test_distance_measures.py
@@ -97,3 +97,91 @@ class TestDistance:
         G = nx.Graph()
         with pytest.raises(nx.NetworkXPointlessConcept, match=r"has no nodes"):
             nx.tree.centroid(G)
+
+
+class TestBroadcast:
+    """Tests for broadcast_center and broadcast_time in tree module."""
+
+    def test_example_tree_broadcast(self):
+        """Test the BROADCAST algorithm on the example from the paper."""
+        edge_list = [
+            (0, 1),
+            (1, 2),
+            (2, 7),
+            (3, 4),
+            (5, 4),
+            (4, 7),
+            (6, 7),
+            (7, 9),
+            (8, 9),
+            (9, 13),
+            (13, 14),
+            (14, 15),
+            (14, 16),
+            (14, 17),
+            (13, 11),
+            (11, 10),
+            (11, 12),
+            (13, 18),
+            (18, 19),
+            (18, 20),
+        ]
+        G = nx.Graph(edge_list)
+        b_T, b_C = nx.tree.broadcast_center(G)
+        assert b_T == 6
+        assert b_C == {13, 9}
+        # test broadcast time from specific vertex
+        assert nx.tree.broadcast_time(G, 17) == 8
+        assert nx.tree.broadcast_time(G, 3) == 9
+        # test broadcast time of entire tree
+        assert nx.tree.broadcast_time(G) == 10
+
+    @pytest.mark.parametrize("n", range(2, 12))
+    def test_path_broadcast(self, n):
+        G = nx.path_graph(n)
+        b_T, b_C = nx.tree.broadcast_center(G)
+        assert b_T == math.ceil(n / 2)
+        assert b_C == {
+            math.ceil(n / 2),
+            n // 2,
+            math.ceil(n / 2 - 1),
+            n // 2 - 1,
+        }
+        assert nx.tree.broadcast_time(G) == n - 1
+
+    def test_empty_graph_broadcast(self):
+        H = nx.empty_graph(1)
+        b_T, b_C = nx.tree.broadcast_center(H)
+        assert b_T == 0
+        assert b_C == {0}
+        assert nx.tree.broadcast_time(H) == 0
+
+    @pytest.mark.parametrize("n", range(4, 12))
+    def test_star_broadcast(self, n):
+        G = nx.star_graph(n)
+        b_T, b_C = nx.tree.broadcast_center(G)
+        assert b_T == n
+        assert b_C == set(G.nodes())
+        assert nx.tree.broadcast_time(G) == b_T
+
+    @pytest.mark.parametrize("n", range(2, 8))
+    def test_binomial_tree_broadcast(self, n):
+        G = nx.binomial_tree(n)
+        b_T, b_C = nx.tree.broadcast_center(G)
+        assert b_T == n
+        assert b_C == {0, 2 ** (n - 1)}
+        assert nx.tree.broadcast_time(G) == 2 * n - 1
+
+    @pytest.mark.parametrize("fn", [nx.tree.broadcast_center, nx.tree.broadcast_time])
+    @pytest.mark.parametrize("graph_type", [nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph])
+    def test_raises_graph_type(self, fn, graph_type):
+        """Check that broadcast functions raise for directed and multigraph types."""
+        G = nx.path_graph(5, create_using=graph_type)
+        with pytest.raises(nx.NetworkXNotImplemented, match=r"not implemented for"):
+            fn(G)
+
+    def test_raises_node_not_in_G(self):
+        """Check that broadcast_time raises for invalid nodes."""
+        G = nx.path_graph(5)
+        with pytest.raises(nx.NodeNotFound, match=r"node.*not in G"):
+            nx.tree.broadcast_time(G, node=10)


### PR DESCRIPTION
## Summary
This PR moves the tree-specific broadcasting algorithms from `networkx.algorithms.broadcasting` to `networkx.algorithms.tree.distance_measures` following the pattern established in #8174 and #8089.

## Changes
- Added `broadcast_center` and `broadcast_time` to `networkx.algorithms.tree.distance_measures`
- Removed `is_tree` check from the new implementations (as being in `nx.tree` implies tree input)
- Deprecated `tree_broadcast_center` and `tree_broadcast_time` in `broadcasting.py`
- Old functions now emit `DeprecationWarning` and call the new `nx.tree` functions
- Added comprehensive tests for the new functions

## Rationale
As discussed in #8220, the `tree_broadcast_*` functions are tree-specific algorithms and should live in the `nx.tree` namespace. This provides:
- Better API organization - tree algorithms are in the tree module
- Performance improvement - no redundant `is_tree` checks when using `nx.tree` functions
- Consistency with other tree-specific distance measures like `center` and `centroid`

Closes #8220