### PR TITLE
DOC: Clarify minimum_node_cut behavior for complete graphs

### DIFF
--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -268,6 +268,10 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
     and undirected graphs. This implementation is based on algorithm 11
     in [1]_.
 
+    For complete graphs K_n, this function returns a set of n-1 nodes.
+    Removing those nodes leaves a single isolated node (the trivial
+    graph), which satisfies the definition of a minimum node cut.
+
     See also
     --------
     :meth:`minimum_node_cut`
@@ -380,6 +384,10 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
     corresponds to the minimum node cut of G. It handles both directed
     and undirected graphs. This implementation is based on algorithm 11
     in [1]_.
+
+    For complete graphs K_n, this function returns a set of n-1 nodes.
+    Removing those nodes leaves a single isolated node (the trivial
+    graph), which satisfies the definition of a minimum node cut.
 
     See also
     --------


### PR DESCRIPTION
Following the discussion in #8190 and #8428, this adds a note to the `minimum_node_cut` and `minimum_st_node_cut` docstrings explaining that returning n-1 nodes for complete graphs K_n is intentional behavior.

For complete graphs, removing n-1 nodes leaves a single isolated node (the trivial graph), which satisfies the formal definition of a minimum node cut.