### PR TITLE
Doc: Add nx_pydot to DOT file documentation

### DIFF
--- a/doc/reference/readwrite/dot.rst
+++ b/doc/reference/readwrite/dot.rst
@@ -10,7 +10,7 @@ If ``pygraphviz`` is installed, `~networkx.drawing.nx_agraph` can be used to
 read and write files in DOT format.
 
 NetworkX also provides an interface to Graphviz via `pydot <https://github.com/pydot/pydot>`__,
-implemented in :mod:`nx_pydot <networkx.drawing.nx_pydot>`.
+implemented in `~networkx.drawing.nx_pydot`.
 If ``pydot`` is installed, `~networkx.drawing.nx_pydot` can be used to
 read and write files in DOT format.
 


### PR DESCRIPTION
I realized that the "Reading and Writing Graphs" page just referred to pygraphviz, however, it also supports pydot. I inserted a comparable paragraph for nx_pydot so that users can obviously understand that they have both alternatives available.

Closes #8204

<img width="1910" height="1075" alt="image" src="https://github.com/user-attachments/assets/4554233c-efd7-47ad-8fd3-a93be5d366d0" />
