### PR TITLE
Fix/refactor dag root to leaf

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -7,7 +7,6 @@ to the user to check for that.
 
 import heapq
 from collections import deque
-from functools import partial
 from itertools import combinations, product
 from math import gcd
 


### PR DESCRIPTION
This PR addresses a internal TODO in `networkx/algorithms/dag.py` within the `root_to_leaf_paths` function. 
As suggested in the code comments, the implementation has been refactored to use `yield from` for a more idiomatic Python 3 approach, replacing the use of `chaini(starmap(...))`.

Testing
Ran the following command: `pytest networkx/algorithms/tests/test_dag.py`
Result: 67 passed in 0.34s
