### PR TITLE
Shortest path/add floating point comparison example

### DIFF
--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -81,25 +81,19 @@ def astar_path(G, source, target, heuristic=None, weight="weight", *, cutoff=Non
     are inherently approximate due to the limited precision of
     floating point arithmetic.
 
-    Examples affecting comparisons
-    ------------------------------
-    >>> import math
-    >>> G = nx.Graph()
-    >>> G.add_edge("s", "a", weight=0.1)
-    >>> G.add_edge("a", "t", weight=0.2)
-    >>> path = nx.astar_path(G, "s", "t")
-    >>> # The path length is approximately 0.3
-    >>> length = sum(G[u][v]["weight"] for u, v in zip(path, path[1:]))
-    >>> length == 0.3
-    False
-    >>> math.isclose(length, 0.3)
-    True
+    Examples affecting path selection:
+    ---------------------------------
+    >>> G = nx.DiGraph()
+    >>> G.add_edge("A", "B", weight=0.1)
+    >>> G.add_edge("B", "C", weight=0.1)
+    >>> G.add_edge("C", "D", weight=0.1)
+    >>> G.add_edge("A", "D", weight=0.3)
+    >>> nx.astar_path(G, "A", "D", weight="weight")
+    ['A', 'D']
 
-    NetworkX treats floating point values as exact. In shortest path
-    algorithms, small numerical errors can be dangerous; for example,
-    they can create 'phantom' negative cycles that cause infinite
-    loops. It is recommended to use integer weights or math.isclose
-    for comparisons.
+    NetworkX treats floating point values as exact. Here, the direct
+    edge is chosen because the summed path A-B-C-D results in
+    0.30000000000000004, which is greater than 0.3.
 
     Notes
     -----

--- a/networkx/algorithms/shortest_paths/dense.py
+++ b/networkx/algorithms/shortest_paths/dense.py
@@ -80,24 +80,24 @@ def floyd_warshall_numpy(G, nodelist=None, weight="weight"):
     inherently approximate due to the limited precision of floating
     point arithmetic.
 
-    Examples affecting comparisons
+    When using floating point weights, the returned distances are
+    inherently approximate due to the limited precision of floating
+    point arithmetic.
+
+    Examples affecting comparisons:
     ------------------------------
-    >>> import math
     >>> G = nx.DiGraph()
-    >>> G.add_edge("s", "a", weight=0.1)
-    >>> G.add_edge("a", "t", weight=0.2)
-    >>> fw = nx.floyd_warshall(G, weight="weight")
-    >>> length = fw["s"]["t"]
-    >>> length == 0.3
+    >>> G.add_edge("A", "B", weight=0.1)
+    >>> G.add_edge("B", "C", weight=0.2)
+    >>> distances = nx.floyd_warshall(G, weight="weight")
+    >>> # The distance A -> C should be 0.3
+    >>> distances["A"]["C"] == 0.3
     False
-    >>> math.isclose(length, 0.3)
+    >>> distances["A"]["C"] > 0.3
     True
 
-    NetworkX treats floating point values as exact. In shortest path
-    algorithms, small numerical errors can be dangerous; for example,
-    they can create "phantom" negative cycles that cause the algorithm
-    to report incorrect results. It is recommended to use integer
-    weights or ``math.isclose`` for comparisons.
+    Because 0.1 + 0.2 is slightly larger than 0.3 in binary, the
+    comparison fails.
 
     Notes
     -----

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -122,25 +122,20 @@ def shortest_path(G, source=None, target=None, weight=None, method="dijkstra"):
     are inherently approximate due to the limited precision of
     floating point arithmetic.
 
-    Examples affecting comparisons
-    ------------------------------
-    >>> import math
-    >>> G = nx.Graph()
-    >>> G.add_edge("s", "a", weight=0.1)
-    >>> G.add_edge("a", "t", weight=0.2)
-    >>> path = nx.shortest_path(G, "s", "t", weight="weight")
-    >>> # The path length is approximately 0.3
-    >>> length = sum(G[u][v]["weight"] for u, v in zip(path, path[1:]))
-    >>> length == 0.3
-    False
-    >>> math.isclose(length, 0.3)
-    True
+    Examples affecting path selection:
+    ---------------------------------
+    >>> G = nx.DiGraph()
+    >>> G.add_edge("A", "B", weight=0.1)
+    >>> G.add_edge("B", "C", weight=0.1)
+    >>> G.add_edge("C", "D", weight=0.1)
+    >>> G.add_edge("A", "D", weight=0.3)
+    >>> # total weight of path A->B->C->D is 0.1 + 0.1 + 0.1 = 0.30000000000000004
+    >>> nx.shortest_path(G, "A", "D", weight="weight")
+    ['A', 'D']
 
-    NetworkX treats floating point values as exact. In shortest path
-    algorithms, small numerical errors can be dangerous; for example,
-    they can create "phantom" negative cycles that cause infinite loops.
-    It is recommended to use integer weights or ``math.isclose`` for
-    comparisons.
+    Even though the path A -> B -> C -> D has a total weight that a human
+    sees as 0.3, the direct edge A -> D is selected because 0.1 + 0.1 + 0.1
+    is slightly larger than 0.3 in floating point math.
 
     Notes
     -----
@@ -279,23 +274,24 @@ def shortest_path_length(G, source=None, target=None, weight=None, method="dijks
     >>> p[0][4]
     4
 
-    Examples affecting comparisons
-    ------------------------------
-    >>> import math
-    >>> G = nx.Graph()
-    >>> G.add_edge("s", "a", weight=0.1)
-    >>> G.add_edge("a", "t", weight=0.2)
-    >>> length = nx.shortest_path_length(G, "s", "t", weight="weight")
-    >>> length == 0.3
-    False
-    >>> math.isclose(length, 0.3)
-    True
+    When using floating point weights, the returned length is
+    inherently approximate due to the limited precision of
+    floating point arithmetic.
 
-    NetworkX treats floating point values as exact. In shortest path
-    algorithms, small numerical errors can be dangerous; for example,
-    they can create "phantom" negative cycles that cause infinite loops.
-    It is recommended to use integer weights or ``math.isclose`` for
-    comparisons.
+    Examples affecting length calculation:
+    -------------------------------------
+    >>> G = nx.DiGraph()
+    >>> G.add_edge("A", "B", weight=0.1)
+    >>> G.add_edge("B", "C", weight=0.1)
+    >>> G.add_edge("C", "D", weight=0.1)
+    >>> G.add_edge("A", "D", weight=0.3)
+    >>> # 0.1 + 0.1 + 0.1 is actually 0.30000000000000004
+    >>> nx.shortest_path_length(G, "A", "D", weight="weight")
+    0.3
+
+    The returned length is 0.3 (the direct edge) rather than the path
+    sum 0.30000000000000004. NetworkX treats these values as exact,
+    picking the smaller value for the shortest path.
 
     Notes
     -----

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -143,24 +143,20 @@ def dijkstra_path(G, source, target, weight="weight"):
     are inherently approximate due to the limited precision of
     floating point arithmetic.
 
-    Examples affecting comparisons
-    ------------------------------
-    >>> import math
-    >>> G = nx.Graph()
-    >>> G.add_edge("s", "a", weight=0.1)
-    >>> G.add_edge("a", "t", weight=0.2)
-    >>> path = nx.dijkstra_path(G, "s", "t")
-    >>> # The path length is approximately 0.3
-    >>> length = sum(G[u][v]["weight"] for u, v in zip(path, path[1:]))
-    >>> length == 0.3
-    False
-    >>> math.isclose(length, 0.3)
-    True
+    Examples affecting path selection:
+    ---------------------------------
+    >>> G = nx.DiGraph()
+    >>> G.add_edge("A", "B", weight=0.1)
+    >>> G.add_edge("B", "C", weight=0.1)
+    >>> G.add_edge("C", "D", weight=0.1)
+    >>> G.add_edge("A", "D", weight=0.3)
+    >>> # total weight of path A->B->C->D is 0.1 + 0.1 + 0.1 = 0.30000000000000004
+    >>> nx.dijkstra_path(G, "A", "D", weight="weight")
+    ['A', 'D']
 
-    NetworkX treats floating point values as exact. Numerical errors
-    can be dangerous in shortest path algorithms, as they can lead to
-    incorrect path selection or "phantom" negative cycles. Use integer
-    weights or ``math.isclose`` for comparisons.
+    Even though the path A -> B -> C -> D has a total weight that a human
+    sees as 0.3, the direct edge A -> D is selected because 0.1 + 0.1 + 0.1
+    is slightly larger than 0.3 in floating point math.
 
     Notes
     -----
@@ -244,22 +240,24 @@ def dijkstra_path_length(G, source, target, weight="weight"):
     >>> nx.dijkstra_path_length(G, 0, 4)
     4
 
-    Examples affecting comparisons
-    ------------------------------
-    >>> import math
-    >>> G = nx.Graph()
-    >>> G.add_edge("s", "a", weight=0.1)
-    >>> G.add_edge("a", "t", weight=0.2)
-    >>> length = nx.dijkstra_path_length(G, "s", "t")
-    >>> length == 0.3
-    False
-    >>> math.isclose(length, 0.3)
-    True
+    When using floating point weights, the returned length is
+    inherently approximate due to the limited precision of
+    floating point arithmetic.
 
-    NetworkX treats floating point values as exact. Numerical errors
-    can be dangerous in shortest path algorithms, as they can lead to
-    incorrect path selection or "phantom" negative cycles. Use integer
-    weights or ``math.isclose`` for comparisons.
+    Examples affecting length calculation:
+    -------------------------------------
+    >>> G = nx.DiGraph()
+    >>> G.add_edge("A", "B", weight=0.1)
+    >>> G.add_edge("B", "C", weight=0.1)
+    >>> G.add_edge("C", "D", weight=0.1)
+    >>> G.add_edge("A", "D", weight=0.3)
+    >>> # 0.1 + 0.1 + 0.1 is actually 0.30000000000000004
+    >>> nx.dijkstra_path_length(G, "A", "D", weight="weight")
+    0.3
+
+    The returned length is 0.3 (the direct edge) rather than the path
+    sum 0.30000000000000004. NetworkX treats these values as exact,
+    picking the smaller value for the shortest path.
 
     Notes
     -----


### PR DESCRIPTION
fix: #8389 

Added floating point comparison example for shortest path algorithms (generic, weighted, Dijkstra, and A*).