### PR TITLE
Clarify that bfs_predecessors() does not actually search through predecessors

### DIFF
--- a/networkx/algorithms/traversal/breadth_first_search.py
+++ b/networkx/algorithms/traversal/breadth_first_search.py
@@ -266,12 +266,12 @@ def bfs_tree(G, source, reverse=False, depth_limit=None, sort_neighbors=None):
 def bfs_predecessors(G, source, depth_limit=None, sort_neighbors=None):
     """Returns an iterator of predecessors in breadth-first-search from source.
 
-    Each yielded ``(node, predecessor)`` tuple, describes a node and
+    Each yielded ``(node, predecessor)`` tuple describes a node and
     the node from which it is discovered in the breadth-first-search.
 
     The term "predecessor" here is not the directed graph term "predecessor".
-    We are not doing BFS in reverse direction. We are reporting the preceding
-    node for each node in a BFS.
+    We are not doing BFS in reverse direction. We are just reporting the
+    preceding node for each node in a BFS.
 
     Parameters
     ----------


### PR DESCRIPTION
Adds a paragraph to the docs of `bfs_predecessors()` addressing the confusion I had in #8442. This confusion has also been brought up in #710.

I tried to keep the wording fairly casual here; I think being explicit about this is best. Please let me know if you'd like any edits.