### PR TITLE
Optimize `_build_paths_from_predecessors` stack logic for 30-40% speedup

### DIFF
--- a/benchmarks/benchmarks/benchmark_shortest_path.py
+++ b/benchmarks/benchmarks/benchmark_shortest_path.py
@@ -1,6 +1,5 @@
 """Benchmarks for a certain set of algorithms"""
 
-import collections
 import random
 
 import networkx as nx

--- a/benchmarks/benchmarks/benchmark_shortest_path.py
+++ b/benchmarks/benchmarks/benchmark_shortest_path.py
@@ -1,5 +1,6 @@
 """Benchmarks for a certain set of algorithms"""
 
+import collections
 import random
 
 import networkx as nx
@@ -47,3 +48,24 @@ class UndirectedGraphAtlasSevenNodesConnected:
     def time_multi_source_dijkstra_over_atlas_with_target(self, edge_weights):
         for G in self.graphs:
             _ = nx.multi_source_dijkstra(G, sources=[0, 1], target=6)
+
+
+class AllShortestPathsGrid:
+    """
+    This tests the performance of _build_paths_from_predecessors
+    on graphs with a large number of paths (high recursion depth).
+    """
+
+    params = [8, 10, 12]
+    param_names = ["N"]
+    timeout = 300
+
+    def setup(self, N):
+        self.G = nx.grid_2d_graph(N, N)
+        self.source = (0, 0)
+        self.target = (N - 1, N - 1)
+
+    def time_all_shortest_paths(self, N):
+        collections.deque(
+            nx.all_shortest_paths(self.G, self.source, self.target), maxlen=0
+        )

--- a/benchmarks/benchmarks/benchmark_shortest_path.py
+++ b/benchmarks/benchmarks/benchmark_shortest_path.py
@@ -66,6 +66,5 @@ class AllShortestPathsGrid:
         self.target = (N - 1, N - 1)
 
     def time_all_shortest_paths(self, N):
-        collections.deque(
-            nx.all_shortest_paths(self.G, self.source, self.target), maxlen=0
-        )
+        for _ in nx.all_shortest_paths(self.G, self.source, self.target):
+            pass

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -697,11 +697,11 @@ def _build_paths_from_predecessors(sources, target, pred):
     seen = {target}
 
     while stack:
-        parent, children = stack[-1]
-        if parent in sources:
+        node, preds = stack[-1]
+        if node in sources:
             yield path[::-1]
 
-        for child in children:
+        for child in preds:
             if child not in seen:
                 seen.add(child)
                 path.append(child)
@@ -710,4 +710,4 @@ def _build_paths_from_predecessors(sources, target, pred):
         else:
             stack.pop()
             path.pop()
-            seen.remove(parent)
+            seen.remove(node)

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -701,11 +701,11 @@ def _build_paths_from_predecessors(sources, target, pred):
         if node in sources:
             yield path[::-1]
 
-        for child in preds:
-            if child not in seen:
-                seen.add(child)
-                path.append(child)
-                stack.append([child, iter(pred[child])])
+        for predecessor in preds:
+            if predecessor not in seen:
+                seen.add(predecessor)
+                path.append(predecessor)
+                stack.append([predecessor, iter(pred[predecessor])])
                 break
         else:
             stack.pop()

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -702,12 +702,13 @@ def _build_paths_from_predecessors(sources, target, pred):
             yield path[::-1]
 
         for predecessor in preds:
-            if predecessor not in seen:
-                seen.add(predecessor)
-                path.append(predecessor)
-                stack.append([predecessor, iter(pred[predecessor])])
-                break
-        else:
+            if predecessor in seen:
+                continue
+            seen.add(predecessor)
+            path.append(predecessor)
+            stack.append([predecessor, iter(pred[predecessor])])
+            break
+        else:  # no preds left!
             stack.pop()
             path.pop()
             seen.remove(node)

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -692,25 +692,22 @@ def _build_paths_from_predecessors(sources, target, pred):
     if target not in pred:
         raise nx.NetworkXNoPath(f"Target {target} cannot be reached from given sources")
 
+    stack = [[target, iter(pred[target])]]
+    path = [target]
     seen = {target}
-    stack = [[target, 0]]
-    top = 0
-    while top >= 0:
-        node, i = stack[top]
-        if node in sources:
-            yield [p for p, n in reversed(stack[: top + 1])]
-        if len(pred[node]) > i:
-            stack[top][1] = i + 1
-            next = pred[node][i]
-            if next in seen:
-                continue
-            else:
-                seen.add(next)
-            top += 1
-            if top == len(stack):
-                stack.append([next, 0])
-            else:
-                stack[top][:] = [next, 0]
+
+    while stack:
+        parent, children = stack[-1]
+        if parent in sources:
+            yield path[::-1]
+
+        for child in children:
+            if child not in seen:
+                seen.add(child)
+                path.append(child)
+                stack.append([child, iter(pred[child])])
+                break
         else:
-            seen.discard(node)
-            top -= 1
+            stack.pop()
+            path.pop()
+            seen.remove(parent)


### PR DESCRIPTION
### Description

This PR optimizes the `_build_paths_from_predecessors` function in `networkx/algorithms/shortest_paths/generic.py`.

The current implementation manages the stack manually using list indices (`stack[top][1] = i + 1`) and an explicit `top` pointer, which is verbose and adds overhead. I have refactored this to use a standard iterator-based stack approach (`stack = [[node, iter(children)]]`).

This change improves performance significantly for large graphs with many paths while maintaining identical behavior.

Fixes #8459

### Improvements

1.  **Performance:** Consistently **30-40% faster** on large graphs (see benchmarks below).
2.  **Readability:** Reduces code complexity by removing manual index tracking and explicit `top` pointer manipulation.
3.  **Memory:** Uses Python iterators, which are generally more memory-efficient than maintaining explicit index integers for every stack level, though the difference is likely negligible compared to the graph size.

### Benchmark Results

I benchmarked both implementations using `nx.grid_2d_graph(N, N)` from $N=2$ to $N=16$. The new implementation shows significant time savings as the number of paths grows.

**Test Environment:** Grid Graph ($N \times N$), finding all shortest paths from `(0,0)` to `(N-1, N-1)`.

| Grid Size | Paths Found | Old Time (s) | New Time (s) | Speedup |
| :--- | :--- | :--- | :--- | :--- |
| **10x10** | 48,620 | 0.190s | 0.105s | **1.80x** |
| **12x12** | 705,432 | 2.55s | 1.52s | **1.68x** |
| **14x14** | 10,400,600 | 38.93s | 22.21s | **1.75x** |
| **15x15** | 40,116,600 | 153.65s | 85.30s | **1.80x** |
| **16x16** | 155,117,520 | 795.19s | 494.92s | **1.61x** |

**Total Time Saved (16x16):** ~300 seconds (5 minutes).

### Performance Graph

<img width="1536" height="754" alt="Benchmark Graph" src="https://github.com/user-attachments/assets/99e63d5e-40e9-4bab-8528-599ad3d94d18" />

### Implementation Details

**Old Approach:**
```python
seen = {target}
stack = [[target, 0]]
top = 0
while top >= 0:
    node, i = stack[top]
    if node in sources:
        yield [p for p, n in reversed(stack[: top + 1])]
    if len(pred[node]) > i:
        stack[top][1] = i + 1
        next = pred[node][i]
        if next in seen:
            continue
        else:
            seen.add(next)
        top += 1
        if top == len(stack):
            stack.append([next, 0])
        else:
            stack[top][:] = [next, 0]
    else:
        seen.discard(node)
        top -= 1
```
**New Approach:**
```python
stack = [[target, iter(pred[target])]]
path = [target]
seen = {target}

while stack:
    parent, children = stack[-1]
    if parent in sources:
        yield path[::-1]

    for child in children:
        if child not in seen:
            seen.add(child)
            path.append(child)
            stack.append([child, iter(pred[child])])
            break
    else:
        stack.pop()
        path.pop()
        seen.remove(parent)
```
### Verification

- [x] Ran `pytest networkx/algorithms/shortest_paths/tests/test_generic.py` - **PASSED**