### PR TITLE
Adopt scikit-learn's agentic AI policy

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -31,7 +31,7 @@ Contributor Guide
 .. _automated_contributions_policy:
 
 Automated Contributions Policy
---------------------
+------------------------------
 
 Contributing to networkx requires human judgment, contextual understanding, and
 familiarity with networkx's structure and goals. It is not suitable for


### PR DESCRIPTION
This adopts [scikit-learn's AI policies](https://scikit-learn.org/stable/developers/contributing.html#automated-contributions-policy) verbatim regarding using automated AI tools to generate PRs/commenting on issues.

Any opinions here? @networkx/maintainers 

