### PR TITLE
Explicitly install nx after deps.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
           command: |
             source venv/bin/activate
             pip install -e '.[default,test,extra,example,doc]'
+            pip install -e .
             pip list
 
       - run:


### PR DESCRIPTION
The [incantation currently used for installing deps](https://github.com/networkx/networkx/blob/d3e018213f562832734fa7126018bb22cc7c6376/.circleci/config.yml#L62) is resulting in [non-development versions of NX to be installed](https://app.circleci.com/pipelines/github/networkx/networkx/12813/workflows/3ab14c0f-b128-4331-9193-36aa92d18d08/jobs/23025). My guess is that the `.[deps]` pattern results in a networkx version which is a transitive dependency of one of our deps ( :upside_down_face: ) overrides the installation of the development version.