### PR TITLE
Improve chordal code readability by removing helper function

### DIFF
--- a/networkx/algorithms/chordal.py
+++ b/networkx/algorithms/chordal.py
@@ -227,7 +227,9 @@ def chordal_graph_cliques(G):
             numbered = {v}
             clique_wanna_be = {v}
             while unnumbered:
-                v = _max_cardinality_node(C, unnumbered, numbered)
+                # The node from the unnumbered set with the most connections
+                # to nodes in the numbered set
+                v = max(unnumbered, key=lambda n: len(G._adj[n].keys() & numbered))
                 unnumbered.remove(v)
                 numbered.add(v)
                 new_clique_wanna_be = set(C.neighbors(v)) & numbered
@@ -303,13 +305,6 @@ def _find_missing_edge(G):
             return (u, missing.pop())
 
 
-def _max_cardinality_node(G, choices, wanna_connect):
-    """Returns a the node in choices that has more connections in G
-    to nodes in wanna_connect.
-    """
-    return max(choices, key=lambda n: len(G._adj[n].keys() & wanna_connect))
-
-
 def _find_chordality_breaker(G, s=None, treewidth_bound=sys.maxsize):
     """Given a graph G, starts a max cardinality search
     (starting from s if s is given and from an arbitrary node otherwise)
@@ -329,7 +324,9 @@ def _find_chordality_breaker(G, s=None, treewidth_bound=sys.maxsize):
     numbered = {s}
     current_treewidth = -1
     while unnumbered:  # and current_treewidth <= treewidth_bound:
-        v = _max_cardinality_node(G, unnumbered, numbered)
+        # The node from the unnumbered set with the most connections
+        # to nodes in the numbered set
+        v = max(unnumbered, key=lambda n: len(G._adj[n].keys() & numbered))
         unnumbered.remove(v)
         numbered.add(v)
         clique_wanna_be = set(G[v]) & numbered


### PR DESCRIPTION
Inspired by changes proposed in #8408 .

This PR replaces the `_max_cardinality_node` internal helper function with a more Pythonic one-line implementation that makes use of the `key=` feature of `max` along with set operations with dict keys.

The two commits here are intentional: the first (32d1c27) essentially shows the change from the original implementation (iterating over all nodes in a set) to the new implementation which uses `max(..., key=)`. The second commit (0ada50d) then simply removes the helper function altogether and "interns" the one-line implementation in the two places where the helper funtion was originally called (along with a comment).

The main motivation here is improved readability, but I did run the benchmarks to ensure that this change wouldn't cause a performance regression. Indeed the new implementation is more performant too:

<details>
<summary>Results of <code>asv continuous --bench ChordalBenchmarks main chordal_rm_max_cardinality_helper</code></summary>
<pre>
| Change   | Before [64d154e8] <main>   | After [0ada50d3] <chordal_rm_max_cardinality_helper>   |   Ratio | Benchmark (Parameter)                                                |
|----------|----------------------------|--------------------------------------------------------|---------|----------------------------------------------------------------------|
| -        | 76.9±0.1ms                 | 69.6±0.1ms                                             |    0.9  | benchmark_chordal.ChordalBenchmarks.time_is_chordal_complete(100)    |
| -        | 1.11±0.01ms                | 965±7μs                                                |    0.87 | benchmark_chordal.ChordalBenchmarks.time_is_chordal_wheel(50)        |
| -        | 3.45±0.04ms                | 2.88±0ms                                               |    0.83 | benchmark_chordal.ChordalBenchmarks.time_is_chordal_wheel(100)       |
| -        | 634±0.7μs                  | 517±3μs                                                |    0.82 | benchmark_chordal.ChordalBenchmarks.time_is_chordal_cycle_graph(50)  |
| -        | 608±1μs                    | 500±9μs                                                |    0.82 | benchmark_chordal.ChordalBenchmarks.time_is_chordal_star(50)         |
| -        | 624±2μs                    | 503±1μs                                                |    0.81 | benchmark_chordal.ChordalBenchmarks.time_is_chordal_path(50)         |
| -        | 1.98±0.01ms                | 1.50±0.01ms                                            |    0.76 | benchmark_chordal.ChordalBenchmarks.time_is_chordal_cycle_graph(100) |
| -        | 1.92±0ms                   | 1.45±0.01ms                                            |    0.76 | benchmark_chordal.ChordalBenchmarks.time_is_chordal_star(100)        |
| -        | 1.97±0ms                   | 1.49±0ms                                               |    0.75 | benchmark_chordal.ChordalBenchmarks.time_is_chordal_path(100)        |
</pre>
</details>