### PR TITLE
CI: Bump dispatch workflow python version.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.14"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
This is a small part of preparations for dropping Python 3.11 support, but the dispatch testing workflow is a bit special so I wanted to isolate this update in particular in its own PR!