### PR TITLE
DOC: Use `dict(G.degree)` in examples.

### DIFF
--- a/networkx/classes/digraph.py
+++ b/networkx/classes/digraph.py
@@ -1114,8 +1114,8 @@ class DiGraph(Graph):
         >>> nx.add_path(G, [0, 1, 2, 3])
         >>> G.degree(0)  # node 0 with degree 1
         1
-        >>> list(G.degree([0, 1, 2]))
-        [(0, 1), (1, 2), (2, 2)]
+        >>> dict(G.degree([0, 1, 2]))
+        {0: 1, 1: 2, 2: 2}
 
         """
         return DiDegreeView(self)
@@ -1161,8 +1161,8 @@ class DiGraph(Graph):
         >>> nx.add_path(G, [0, 1, 2, 3])
         >>> G.in_degree(0)  # node 0 with degree 0
         0
-        >>> list(G.in_degree([0, 1, 2]))
-        [(0, 0), (1, 1), (2, 1)]
+        >>> dict(G.in_degree([0, 1, 2]))
+        {0: 0, 1: 1, 2: 1}
 
         """
         return InDegreeView(self)
@@ -1208,8 +1208,8 @@ class DiGraph(Graph):
         >>> nx.add_path(G, [0, 1, 2, 3])
         >>> G.out_degree(0)  # node 0 with degree 1
         1
-        >>> list(G.out_degree([0, 1, 2]))
-        [(0, 1), (1, 1), (2, 1)]
+        >>> dict(G.out_degree([0, 1, 2]))
+        {0: 1, 1: 1, 2: 1}
 
         """
         return OutDegreeView(self)

--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -1540,8 +1540,8 @@ class Graph:
         >>> G = nx.path_graph(4)  # or DiGraph, MultiGraph, MultiDiGraph, etc
         >>> G.degree[0]  # node 0 has degree 1
         1
-        >>> list(G.degree([0, 1, 2]))
-        [(0, 1), (1, 2), (2, 2)]
+        >>> dict(G.degree([0, 1, 2]))
+        {0: 1, 1: 2, 2: 2}
         """
         return DegreeView(self)
 

--- a/networkx/classes/multidigraph.py
+++ b/networkx/classes/multidigraph.py
@@ -758,12 +758,12 @@ class MultiDiGraph(MultiGraph, DiGraph):
         >>> nx.add_path(G, [0, 1, 2, 3])
         >>> G.degree(0)  # node 0 with degree 1
         1
-        >>> list(G.degree([0, 1, 2]))
-        [(0, 1), (1, 2), (2, 2)]
+        >>> dict(G.degree([0, 1, 2]))
+        {0: 1, 1: 2, 2: 2}
         >>> G.add_edge(0, 1)  # parallel edge
         1
-        >>> list(G.degree([0, 1, 2]))  # parallel edges are counted
-        [(0, 2), (1, 3), (2, 2)]
+        >>> dict(G.degree([0, 1, 2]))  # parallel edges are counted
+        {0: 2, 1: 3, 2: 2}
 
         """
         return DiMultiDegreeView(self)
@@ -809,12 +809,12 @@ class MultiDiGraph(MultiGraph, DiGraph):
         >>> nx.add_path(G, [0, 1, 2, 3])
         >>> G.in_degree(0)  # node 0 with degree 0
         0
-        >>> list(G.in_degree([0, 1, 2]))
-        [(0, 0), (1, 1), (2, 1)]
+        >>> dict(G.in_degree([0, 1, 2]))
+        {0: 0, 1: 1, 2: 1}
         >>> G.add_edge(0, 1)  # parallel edge
         1
-        >>> list(G.in_degree([0, 1, 2]))  # parallel edges counted
-        [(0, 0), (1, 2), (2, 1)]
+        >>> dict(G.in_degree([0, 1, 2]))  # parallel edges counted
+        {0: 0, 1: 2, 2: 1}
 
         """
         return InMultiDegreeView(self)
@@ -859,12 +859,12 @@ class MultiDiGraph(MultiGraph, DiGraph):
         >>> nx.add_path(G, [0, 1, 2, 3])
         >>> G.out_degree(0)  # node 0 with degree 1
         1
-        >>> list(G.out_degree([0, 1, 2]))
-        [(0, 1), (1, 1), (2, 1)]
+        >>> dict(G.out_degree([0, 1, 2]))
+        {0: 1, 1: 1, 2: 1}
         >>> G.add_edge(0, 1)  # parallel edge
         1
-        >>> list(G.out_degree([0, 1, 2]))  # counts parallel edges
-        [(0, 2), (1, 1), (2, 1)]
+        >>> dict(G.out_degree([0, 1, 2]))  # counts parallel edges
+        {0: 2, 1: 1, 2: 1}
 
         """
         return OutMultiDegreeView(self)

--- a/networkx/classes/multigraph.py
+++ b/networkx/classes/multigraph.py
@@ -1017,8 +1017,8 @@ class MultiGraph(Graph):
         >>> nx.add_path(G, [0, 1, 2, 3])
         >>> G.degree(0)  # node 0 with degree 1
         1
-        >>> list(G.degree([0, 1]))
-        [(0, 1), (1, 2)]
+        >>> dict(G.degree([0, 1]))
+        {0: 1, 1: 2}
 
         """
         return MultiDegreeView(self)


### PR DESCRIPTION
Consuming the `degree` iterator with a dict is a more common pattern than using list, so highlight it in the relevant docstring examples.