### PR TITLE
DOC: footnote -> hyperlink.

### DIFF
--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -2,9 +2,9 @@
 
 Finding the largest clique in a graph is NP-complete problem, so most of
 these algorithms have an exponential running time; for more information,
-see the Wikipedia article on the clique problem [1]_.
+see the `Wikipedia article on the clique problem <clique_wiki_>`_.
 
-.. [1] clique problem:: https://en.wikipedia.org/wiki/Clique_problem
+.. _clique_wiki: https://en.wikipedia.org/wiki/Clique_problem
 
 """
 


### PR DESCRIPTION
Very minor rst-formatting update to improve the rendering of the clique module docstring in the refguide. The current syntax results in a footnote - the proposed syntax is a standard hyperlink.