### PR TITLE
Closer look at node attribute iter

### DIFF
--- a/networkx/algorithms/assortativity/pairs.py
+++ b/networkx/algorithms/assortativity/pairs.py
@@ -47,7 +47,7 @@ def node_attribute_xy(G, attribute, nodes=None):
     """
     nodes = set(G) if nodes is None else set(nodes)
     n_attrs = G.nodes(data=attribute, default=None)
-    for u, v in G.edges(nbunch=nodes):
+    for u, v in G.to_directed().edges(nbunch=nodes):
         yield (n_attrs[u], n_attrs[v])
 
 

--- a/networkx/algorithms/assortativity/pairs.py
+++ b/networkx/algorithms/assortativity/pairs.py
@@ -47,6 +47,9 @@ def node_attribute_xy(G, attribute, nodes=None):
     """
     nodes = set(G) if nodes is None else set(nodes)
     n_attrs = G.nodes(data=attribute, default=None)
+
+    # Use `to_directed()` to ensure that attribute pairs for both (u, v) and
+    # (v, u) are reported (self-loops reported only once)
     for u, v in G.to_directed().edges(nbunch=nodes):
         yield (n_attrs[u], n_attrs[v])
 

--- a/networkx/algorithms/assortativity/pairs.py
+++ b/networkx/algorithms/assortativity/pairs.py
@@ -45,24 +45,10 @@ def node_attribute_xy(G, attribute, nodes=None):
     representation (u, v) and (v, u), with the exception of self-loop edges
     which only appear once.
     """
-    if nodes is None:
-        nodes = set(G)
-    else:
-        nodes = set(nodes)
-    Gnodes = G.nodes
-    for u, nbrsdict in G.adjacency():
-        if u not in nodes:
-            continue
-        uattr = Gnodes[u].get(attribute, None)
-        if G.is_multigraph():
-            for v, keys in nbrsdict.items():
-                vattr = Gnodes[v].get(attribute, None)
-                for _ in keys:
-                    yield (uattr, vattr)
-        else:
-            for v in nbrsdict:
-                vattr = Gnodes[v].get(attribute, None)
-                yield (uattr, vattr)
+    nodes = set(G) if nodes is None else set(nodes)
+    n_attrs = G.nodes(data=attribute, default=None)
+    for u, v in G.edges(nbunch=nodes):
+        yield (n_attrs[u], n_attrs[v])
 
 
 @nx._dispatchable(edge_attrs="weight")


### PR DESCRIPTION
Reviewing the issues/PRs related to pearson assortativity prompted me to look more closely at the assortativity package. There's a lot of indirection there, and it got me wondering whether some of it couldn't be simplified.

The first rabbit hole I fell down was with the `node_attribute_xy` iterator - the docstring describes it as yielding node attribute pairs for all edges incident to the specified nodes. The implementation seemed quite complicated given this description.

It turns out you can get the same[^1] behavior by iterating over the edges rather than the adjacency. This has the advantage of getting rid of conditionals in the loop (no more `if ... : continue`, and no special casing for multigraphs). I'd argue this is much more readable.

The downside is that `node_attribute_xy` yields attributes for all possible orderings of node pairs (i.e. `u, v` and `v, u`), regardless whether `G` is directed or not. We can get this same behavior using `to_directed` when iterating over `G` 's edges, but this has the disadvantage of making a (deep) copy of the entire graph.