### PR TITLE
Fix ZeroDivisionError in normalized rich_club_coefficient

### DIFF
--- a/networkx/algorithms/richclub.py
+++ b/networkx/algorithms/richclub.py
@@ -1,5 +1,6 @@
 """Functions for computing rich-club coefficients."""
 
+import math
 from itertools import accumulate
 
 import networkx as nx
@@ -96,7 +97,10 @@ def rich_club_coefficient(G, normalized=True, Q=100, seed=None):
         E = R.number_of_edges()
         nx.double_edge_swap(R, Q * E, max_tries=Q * E * 10, seed=seed)
         rcran = _compute_rc(R)
-        rc = {k: v / rcran[k] for k, v in rc.items()}
+        rc = {
+            k: v / rcran[k] if rcran[k] != 0 else math.nan
+            for k, v in rc.items()
+        }
     return rc
 
 

--- a/networkx/algorithms/tests/test_richclub.py
+++ b/networkx/algorithms/tests/test_richclub.py
@@ -137,6 +137,38 @@ def test_rich_club_leq_3_nodes_normalized():
             rc = nx.rich_club_coefficient(G, normalized=True)
 
 
+def test_richclub_zerodivision():
+    """Test that ZeroDivisionError is avoided when random graph has zero coefficient.
+
+    Regression test for issue #8485.
+    When the randomized graph has a zero rich-club coefficient for a degree k,
+    but the original graph does not, the normalization would divide by zero.
+    The fix returns NaN in this case.
+    """
+    import math
+
+    # This graph structure can produce zero rich-club coefficients in
+    # randomized versions due to its sparse connectivity
+    G = nx.Graph()
+    G.add_nodes_from(["A", "A_1", "A_2", "B", "B_1", "B_2", "C", "D"])
+    G.add_edge("A", "A_1")
+    G.add_edge("A", "A_2")
+    G.add_edge("B", "B_1")
+    G.add_edge("B", "B_2")
+    G.add_edge("A", "B")
+    G.add_edge("C", "D")
+
+    # Run many times to increase chance of hitting the edge case
+    # where random graph has zero coefficient
+    for _ in range(100):
+        rc = nx.rich_club_coefficient(G, normalized=True, Q=1, seed=None)
+        # Check that all values are either valid floats or NaN (not exceptions)
+        for k, v in rc.items():
+            assert isinstance(v, float), f"Expected float, got {type(v)}"
+            # If v is NaN, that's acceptable (division by zero case handled)
+            # If v is a normal float, that's also fine
+
+
 # def test_richclub2_normalized():
 #    T = nx.balanced_tree(2,10)
 #    rcNorm = nx.richclub.rich_club_coefficient(T,Q=2)


### PR DESCRIPTION
## Summary

- Fixes ZeroDivisionError that occurs when computing normalized rich-club coefficient on sparse graphs
- Returns `math.nan` instead of raising an exception when the randomized graph has a zero coefficient for a degree k
- Adds regression test for the fix

## Details

When computing the normalized rich-club coefficient, the function divides by the coefficient from a randomized graph. For sparse graphs with few high-degree nodes, the randomized graph can have a zero coefficient for some degree k while the original graph has a non-zero coefficient, causing `ZeroDivisionError`.

The fix follows Option 1 from issue #8485:
```python
rc = {
    k: v / rcran[k] if rcran[k] != 0 else math.nan
    for k, v in rc.items()
}
```

## Test plan

- [x] Added `test_richclub_zerodivision` test that reproduces the issue
- [x] All existing rich club tests pass

Fixes #8485

🤖 Generated with [Claude Code](https://claude.com/claude-code)