### PR TITLE
BUG: fix ISMAGS self-loops error

### DIFF
--- a/networkx/algorithms/isomorphism/tests/test_common.py
+++ b/networkx/algorithms/isomorphism/tests/test_common.py
@@ -543,9 +543,7 @@ def test_subgraph_triangle_square_2tails(iso_ic, symmetry, Gclass):
     assert iso_ic(Gclass(G), Gclass(SG), symmetry=symmetry)
     SG.remove_edge(2, 3)
 
-    if "ismags" not in iso_ic.__name__:
-        # FIXME: check why fails ismags but not vf2
-        assert mono == iso_ic(Gclass(G), Gclass(SG), symmetry=symmetry)
+    assert mono == iso_ic(Gclass(G), Gclass(SG), symmetry=symmetry)
 
     SG.add_edges_from([(7, 3), (7, 4)])
     assert not iso_ic(Gclass(G), Gclass(SG), symmetry=symmetry)


### PR DESCRIPTION
The recently merged `isomorphism/tests/test_common.py` suite of isomorphism tests showed that self-loops were not being handled correctly in the ISMAGS isomorphism algorithm.

This PR fixes that. The check of matching self-loop count is added when creating the initial candidate sets -- that is, while checking for correct colors.  Now it checks for matching node color and count of self-loops. 

Test is updated and method doc-string in ISMAGS is updated.

This is independent of other isomorphism PRs.