### PR TITLE
CI: Explicitly add pip as a dep while resolving doc env

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,7 +1,6 @@
 name: deploy
 
 on:
-  pull_request:
   push:
     branches: [main]
 
@@ -17,7 +16,6 @@ jobs:
           environments: docs
       - name: Register graphviz plugins
         run: pixi run -e docs dot -c
-      - run: pixi run -e docs pip -V
       - name: Install backend stubs
         run: pixi run -e docs install-backend-stubs
 


### PR DESCRIPTION
Ahhhh, alright mystery solved. We need to add `pip` explicitly as a dep as python on conda-forge doesn't package pip with it. It the previous runs it was picking up a stray pip which is there by default in the github action runners.
```
pip 22.0.2 from /usr/lib/python3/dist-packages/pip (python 3.10)
```

We are using the Ubuntu 22.04 image here which comes with [some tools like python preinstalled.](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#language-and-runtime)

This should fix https://github.com/networkx/networkx/issues/8516. Tested in CI: https://github.com/networkx/networkx/actions/runs/22111307570/job/63907949733