### PR TITLE
Fix astar_path ignoring cutoff=0 due to truthiness check

### DIFF
--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -162,7 +162,7 @@ def astar_path(G, source, target, heuristic=None, weight="weight", *, cutoff=Non
             else:
                 h = heuristic(neighbor, target)
 
-            if cutoff and ncost + h > cutoff:
+            if cutoff is not None and ncost + h > cutoff:
                 continue
 
             enqueued[neighbor] = ncost, h


### PR DESCRIPTION
## Summary

`astar_path` ignores `cutoff=0` (and `cutoff=0.0`) because the cutoff check uses Python truthiness instead of a `None` check.

## The Bug

Line 165 in `astar.py`:
```python
if cutoff and ncost + h > cutoff:
```

Since `0` is falsy in Python, `cutoff=0` makes the entire condition `False`, and the cutoff constraint is never enforced. A* then returns paths that exceed the cutoff.

This is inconsistent with Dijkstra's implementation which correctly uses `cutoff is not None`:
```python
# dijkstra.py correctly handles cutoff=0
if cutoff is not None:
    if next_dist > cutoff:
        continue
```

```python
import networkx as nx

G = nx.path_graph(5)  # 0-1-2-3-4, all weights = 1

# Should raise NetworkXNoPath since path cost (4) > cutoff (0)
path = nx.astar_path(G, 0, 4, cutoff=0)
print(path)  # Bug: returns [0, 1, 2, 3, 4] instead of raising
```

## The Fix

Changed `if cutoff and ...` to `if cutoff is not None and ...`.
