### PR TITLE
Fix LCA greedy descent returning non-lowest common ancestor

### DIFF
--- a/networkx/algorithms/lowest_common_ancestors.py
+++ b/networkx/algorithms/lowest_common_ancestors.py
@@ -108,16 +108,22 @@ def all_pairs_lowest_common_ancestor(G, pairs=None):
             common_ancestors = ancestor_cache[v] & ancestor_cache[w]
 
             if common_ancestors:
-                common_ancestor = next(iter(common_ancestors))
-                while True:
-                    successor = None
-                    for lower_ancestor in G.successors(common_ancestor):
-                        if lower_ancestor in common_ancestors:
-                            successor = lower_ancestor
-                            break
-                    if successor is None:
-                        break
-                    common_ancestor = successor
+                # Find a lowest common ancestor: a common ancestor with no
+                # descendant that is also a common ancestor.  The previous
+                # greedy-descent approach could get stuck when the path from
+                # a root to the true LCA passes through non-common-ancestor
+                # nodes.
+                #
+                # We iterate through common_ancestors and look for one whose
+                # successors (in the transitive closure restricted to common
+                # ancestors) are empty — i.e. it has no "lower" common
+                # ancestor below it.
+                ca_graph = G.subgraph(common_ancestors)
+                # Any node with out-degree 0 in the common-ancestor subgraph
+                # is a valid lowest common ancestor.
+                common_ancestor = next(
+                    n for n in ca_graph if ca_graph.out_degree(n) == 0
+                )
                 yield ((v, w), common_ancestor)
 
     return generate_lca_from_pairs(G, pairs)


### PR DESCRIPTION
## Summary

The greedy descent in `_generate_lca_from_pairs` can return a non-lowest common ancestor when the path from a root ancestor to the true LCA passes through nodes that are *not* common ancestors of both targets.

## Problem

The current algorithm picks an arbitrary common ancestor and greedily descends by following successors that are also common ancestors. However, in certain DAG topologies the immediate successors of a higher common ancestor are not themselves common ancestors — they're only ancestors of one target. This causes the descent to get stuck and return a higher (non-lowest) ancestor.

**Minimal example:**

```python
import networkx as nx

G = nx.DiGraph([(0, 1), (0, 2), (1, 3), (2, 4), (3, 5), (4, 5), (5, 6), (5, 7)])

# Common ancestors of 6 and 7 are {0, 5}
# The true LCA is 5, but:
print(dict(nx.all_pairs_lowest_common_ancestor(G, pairs=[(6, 7)])))
# May return {(6, 7): 0} instead of {(6, 7): 5}
```

Node 0 is a common ancestor of 6 and 7. The greedy descent tries successors of 0 (nodes 1, 2), but neither is a common ancestor of *both* 6 and 7 — node 1 reaches only 6 via 3→5→6, and node 2 reaches only 7 via 4→5→7. The descent stops at 0 and incorrectly returns it as the LCA.

## Fix

Instead of greedy descent, build a subgraph of all common ancestors and find a sink node (out-degree 0 within that subgraph). A sink in the common-ancestor subgraph is by definition a lowest common ancestor — it has no common-ancestor descendants, which is exactly the LCA criterion.

This approach is correct for any DAG topology since it doesn't depend on the local greedy property holding at every step.
