### PR TITLE
Making edge view behavior consistent across different graph types

### DIFF
--- a/networkx/algorithms/tests/test_planarity.py
+++ b/networkx/algorithms/tests/test_planarity.py
@@ -350,7 +350,7 @@ def check_embedding(G, embedding):
         if edge[0] != edge[1]:
             g_edges.add((edge[0], edge[1]))
             g_edges.add((edge[1], edge[0]))
-    assert g_edges == set(embedding.edges), (
+    assert g_edges == {edge for u, v in embedding.edges for edge in [(u, v), (v, u)]}, (
         "Bad embedding. Edges don't match the original graph."
     )
 

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -1208,7 +1208,7 @@ class OutEdgeView(Set, Mapping, EdgeViewABC):
             case (u, v):
                 return (u, v)
             case _:
-                raise ValueError("Edge must have length 2 or 3")
+                raise ValueError("Edge must have length 2")
 
     # EdgeDataView methods
     def __call__(self, nbunch=None, data=False, *, default=None):

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -657,9 +657,9 @@ class OutDegreeView(DiDegreeView):
     def __getitem__(self, n):
         weight = self._weight
         nbrs = self._succ[n]
-        if self._weight is None:
+        if weight is None:
             return len(nbrs)
-        return sum(dd.get(self._weight, 1) for dd in nbrs.values())
+        return sum(dd.get(weight, 1) for dd in nbrs.values())
 
     def __iter__(self):
         weight = self._weight
@@ -1165,6 +1165,7 @@ class OutEdgeView(Set, Mapping, EdgeViewABC):
         return set(it)
 
     dataview = OutEdgeDataView
+    method_name = "edges"
 
     def __init__(self, G):
         self._graph = G
@@ -1182,9 +1183,9 @@ class OutEdgeView(Set, Mapping, EdgeViewABC):
 
     def __contains__(self, e):
         try:
-            u, v = e
-            return v in self._adjdict[u]
-        except KeyError:
+            self[e]
+            return True
+        except (KeyError, ValueError):
             return False
 
     # Mapping Methods
@@ -1192,13 +1193,22 @@ class OutEdgeView(Set, Mapping, EdgeViewABC):
         if isinstance(e, slice):
             raise nx.NetworkXError(
                 f"{type(self).__name__} does not support slicing, "
-                f"try list(G.edges)[{e.start}:{e.stop}:{e.step}]"
+                f"try list(G.{self.method_name})[{e.start}:{e.stop}:{e.step}]"
             )
-        u, v = e
-        try:
-            return self._adjdict[u][v]
-        except KeyError as ex:  # Customize msg to indicate exception origin
-            raise KeyError(f"The edge {e} is not in the graph.")
+        ret = self._adjdict
+        for elem in self._edge_as_tuple(e):
+            try:
+                ret = ret[elem]
+            except KeyError:
+                raise KeyError(f"The edge {e} is not in the graph.")
+        return ret
+
+    def _edge_as_tuple(self, e):
+        match e:
+            case (u, v):
+                return (u, v)
+            case _:
+                raise ValueError("Edge must have length 2 or 3")
 
     # EdgeDataView methods
     def __call__(self, nbunch=None, data=False, *, default=None):
@@ -1382,13 +1392,6 @@ class EdgeView(OutEdgeView):
             seen[n] = 1
         del seen
 
-    def __contains__(self, e):
-        try:
-            u, v = e[:2]
-            return v in self._adjdict[u] or u in self._adjdict[v]
-        except (KeyError, ValueError):
-            return False
-
 
 class InEdgeView(OutEdgeView):
     """A EdgeView class for inward edges of a DiGraph"""
@@ -1401,6 +1404,7 @@ class InEdgeView(OutEdgeView):
         self._nodes_nbrs = self._adjdict.items
 
     dataview = InEdgeDataView
+    method_name = "in_edges"
 
     def __init__(self, G):
         self._graph = G
@@ -1412,21 +1416,9 @@ class InEdgeView(OutEdgeView):
             for nbr in nbrs:
                 yield (nbr, n)
 
-    def __contains__(self, e):
-        try:
-            u, v = e
-            return u in self._adjdict[v]
-        except KeyError:
-            return False
-
-    def __getitem__(self, e):
-        if isinstance(e, slice):
-            raise nx.NetworkXError(
-                f"{type(self).__name__} does not support slicing, "
-                f"try list(G.in_edges)[{e.start}:{e.stop}:{e.step}]"
-            )
-        u, v = e
-        return self._adjdict[v][u]
+    def _edge_as_tuple(self, e):
+        u, v = super()._edge_as_tuple(e)
+        return v, u
 
 
 class OutMultiEdgeView(OutEdgeView):
@@ -1447,33 +1439,19 @@ class OutMultiEdgeView(OutEdgeView):
                 for key in kdict:
                     yield (n, nbr, key)
 
-    def __contains__(self, e):
-        N = len(e)
-        if N == 3:
-            u, v, k = e
-        elif N == 2:
-            u, v = e
-            k = 0
-        else:
-            raise ValueError("MultiEdge must have length 2 or 3")
-        try:
-            return k in self._adjdict[u][v]
-        except KeyError:
-            return False
-
-    def __getitem__(self, e):
-        if isinstance(e, slice):
-            raise nx.NetworkXError(
-                f"{type(self).__name__} does not support slicing, "
-                f"try list(G.edges)[{e.start}:{e.stop}:{e.step}]"
-            )
-        u, v, k = e
-        return self._adjdict[u][v][k]
-
     def __call__(self, nbunch=None, data=False, *, default=None, keys=False):
         if nbunch is None and data is False and keys is True:
             return self
         return self.dataview(self, nbunch, data, default=default, keys=keys)
+
+    def _edge_as_tuple(self, e):
+        match e:
+            case (u, v):
+                return u, v, 0
+            case (u, v, k):
+                return u, v, k
+            case _:
+                raise ValueError("MultiEdge must have length 2 or 3")
 
     def data(self, data=True, default=None, nbunch=None, keys=False):
         if nbunch is None and data is False and keys is True:
@@ -1513,6 +1491,7 @@ class InMultiEdgeView(OutMultiEdgeView):
         self._nodes_nbrs = self._adjdict.items
 
     dataview = InMultiEdgeDataView
+    method_name = "in_edges"
 
     def __init__(self, G):
         self._graph = G
@@ -1525,25 +1504,6 @@ class InMultiEdgeView(OutMultiEdgeView):
                 for key in kdict:
                     yield (nbr, n, key)
 
-    def __contains__(self, e):
-        N = len(e)
-        if N == 3:
-            u, v, k = e
-        elif N == 2:
-            u, v = e
-            k = 0
-        else:
-            raise ValueError("MultiEdge must have length 2 or 3")
-        try:
-            return k in self._adjdict[v][u]
-        except KeyError:
-            return False
-
-    def __getitem__(self, e):
-        if isinstance(e, slice):
-            raise nx.NetworkXError(
-                f"{type(self).__name__} does not support slicing, "
-                f"try list(G.in_edges)[{e.start}:{e.stop}:{e.step}]"
-            )
-        u, v, k = e
-        return self._adjdict[v][u][k]
+    def _edge_as_tuple(self, e):
+        u, v, k = super()._edge_as_tuple(e)
+        return (v, u, k)

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -1164,11 +1164,11 @@ class OutEdgeView(Set, Mapping, EdgeViewABC):
     def _from_iterable(cls, it):
         return set(it)
 
-    in_edges = False
+    out_edges = True
 
     def __init__(self, G):
         self._graph = G
-        G_attr = "pred" if self.in_edges else "succ"
+        G_attr = "succ" if self.out_edges else "pred"
         self._adjdict = getattr(G, G_attr, G._adj)
         self._nodes_nbrs = self._adjdict.items
 
@@ -1206,7 +1206,7 @@ class OutEdgeView(Set, Mapping, EdgeViewABC):
     def __iter__(self):
         directed = self._graph.is_directed()
         multigraph = self._graph.is_multigraph()
-        in_edges = self.in_edges
+        out_edges = self.out_edges
         seen = set()
         for n, nbrs in self._nodes_nbrs():
             if not directed and n in seen:
@@ -1216,12 +1216,12 @@ class OutEdgeView(Set, Mapping, EdgeViewABC):
                     if nbr in seen:
                         continue
                     for key in kdict:
-                        yield (nbr, n, key) if in_edges else (n, nbr, key)
+                        yield (n, nbr, key) if out_edges else (nbr, n, key)
             else:
                 for nbr in list(nbrs):
                     if nbr in seen:
                         continue
-                    yield (nbr, n) if in_edges else (n, nbr)
+                    yield (n, nbr) if out_edges else (nbr, n)
             if not directed:
                 seen.add(n)
 
@@ -1237,14 +1237,14 @@ class OutEdgeView(Set, Mapping, EdgeViewABC):
         if isinstance(e, slice):
             raise nx.NetworkXError(
                 f"{type(self).__name__} does not support slicing, "
-                f"try list(G.{'in_edges' if self.in_edges else 'edges'})[{e.start}:{e.stop}:{e.step}]"
+                f"try list(G.{'edges' if self.out_edges else 'in_edges'})[{e.start}:{e.stop}:{e.step}]"
             )
         if not isinstance(e, tuple):
             raise ValueError("The edge must be a tuple.")
         multigraph = self._graph.is_multigraph()
         if len(e) != 2 and not (multigraph and len(e) == 3):
             raise ValueError(f"The edge {e} has an invalid length {len(e)}.")
-        u, v = (e[1], e[0]) if self.in_edges else (e[0], e[1])
+        u, v = (e[0], e[1]) if self.out_edges else (e[1], e[0])
         try:
             if multigraph:
                 k = 0 if len(e) == 2 else e[2]
@@ -1369,12 +1369,12 @@ class OutEdgeView(Set, Mapping, EdgeViewABC):
     def _dataview(self, multigraph, directed):
         if multigraph:
             if directed:
-                return InMultiEdgeDataView if self.in_edges else OutMultiEdgeDataView
+                return OutMultiEdgeDataView if self.out_edges else InMultiEdgeDataView
             else:
                 return MultiEdgeDataView
         else:
             if directed:
-                return InEdgeDataView if self.in_edges else OutEdgeDataView
+                return OutEdgeDataView if self.out_edges else InEdgeDataView
             else:
                 return EdgeDataView
 
@@ -1465,7 +1465,7 @@ class InEdgeView(OutEdgeView):
 
     __slots__ = ()
 
-    in_edges = True
+    out_edges = False
 
 
 class OutMultiEdgeView(OutEdgeView):
@@ -1485,4 +1485,4 @@ class InMultiEdgeView(OutMultiEdgeView):
 
     __slots__ = ()
 
-    in_edges = True
+    out_edges = False

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -1164,22 +1164,66 @@ class OutEdgeView(Set, Mapping, EdgeViewABC):
     def _from_iterable(cls, it):
         return set(it)
 
-    dataview = OutEdgeDataView
-    method_name = "edges"
+    in_edges = False
 
     def __init__(self, G):
         self._graph = G
-        self._adjdict = G._succ if hasattr(G, "succ") else G._adj
+        G_attr = "pred" if self.in_edges else "succ"
+        self._adjdict = getattr(G, G_attr, G._adj)
         self._nodes_nbrs = self._adjdict.items
 
     # Set methods
     def __len__(self):
-        return sum(len(nbrs) for n, nbrs in self._nodes_nbrs())
+        directed = self._graph.is_directed()
+        multigraph = self._graph.is_multigraph()
+
+        if directed:
+            if multigraph:
+                return sum(
+                    len(kdict)
+                    for _, nbrs in self._nodes_nbrs()
+                    for kdict in nbrs.values()
+                )
+            else:
+                return sum(len(nbrs) for _, nbrs in self._nodes_nbrs())
+        else:
+            seen = set()
+            count = 0
+            for n, nbrs in self._nodes_nbrs():
+                if multigraph:
+                    for nbr, kdict in nbrs.items():
+                        if nbr in seen:
+                            continue
+                        count += len(kdict)
+                else:
+                    for nbr in nbrs:
+                        if nbr in seen:
+                            continue
+                        count += 1
+                seen.add(n)
+            return count
 
     def __iter__(self):
+        directed = self._graph.is_directed()
+        multigraph = self._graph.is_multigraph()
+        in_edges = self.in_edges
+        seen = set()
         for n, nbrs in self._nodes_nbrs():
-            for nbr in nbrs:
-                yield (n, nbr)
+            if not directed and n in seen:
+                continue
+            if multigraph:
+                for nbr, kdict in list(nbrs.items()):
+                    if nbr in seen:
+                        continue
+                    for key in kdict:
+                        yield (nbr, n, key) if in_edges else (n, nbr, key)
+            else:
+                for nbr in list(nbrs):
+                    if nbr in seen:
+                        continue
+                    yield (nbr, n) if in_edges else (n, nbr)
+            if not directed:
+                seen.add(n)
 
     def __contains__(self, e):
         try:
@@ -1193,30 +1237,39 @@ class OutEdgeView(Set, Mapping, EdgeViewABC):
         if isinstance(e, slice):
             raise nx.NetworkXError(
                 f"{type(self).__name__} does not support slicing, "
-                f"try list(G.{self.method_name})[{e.start}:{e.stop}:{e.step}]"
+                f"try list(G.{'in_edges' if self.in_edges else 'edges'})[{e.start}:{e.stop}:{e.step}]"
             )
-        ret = self._adjdict
-        for elem in self._edge_as_tuple(e):
-            try:
-                ret = ret[elem]
-            except KeyError:
-                raise KeyError(f"The edge {e} is not in the graph.")
-        return ret
-
-    def _edge_as_tuple(self, e):
-        match e:
-            case (u, v):
-                return (u, v)
-            case _:
-                raise ValueError("Edge must have length 2")
+        if not isinstance(e, tuple):
+            raise ValueError("The edge must be a tuple.")
+        multigraph = self._graph.is_multigraph()
+        if len(e) != 2 and not (multigraph and len(e) == 3):
+            raise ValueError(f"The edge {e} has an invalid length {len(e)}.")
+        u, v = (e[1], e[0]) if self.in_edges else (e[0], e[1])
+        try:
+            if multigraph:
+                k = 0 if len(e) == 2 else e[2]
+                return self._adjdict[u][v][k]
+            else:
+                return self._adjdict[u][v]
+        except KeyError:
+            raise KeyError(f"The edge {e} is not in the graph.")
 
     # EdgeDataView methods
-    def __call__(self, nbunch=None, data=False, *, default=None):
-        if nbunch is None and data is False:
-            return self
-        return self.dataview(self, nbunch, data, default=default)
+    def __call__(self, nbunch=None, data=False, *, default=None, keys=False):
+        multigraph = self._graph.is_multigraph()
 
-    def data(self, data=True, default=None, nbunch=None):
+        if not multigraph and keys:
+            raise TypeError("keys is not supported for simple graphs")
+
+        if nbunch is None and data is False and (not multigraph or keys):
+            return self
+        dataview = self._dataview(multigraph, self._graph.is_directed())
+        if multigraph:
+            return dataview(self, nbunch, data, default=default, keys=keys)
+        else:
+            return dataview(self, nbunch, data, default=default)
+
+    def data(self, data=True, default=None, nbunch=None, keys=False):
         """
         Return a read-only view of edge data.
 
@@ -1233,6 +1286,10 @@ class OutEdgeView(Set, Mapping, EdgeViewABC):
         nbunch : container of nodes, optional (default=None)
             Allows restriction to edges only involving certain nodes. All edges
             are considered by default.
+        keys : bool, optional (default=False)
+            Only relevant for MultiGraphs/MultiDiGraphs.
+            If True, the view includes the edge keys as part of each edge tuple.
+            Not allowed for simple graphs (raises TypeError if set).
 
         Returns
         -------
@@ -1292,9 +1349,34 @@ class OutEdgeView(Set, Mapping, EdgeViewABC):
         >>> G.edges.data("speed")
         EdgeDataView([(0, 1, None), (0, 2, None), (1, 2, None)])
         """
-        if nbunch is None and data is False:
+        multigraph = self._graph.is_multigraph()
+
+        # Reject keys if not a multigraph
+        if not multigraph and keys:
+            raise TypeError("keys is not supported for simple graphs")
+
+        # Return self in the same cases as the old method
+        if nbunch is None and data is False and (not multigraph or keys):
             return self
-        return self.dataview(self, nbunch, data, default=default)
+
+        # Call dataview with appropriate arguments
+        dataview = self._dataview(multigraph, self._graph.is_directed())
+        if multigraph:
+            return dataview(self, nbunch, data, default=default, keys=keys)
+        else:
+            return dataview(self, nbunch, data, default=default)
+
+    def _dataview(self, multigraph, directed):
+        if multigraph:
+            if directed:
+                return InMultiEdgeDataView if self.in_edges else OutMultiEdgeDataView
+            else:
+                return MultiEdgeDataView
+        else:
+            if directed:
+                return InEdgeDataView if self.in_edges else OutEdgeDataView
+            else:
+                return EdgeDataView
 
     # String Methods
     def __str__(self):
@@ -1377,48 +1459,13 @@ class EdgeView(OutEdgeView):
 
     __slots__ = ()
 
-    dataview = EdgeDataView
-
-    def __len__(self):
-        num_nbrs = (len(nbrs) + (n in nbrs) for n, nbrs in self._nodes_nbrs())
-        return sum(num_nbrs) // 2
-
-    def __iter__(self):
-        seen = {}
-        for n, nbrs in self._nodes_nbrs():
-            for nbr in list(nbrs):
-                if nbr not in seen:
-                    yield (n, nbr)
-            seen[n] = 1
-        del seen
-
 
 class InEdgeView(OutEdgeView):
     """A EdgeView class for inward edges of a DiGraph"""
 
     __slots__ = ()
 
-    def __setstate__(self, state):
-        self._graph = state["_graph"]
-        self._adjdict = state["_adjdict"]
-        self._nodes_nbrs = self._adjdict.items
-
-    dataview = InEdgeDataView
-    method_name = "in_edges"
-
-    def __init__(self, G):
-        self._graph = G
-        self._adjdict = G._pred if hasattr(G, "pred") else G._adj
-        self._nodes_nbrs = self._adjdict.items
-
-    def __iter__(self):
-        for n, nbrs in self._nodes_nbrs():
-            for nbr in nbrs:
-                yield (nbr, n)
-
-    def _edge_as_tuple(self, e):
-        u, v = super()._edge_as_tuple(e)
-        return v, u
+    in_edges = True
 
 
 class OutMultiEdgeView(OutEdgeView):
@@ -1426,58 +1473,11 @@ class OutMultiEdgeView(OutEdgeView):
 
     __slots__ = ()
 
-    dataview = OutMultiEdgeDataView
-
-    def __len__(self):
-        return sum(
-            len(kdict) for n, nbrs in self._nodes_nbrs() for nbr, kdict in nbrs.items()
-        )
-
-    def __iter__(self):
-        for n, nbrs in self._nodes_nbrs():
-            for nbr, kdict in nbrs.items():
-                for key in kdict:
-                    yield (n, nbr, key)
-
-    def __call__(self, nbunch=None, data=False, *, default=None, keys=False):
-        if nbunch is None and data is False and keys is True:
-            return self
-        return self.dataview(self, nbunch, data, default=default, keys=keys)
-
-    def _edge_as_tuple(self, e):
-        match e:
-            case (u, v):
-                return u, v, 0
-            case (u, v, k):
-                return u, v, k
-            case _:
-                raise ValueError("MultiEdge must have length 2 or 3")
-
-    def data(self, data=True, default=None, nbunch=None, keys=False):
-        if nbunch is None and data is False and keys is True:
-            return self
-        return self.dataview(self, nbunch, data, default=default, keys=keys)
-
 
 class MultiEdgeView(OutMultiEdgeView):
     """A EdgeView class for edges of a MultiGraph"""
 
     __slots__ = ()
-
-    dataview = MultiEdgeDataView
-
-    def __len__(self):
-        return sum(1 for e in self)
-
-    def __iter__(self):
-        seen = {}
-        for n, nbrs in self._nodes_nbrs():
-            for nbr, kd in nbrs.items():
-                if nbr not in seen:
-                    for k, dd in kd.items():
-                        yield (n, nbr, k)
-            seen[n] = 1
-        del seen
 
 
 class InMultiEdgeView(OutMultiEdgeView):
@@ -1485,25 +1485,4 @@ class InMultiEdgeView(OutMultiEdgeView):
 
     __slots__ = ()
 
-    def __setstate__(self, state):
-        self._graph = state["_graph"]
-        self._adjdict = state["_adjdict"]
-        self._nodes_nbrs = self._adjdict.items
-
-    dataview = InMultiEdgeDataView
-    method_name = "in_edges"
-
-    def __init__(self, G):
-        self._graph = G
-        self._adjdict = G._pred if hasattr(G, "pred") else G._adj
-        self._nodes_nbrs = self._adjdict.items
-
-    def __iter__(self):
-        for n, nbrs in self._nodes_nbrs():
-            for nbr, kdict in nbrs.items():
-                for key in kdict:
-                    yield (nbr, n, key)
-
-    def _edge_as_tuple(self, e):
-        u, v, k = super()._edge_as_tuple(e)
-        return (v, u, k)
+    in_edges = True

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -1168,8 +1168,9 @@ class OutEdgeView(Set, Mapping, EdgeViewABC):
 
     def __init__(self, G):
         self._graph = G
-        G_attr = "succ" if self.out_edges else "pred"
-        self._adjdict = getattr(G, G_attr, G._adj)
+        self._adjdict = (
+            (G.succ if self.out_edges else G.pred) if G.is_directed() else G._adj
+        )
         self._nodes_nbrs = self._adjdict.items
 
     # Set methods

--- a/networkx/classes/tests/test_reportviews.py
+++ b/networkx/classes/tests/test_reportviews.py
@@ -781,6 +781,7 @@ class TestMultiEdgeView(TestEdgeView):
         G = self.G.copy()
         ev = G.edges
         G.edges[0, 1, 0]["foo"] = "bar"
+        G.edges[0, 1]["foo"] = "bar"
         assert ev[0, 1, 0] == {"foo": "bar"}
 
         # slicing

--- a/networkx/classes/tests/test_reportviews.py
+++ b/networkx/classes/tests/test_reportviews.py
@@ -780,9 +780,12 @@ class TestMultiEdgeView(TestEdgeView):
     def test_getitem(self):
         G = self.G.copy()
         ev = G.edges
-        G.edges[0, 1, 0]["foo"] = "bar"
         G.edges[0, 1]["foo"] = "bar"
+        assert ev[0, 1] == {"foo": "bar"}
         assert ev[0, 1, 0] == {"foo": "bar"}
+        G.edges[0, 1, 0]["foo"] = "bar_0"
+        assert ev[0, 1] == {"foo": "bar_0"}
+        assert ev[0, 1, 0] == {"foo": "bar_0"}
 
         # slicing
         with pytest.raises(nx.NetworkXError):


### PR DESCRIPTION
This PR makes `.edges` views consistent when using `__contains__` and `__getitem__` and also makes exceptions clearer when an edge is not found.

### contains vs getitem consistency

In multigraphs, contains accepts two elements but getitem doesnt:
```python
>>> (0,1) in G.edges # nx.MultiDiGraph()
True

>>> G.edges[0,1] # nx.MultiDiGraph()
Traceback (most recent call last):
  File ~/amcandio/networkx/classes/reportviews.py:1470 in __getitem__
    u, v, k = e
ValueError: not enough values to unpack (expected 3, got 2)
```

### Error messaging: KeyError

When accessing a missing edge
```python
>>> G = nx.MultiDiGraph([(0, 1)])
>>> G.edges[1,0,0]
Traceback (most recent call last):
  File ~/amcandio/networkx/classes/reportviews.py:1471 in __getitem__
    return self._adjdict[u][v][k]
KeyError: 0
```

which can be confusing as it reads as the node is missing. It is also inconsistent with `nx.Graph` behavior:
```python
>>> G=nx.Graph(nodes=[0, 1])
>>> G.edges[0,1]
Traceback (most recent call last):
  File ~/amcandio/networkx/classes/reportviews.py:1201 in __getitem__
    raise KeyError(f"The edge {e} is not in the graph.")
KeyError: 'The edge (0, 1) is not in the graph.'
```

### Error messaging: tuple length mismatch

When passing the wrong amount of elements, sometimes we get a clear error, sometimes we don't. Simple graphs just return False when passing the wrong amount of elements while Multigraphs raise:

```python
>>> (0,) in G.edges # nx.Graph()
False
```

```python
>>> (1,1,1,1,1) in G.edges # nx.MultiDiGraph()
Traceback (most recent call last):
  File ~/amcandio/networkx/classes/reportviews.py:1458 in __contains__
    raise ValueError("MultiEdge must have length 2 or 3")
ValueError: MultiEdge must have length 2 or 3
```

```python
>>> G.edges[0,] # nx.MultiDiGraph()
Traceback (most recent call last):
  File ~/amcandio/networkx/classes/reportviews.py:1470 in __getitem__
    u, v, k = e
ValueError: not enough values to unpack (expected 3, got 1)
```

## After this PR

We have:
- Clear and consistent KeyError when edge is missing
- Consistent contains and getitem behavior for all edge views
- Consistent ValueError behavior for all edge views when passing the wrong amount of edges

```python

>>> import networkx as nx
>>> G=nx.MultiDiGraph([(0,1)])
>>> (0, 1) in G.edges
True
>>> G.edges[0,1]
{}
>>>  G.edges[1,0]
Traceback (most recent call last):
  File ~/amcandio/networkx/classes/reportviews.py:1203 in __getitem__
    raise KeyError(f"The edge {e} is not in the graph.")
KeyError: 'The edge (1, 0) is not in the graph.'

>>> (1,1,1,1,1) in G.edges
False
```

We achieve this naturally in the code by removing duplicated `__contains__` and `__getitem__` definitions. Each subclass only needs to define how to parse edges into the tuple used to access internal adjacency dictionary.
