### PR TITLE
fix: replace 18 bare except clauses with except Exception

### DIFF
--- a/examples/geospatial/plot_delaunay.py
+++ b/examples/geospatial/plot_delaunay.py
@@ -60,7 +60,7 @@ positions = dict(zip(delaunay_graph.nodes, coordinates))
 ax = cells.plot(facecolor="lightblue", alpha=0.50, edgecolor="cornsilk", linewidth=2)
 try:  # Try-except for issues with timeout/parsing failures in CI
     add_basemap(ax)
-except:
+except Exception:
     pass
 
 ax.axis("off")

--- a/examples/geospatial/plot_lines.py
+++ b/examples/geospatial/plot_lines.py
@@ -77,7 +77,7 @@ for i, facet in enumerate(ax):
     facet.axis("off")
     try:  # For issues with downloading/parsing in CI
         add_basemap(facet)
-    except:
+    except Exception:
         pass
 nx.draw(
     G_primal, {n: [n[0], n[1]] for n in list(G_primal.nodes)}, ax=ax[1], node_size=50
@@ -96,7 +96,7 @@ for i, facet in enumerate(ax):
     facet.axis("off")
     try:  # For issues with downloading/parsing in CI
         add_basemap(facet)
-    except:
+    except Exception:
         pass
 nx.draw(G_dual, {n: [n[0], n[1]] for n in list(G_dual.nodes)}, ax=ax[1], node_size=50)
 plt.show()

--- a/examples/geospatial/plot_points.py
+++ b/examples/geospatial/plot_points.py
@@ -53,7 +53,7 @@ for i, facet in enumerate(ax):
     cases.plot(marker=".", color="orangered", ax=facet)
     try:  # For issues with downloading/parsing basemaps in CI
         add_basemap(facet)
-    except:
+    except Exception:
         pass
     facet.set_title(("KNN-3", "50-meter Distance Band")[i])
     facet.axis("off")

--- a/networkx/algorithms/structuralholes.py
+++ b/networkx/algorithms/structuralholes.py
@@ -155,7 +155,7 @@ def effective_size(G, nodes=None, weight=None):
         import scipy as sp
 
         has_scipy = True
-    except:
+    except Exception:
         has_scipy = False
 
     if nodes is None and has_scipy:
@@ -271,7 +271,7 @@ def constraint(G, nodes=None, weight=None):
         import scipy as sp
 
         has_scipy = True
-    except:
+    except Exception:
         has_scipy = False
 
     if nodes is None and has_scipy:

--- a/networkx/algorithms/time_dependent.py
+++ b/networkx/algorithms/time_dependent.py
@@ -118,7 +118,7 @@ def cd_index(G, node, time_delta, *, time="time", weight=None):
         target_date = G.nodes[node][time] + time_delta
         # keep the predecessors that existed before the target date
         pred = {i for i in G.pred[node] if G.nodes[i][time] <= target_date}
-    except:
+    except Exception:
         raise nx.NetworkXError(
             "Addition and comparison are not supported between 'time_delta' "
             "and 'time' types."

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -110,7 +110,7 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
     if isinstance(data, list | tuple | nx.reportviews.EdgeViewABC | Iterator):
         try:
             return from_edgelist(data, create_using=create_using)
-        except:
+        except Exception:
             pass
 
     # pygraphviz  agraph

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -319,7 +319,7 @@ def pygraphviz_layout(G, prog="neato", root=None, args=""):
         try:
             xs = node.attr["pos"].split(",")
             node_pos[n] = tuple(float(x) for x in xs)
-        except:
+        except Exception:
             print("no position for node", n)
             node_pos[n] = (0.0, 0.0)
     return node_pos

--- a/networkx/lazy_imports.py
+++ b/networkx/lazy_imports.py
@@ -159,7 +159,7 @@ def _lazy_import(fullname):
     """
     try:
         return sys.modules[fullname]
-    except:
+    except Exception:
         pass
 
     # Not previously loaded -- look it up

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -408,7 +408,7 @@ class GraphML:
         # These additions to types allow writing numpy types
         try:
             import numpy as np
-        except:
+        except Exception:
             pass
         else:
             # prepend so that python types are created upon read (last entry wins)

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -293,7 +293,7 @@ def parse_multiline_adjlist(
             else:
                 try:  # try to evaluate
                     edgedata = literal_eval(data)
-                except:
+                except Exception:
                     edgedata = {}
             G.add_edge(u, v, **edgedata)
 

--- a/networkx/readwrite/pajek.py
+++ b/networkx/readwrite/pajek.py
@@ -223,7 +223,7 @@ def parse_pajek(lines):
                     G.nodes[label].update(
                         {"x": float(x), "y": float(y), "shape": shape}
                     )
-                except:
+                except Exception:
                     pass
                 extra_attr = zip(splitline[5::2], splitline[6::2])
                 G.nodes[label].update(extra_attr)
@@ -253,7 +253,7 @@ def parse_pajek(lines):
                     # there should always be a single value on the edge?
                     w = splitline[2:3]
                     edge_data.update({"weight": float(w[0])})
-                except:
+                except Exception:
                     pass
                     # if there isn't, just assign a 1
                 #                    edge_data.update({'value':1})


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance.