### PR TITLE
ENH: Add format parameter to sparse matrix functions (closes #7980)

### DIFF
--- a/networkx/algorithms/tournament.py
+++ b/networkx/algorithms/tournament.py
@@ -219,7 +219,7 @@ def score_sequence(G):
 @not_implemented_for("undirected")
 @not_implemented_for("multigraph")
 @nx._dispatchable(preserve_edge_attrs={"G": {"weight": 1}})
-def tournament_matrix(G):
+def tournament_matrix(G, format="csr"):
     r"""Returns the tournament matrix for the given tournament graph.
 
     This function requires SciPy.
@@ -244,10 +244,15 @@ def tournament_matrix(G):
     G : NetworkX graph
         A directed graph representing a tournament.
 
+    format : str in {'bsr', 'csr', 'csc', 'coo', 'lil', 'dia', 'dok', 'dense'}
+        The format of the result (default 'csr'). For 'dense', a NumPy array
+        is returned. See `scipy.sparse` documentation for other formats.
+
     Returns
     -------
-    SciPy sparse array
-        The tournament matrix of the tournament graph `G`.
+    SciPy sparse array or NumPy ndarray
+        The tournament matrix of the tournament graph `G`. Returns a NumPy
+        array if ``format='dense'``.
 
     Raises
     ------
@@ -255,8 +260,8 @@ def tournament_matrix(G):
         If SciPy is not available.
 
     """
-    A = nx.adjacency_matrix(G)
-    return A - A.T
+    A = nx.adjacency_matrix(G, format="csr")
+    return (A - A.T).asformat(format)
 
 
 @not_implemented_for("undirected")

--- a/networkx/linalg/bethehessianmatrix.py
+++ b/networkx/linalg/bethehessianmatrix.py
@@ -9,7 +9,7 @@ __all__ = ["bethe_hessian_matrix"]
 @not_implemented_for("directed")
 @not_implemented_for("multigraph")
 @nx._dispatchable
-def bethe_hessian_matrix(G, r=None, nodelist=None):
+def bethe_hessian_matrix(G, r=None, nodelist=None, format="csr"):
     r"""Returns the Bethe Hessian matrix of G.
 
     The Bethe Hessian is a family of matrices parametrized by r, defined as
@@ -32,10 +32,15 @@ def bethe_hessian_matrix(G, r=None, nodelist=None):
        The rows and columns are ordered according to the nodes in nodelist.
        If nodelist is None, then the ordering is produced by ``G.nodes()``.
 
+    format : str in {'bsr', 'csr', 'csc', 'coo', 'lil', 'dia', 'dok', 'dense'}
+        The format of the result (default 'csr'). For 'dense', a NumPy array
+        is returned. See `scipy.sparse` documentation for other formats.
+
     Returns
     -------
-    H : scipy.sparse.csr_array
-      The Bethe Hessian matrix of `G`, with parameter `r`.
+    H : scipy.sparse.csr_array or NumPy ndarray
+      The Bethe Hessian matrix of `G`, with parameter `r`. Returns a NumPy
+      array if ``format='dense'``.
 
     Examples
     --------
@@ -74,4 +79,4 @@ def bethe_hessian_matrix(G, r=None, nodelist=None):
     n, m = A.shape
     D = sp.sparse.dia_array((A.sum(axis=1), 0), shape=(m, n)).tocsr()
     I = sp.sparse.eye_array(m, n, format="csr")
-    return (r**2 - 1) * I - r * A + D
+    return ((r**2 - 1) * I - r * A + D).asformat(format)

--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -9,7 +9,14 @@ __all__ = ["incidence_matrix", "adjacency_matrix"]
 
 @nx._dispatchable(edge_attrs="weight")
 def incidence_matrix(
-    G, nodelist=None, edgelist=None, oriented=False, weight=None, *, dtype=None
+    G,
+    nodelist=None,
+    edgelist=None,
+    oriented=False,
+    weight=None,
+    *,
+    dtype=None,
+    format="csc",
 ):
     """Returns incidence matrix of G.
 
@@ -48,10 +55,14 @@ def incidence_matrix(
         argument should also be a float.
         If None, then the default for SciPy is used.
 
+    format : str in {'bsr', 'csr', 'csc', 'coo', 'lil', 'dia', 'dok', 'dense'}
+        The format of the result (default 'csc'). For 'dense', a NumPy array
+        is returned. See `scipy.sparse` documentation for other formats.
+
     Returns
     -------
-    A : SciPy sparse array
-      The incidence matrix of G.
+    A : SciPy sparse array or NumPy ndarray
+      The incidence matrix of G. Returns a NumPy array if ``format='dense'``.
 
     Notes
     -----
@@ -102,11 +113,11 @@ def incidence_matrix(
         else:
             A[ui, ei] = wt
             A[vi, ei] = wt
-    return A.asformat("csc")
+    return A.asformat(format)
 
 
 @nx._dispatchable(edge_attrs="weight")
-def adjacency_matrix(G, nodelist=None, dtype=None, weight="weight"):
+def adjacency_matrix(G, nodelist=None, dtype=None, weight="weight", format="csr"):
     """Returns adjacency matrix of `G`.
 
     Parameters
@@ -127,10 +138,15 @@ def adjacency_matrix(G, nodelist=None, dtype=None, weight="weight"):
        The edge data key used to provide each value in the matrix.
        If None, then each edge has weight 1.
 
+    format : str in {'bsr', 'csr', 'csc', 'coo', 'lil', 'dia', 'dok', 'dense'}
+        The format of the result (default 'csr'). For 'dense', a NumPy array
+        is returned. See `scipy.sparse` documentation for other formats.
+
     Returns
     -------
-    A : SciPy sparse array
-      Adjacency matrix representation of G.
+    A : SciPy sparse array or NumPy ndarray
+      Adjacency matrix representation of G. Returns a NumPy array if
+      ``format='dense'``.
 
     Notes
     -----
@@ -165,4 +181,6 @@ def adjacency_matrix(G, nodelist=None, dtype=None, weight="weight"):
     to_dict_of_dicts
     adjacency_spectrum
     """
-    return nx.to_scipy_sparse_array(G, nodelist=nodelist, dtype=dtype, weight=weight)
+    return nx.to_scipy_sparse_array(
+        G, nodelist=nodelist, dtype=dtype, weight=weight, format=format
+    )

--- a/networkx/linalg/laplacianmatrix.py
+++ b/networkx/linalg/laplacianmatrix.py
@@ -20,7 +20,7 @@ __all__ = [
 
 
 @nx._dispatchable(edge_attrs="weight")
-def laplacian_matrix(G, nodelist=None, weight="weight"):
+def laplacian_matrix(G, nodelist=None, weight="weight", format="csr"):
     """Returns the Laplacian matrix of G.
 
     The graph Laplacian is the matrix L = D - A, where
@@ -39,10 +39,14 @@ def laplacian_matrix(G, nodelist=None, weight="weight"):
        The edge data key used to compute each value in the matrix.
        If None, then each edge has weight 1.
 
+    format : str in {'bsr', 'csr', 'csc', 'coo', 'lil', 'dia', 'dok', 'dense'}
+        The format of the result (default 'csr'). For 'dense', a NumPy array
+        is returned. See `scipy.sparse` documentation for other formats.
+
     Returns
     -------
-    L : SciPy sparse array
-      The Laplacian matrix of G.
+    L : SciPy sparse array or NumPy ndarray
+      The Laplacian matrix of G. Returns a NumPy array if ``format='dense'``.
 
     Notes
     -----
@@ -126,11 +130,11 @@ def laplacian_matrix(G, nodelist=None, weight="weight"):
     A = nx.to_scipy_sparse_array(G, nodelist=nodelist, weight=weight, format="csr")
     n, m = A.shape
     D = sp.sparse.dia_array((A.sum(axis=1), 0), shape=(m, n)).tocsr()
-    return D - A
+    return (D - A).asformat(format)
 
 
 @nx._dispatchable(edge_attrs="weight")
-def normalized_laplacian_matrix(G, nodelist=None, weight="weight"):
+def normalized_laplacian_matrix(G, nodelist=None, weight="weight", format="csr"):
     r"""Returns the normalized Laplacian matrix of G.
 
     The normalized graph Laplacian is the matrix
@@ -155,10 +159,15 @@ def normalized_laplacian_matrix(G, nodelist=None, weight="weight"):
        The edge data key used to compute each value in the matrix.
        If None, then each edge has weight 1.
 
+    format : str in {'bsr', 'csr', 'csc', 'coo', 'lil', 'dia', 'dok', 'dense'}
+        The format of the result (default 'csr'). For 'dense', a NumPy array
+        is returned. See `scipy.sparse` documentation for other formats.
+
     Returns
     -------
-    N : SciPy sparse array
-      The normalized Laplacian matrix of G.
+    N : SciPy sparse array or NumPy ndarray
+      The normalized Laplacian matrix of G. Returns a NumPy array if
+      ``format='dense'``.
 
     Notes
     -----
@@ -240,7 +249,7 @@ def normalized_laplacian_matrix(G, nodelist=None, weight="weight"):
         diags_sqrt = 1.0 / np.sqrt(diags)
     diags_sqrt[np.isinf(diags_sqrt)] = 0
     DH = sp.sparse.dia_array((diags_sqrt, 0), shape=(n, n)).tocsr()
-    return DH @ (L @ DH)
+    return (DH @ (L @ DH)).asformat(format)
 
 
 ###############################################################################


### PR DESCRIPTION
## Summary

Fixes #7980

Adds a `format` parameter to the following functions that return SciPy sparse arrays but previously had no way to control the output format:

- `adjacency_matrix`
- `incidence_matrix`
- `laplacian_matrix`
- `normalized_laplacian_matrix`
- `bethe_hessian_matrix`
- `tournament_matrix`

This is consistent with `to_scipy_sparse_array` which already supports the `format` parameter including `"dense"` to return a NumPy array directly.

## Usage Examples

```python
import networkx as nx

G = nx.path_graph(4)

# Get a dense NumPy array directly
L = nx.laplacian_matrix(G, format="dense")

# Get in CSC format
A = nx.adjacency_matrix(G, format="csc")

# Get incidence matrix in COO format
I = nx.incidence_matrix(G, format="coo")
```

## Changes

Each function received:
- A new `format` parameter (default preserves existing behavior: `"csr"` or `"csc"`)
- Updated docstring documenting the new parameter and the updated return type
- Return value wrapped with `.asformat(format)`

## Notes

- Default values are unchanged (`format="csr"` for most, `format="csc"` for `incidence_matrix`)
- All existing tests should pass unchanged
- Passing `format="dense"` returns a NumPy ndarray, consistent with `to_scipy_sparse_array`
