### PR TITLE
Minimum weight mean cycle contribution

### DIFF
--- a/networkx/algorithms/cycles/karp.py
+++ b/networkx/algorithms/cycles/karp.py
@@ -1,0 +1,117 @@
+import math
+
+import networkx as nx
+from networkx.exception import NetworkXError
+
+
+def karp(G, source=None, weight="weight"):
+    """
+    Finds the minimum mean negative cycle using Karp's Algorithm.
+
+    1. Preprocesses MultiDiGraphs to simple DiGraphs (keeping min weight).
+    2. Uses Dynamic Programming to find shortest paths of exact lengths.
+    3. Applies Karp's formula to find the minimum mean value.
+    4. Traces back through DP layers to recover the exact cycle nodes.
+    """
+
+    # STEP 1: PREPROCESS -------------------------------------------------------
+    # Cycle-cancelling residual graphs are MultiDiGraphs
+    # Karp's DP requires a simple DiGraph where we use the cheapest edge
+    if not isinstance(G, nx.DiGraph | nx.MultiDiGraph):
+        raise TypeError("Karp requires a directed graph")
+
+    if G.is_multigraph():
+        S = nx.DiGraph()
+        for u, v, data in G.edges(data=True):
+            w = data.get(weight, 0)
+            if S.has_edge(u, v):
+                # Save only one edge per direction between two nodes
+                # Choose the cheapest edge
+                if w < S[u][v][weight]:
+                    S[u][v][weight] = w
+            else:
+                S.add_edge(u, v, **{weight: w})
+        G = S
+
+    # Initialization for dynamic programming
+    nodes = list(G.nodes())
+    n = len(nodes)
+    if n == 0:
+        raise nx.NetworkXError("Empty graph")
+
+    idx = {v: i for i, v in enumerate(nodes)}  # Index mapping: node → int
+
+    # dp[k][v] = min cost of walk of length k ending at v
+    dp = [[math.inf] * n for _ in range(n + 1)]
+    # parent[k][v] = the node u that preceded v in a path of length k
+    # Compute walks of length up to n: any cycle must repeat within n nodes
+    parent = [[None] * n for _ in range(n + 1)]
+
+    # Virtual source: initialize all nodes at distance 0
+    # Allows detecting cycles anywhere in the graph
+    for v in range(n):
+        dp[0][v] = 0
+
+    # STEP 2: DYNAMIC PROGRAMMING ----------------------------------------------
+    # Calculate shortest paths for every length k from 1 to n
+    for k in range(1, n + 1):
+        # Iterate over all directed edges (u → v)
+        for u, v, data in G.edges(data=True):
+            w = data[weight]
+            # Convert node labels to integer indices for DP table access
+            ui, vi = idx[u], idx[v]
+            # If extending the cheapest (k−1)-edge walk ending at u via edge u→v
+            # yields a cheaper k-edge walk ending at v, update the DP value
+            if dp[k - 1][ui] + w < dp[k][vi]:
+                dp[k][vi] = dp[k - 1][ui] + w
+                parent[k][vi] = u
+
+    # STEP 3: KARP'S MIN-MAX FORMULA -------------------------------------------
+    mu = math.inf  # Initialize the minimum mean cycle cost to infinity
+    v_star = None  # Will store a node that lies on the minimum mean cycle
+
+    # Iterate over every node to consider cycles ending at that node
+    for v in range(n):
+        if dp[n][v] == math.inf:
+            # Skip nodes that are unreachable in a walk of length n
+            continue
+
+        # max_k [(dp[n][v] - dp[k][v]) / (n - k)]
+        max_avg = -math.inf
+        for k in range(n):
+            if dp[k][v] != math.inf:
+                avg = (dp[n][v] - dp[k][v]) / (n - k)
+                if avg > max_avg:
+                    max_avg = avg
+
+        if max_avg < mu:
+            mu = max_avg
+            v_star = v
+
+    # STEP 4: TERMINATION CHECK ------------------------------------------------
+    # mu < 0 indicates a negative mean cycle exists
+    # Use small epsilon to handle floating point precision issues
+    if v_star is None or mu >= -1e-11:
+        raise nx.NetworkXError("No negative mean cycle found")
+
+    # STEP 5: ROBUST CYCLE RECONSTRUCTION --------------------------------------
+    # We trace the path back from the n-th layer to find the repeated nodes
+    curr = nodes[v_star]
+    path = []
+    for k in range(n, -1, -1):
+        path.append(curr)
+        curr = parent[k][idx[curr]]
+        if curr is None:
+            break
+
+    path.reverse()
+
+    # Identify the actual cycle within the path (remove the "tail")
+    seen = {}
+    for i, node in enumerate(path):
+        if node in seen:
+            # Return cycle including the closing node for the backbone
+            return path[seen[node] : i + 1]
+        seen[node] = i
+
+    raise nx.NetworkXError("Failed to reconstruct cycle")

--- a/networkx/algorithms/cycles/minimum_weight_mean_cycle.py
+++ b/networkx/algorithms/cycles/minimum_weight_mean_cycle.py
@@ -1,0 +1,117 @@
+import math
+
+import networkx as nx
+from networkx.exception import NetworkXError
+
+
+def minimum_weight_mean_cycle(G, source=None, weight="weight"):
+    """
+    Finds the minimum mean negative cycle using Karp's Algorithm.
+
+    1. Preprocesses MultiDiGraphs to simple DiGraphs (keeping min weight).
+    2. Uses Dynamic Programming to find shortest paths of exact lengths.
+    3. Applies Karp's formula to find the minimum mean value.
+    4. Traces back through DP layers to recover the exact cycle nodes.
+    """
+
+    # STEP 1: PREPROCESS -------------------------------------------------------
+    # Cycle-cancelling residual graphs are MultiDiGraphs
+    # Karp's DP requires a simple DiGraph where we use the cheapest edge
+    if not isinstance(G, nx.DiGraph | nx.MultiDiGraph):
+        raise TypeError("Karp requires a directed graph")
+
+    if G.is_multigraph():
+        S = nx.DiGraph()
+        for u, v, data in G.edges(data=True):
+            w = data.get(weight, 0)
+            if S.has_edge(u, v):
+                # Save only one edge per direction between two nodes
+                # Choose the cheapest edge
+                if w < S[u][v][weight]:
+                    S[u][v][weight] = w
+            else:
+                S.add_edge(u, v, **{weight: w})
+        G = S
+
+    # Initialization for dynamic programming
+    nodes = list(G.nodes())
+    n = len(nodes)
+    if n == 0:
+        raise nx.NetworkXError("Empty graph")
+
+    idx = {v: i for i, v in enumerate(nodes)}  # Index mapping: node → int
+
+    # dp[k][v] = min cost of walk of length k ending at v
+    dp = [[math.inf] * n for _ in range(n + 1)]
+    # parent[k][v] = the node u that preceded v in a path of length k
+    # Compute walks of length up to n: any cycle must repeat within n nodes
+    parent = [[None] * n for _ in range(n + 1)]
+
+    # Virtual source: initialize all nodes at distance 0
+    # Allows detecting cycles anywhere in the graph
+    for v in range(n):
+        dp[0][v] = 0
+
+    # STEP 2: DYNAMIC PROGRAMMING ----------------------------------------------
+    # Calculate shortest paths for every length k from 1 to n
+    for k in range(1, n + 1):
+        # Iterate over all directed edges (u → v)
+        for u, v, data in G.edges(data=True):
+            w = data[weight]
+            # Convert node labels to integer indices for DP table access
+            ui, vi = idx[u], idx[v]
+            # If extending the cheapest (k−1)-edge walk ending at u via edge u→v
+            # yields a cheaper k-edge walk ending at v, update the DP value
+            if dp[k - 1][ui] + w < dp[k][vi]:
+                dp[k][vi] = dp[k - 1][ui] + w
+                parent[k][vi] = u
+
+    # STEP 3: KARP'S MIN-MAX FORMULA -------------------------------------------
+    mu = math.inf  # Initialize the minimum mean cycle cost to infinity
+    v_star = None  # Will store a node that lies on the minimum mean cycle
+
+    # Iterate over every node to consider cycles ending at that node
+    for v in range(n):
+        if dp[n][v] == math.inf:
+            # Skip nodes that are unreachable in a walk of length n
+            continue
+
+        # max_k [(dp[n][v] - dp[k][v]) / (n - k)]
+        max_avg = -math.inf
+        for k in range(n):
+            if dp[k][v] != math.inf:
+                avg = (dp[n][v] - dp[k][v]) / (n - k)
+                if avg > max_avg:
+                    max_avg = avg
+
+        if max_avg < mu:
+            mu = max_avg
+            v_star = v
+
+    # STEP 4: TERMINATION CHECK ------------------------------------------------
+    # mu < 0 indicates a negative mean cycle exists
+    # Use small epsilon to handle floating point precision issues
+    if v_star is None or mu >= -1e-11:
+        raise nx.NetworkXError("No negative mean cycle found")
+
+    # STEP 5: ROBUST CYCLE RECONSTRUCTION --------------------------------------
+    # We trace the path back from the n-th layer to find the repeated nodes
+    curr = nodes[v_star]
+    path = []
+    for k in range(n, -1, -1):
+        path.append(curr)
+        curr = parent[k][idx[curr]]
+        if curr is None:
+            break
+
+    path.reverse()
+
+    # Identify the actual cycle within the path (remove the "tail")
+    seen = {}
+    for i, node in enumerate(path):
+        if node in seen:
+            # Return cycle including the closing node for the backbone
+            return path[seen[node] : i + 1]
+        seen[node] = i
+
+    raise nx.NetworkXError("Failed to reconstruct cycle")

--- a/networkx/algorithms/cycles/tests/test_karp.py
+++ b/networkx/algorithms/cycles/tests/test_karp.py
@@ -3,7 +3,7 @@ import math
 import pytest
 
 import networkx as nx
-from networkx.algorithms.cycles.mean_cycle import karp
+from networkx.algorithms.cycles import karp
 
 
 def mean_cycle_weight(G, cycle, weight="weight"):

--- a/networkx/algorithms/cycles/tests/test_karp.py
+++ b/networkx/algorithms/cycles/tests/test_karp.py
@@ -1,0 +1,95 @@
+import math
+
+import pytest
+
+import networkx as nx
+from networkx.algorithms.cycles.mean_cycle import karp
+
+
+def mean_cycle_weight(G, cycle, weight="weight"):
+    """
+    Helper: compute mean edge weight for a cycle returned as a node list
+    that includes the closing node (e.g., [a,b,c,a]).
+    """
+    if len(cycle) < 2:
+        raise ValueError("Cycle too short")
+    total = 0.0
+    m = 0
+    for u, v in zip(cycle, cycle[1:]):
+        total += G[u][v].get(weight, 0)
+        m += 1
+    return total / m
+
+
+def test_karp_raises_on_empty_graph():
+    G = nx.DiGraph()
+    with pytest.raises(nx.NetworkXError, match="Empty graph"):
+        karp(G)
+
+
+def test_karp_finds_negative_self_loop():
+    # Negative self-loop is a negative mean cycle with mean = weight itself.
+    G = nx.DiGraph()
+    G.add_edge("A", "A", weight=-2)
+
+    cycle = karp(G)
+    assert cycle[0] == "A" and cycle[-1] == "A"
+    assert len(cycle) == 2  # ["A","A"]
+
+    mu = mean_cycle_weight(G, cycle)
+    assert mu < 0
+    assert math.isclose(mu, -2.0, rel_tol=0, abs_tol=1e-12)
+
+
+def test_karp_raises_when_no_negative_mean_cycle():
+    # Simple directed 3-cycle with positive mean
+    G = nx.DiGraph()
+    G.add_weighted_edges_from([(0, 1, 1), (1, 2, 1), (2, 0, 1)], weight="weight")
+
+    with pytest.raises(nx.NetworkXError, match="No negative mean cycle found"):
+        karp(G)
+
+
+def test_karp_multidigraph_keeps_min_weight_parallel_edge():
+    # MultiDiGraph with two parallel edges u->v; preprocessing should keep the cheapest one.
+    MG = nx.MultiDiGraph()
+    MG.add_edge("u", "v", weight=5)  # expensive
+    MG.add_edge("u", "v", weight=-10)  # cheap
+    MG.add_edge(
+        "v", "u", weight=1
+    )  # completes a cycle: u->v->u mean = (-10 + 1)/2 = -4.5
+
+    cycle = karp(MG)
+    # After preprocessing, cycle should exist and be negative
+    # Convert to simple DiGraph with min edge chosen to compute mean:
+    G = nx.DiGraph()
+    for u, v, data in MG.edges(data=True):
+        w = data.get("weight", 0)
+        if G.has_edge(u, v):
+            G[u][v]["weight"] = min(G[u][v]["weight"], w)
+        else:
+            G.add_edge(u, v, weight=w)
+
+    mu = mean_cycle_weight(G, cycle)
+    assert mu < 0
+    assert math.isclose(mu, (-10 + 1) / 2, rel_tol=0, abs_tol=1e-12)
+
+
+def test_karp_prefers_more_negative_mean_among_multiple_cycles():
+    # Two disjoint negative cycles; algorithm should return the one with smaller (more negative) mean.
+    G = nx.DiGraph()
+
+    # Cycle 1: mean = (-2 + 0)/2 = -1
+    G.add_edge("a", "b", weight=-2)
+    G.add_edge("b", "a", weight=0)
+
+    # Cycle 2: mean = (-10 + 1)/2 = -4.5  (more negative)
+    G.add_edge("x", "y", weight=-10)
+    G.add_edge("y", "x", weight=1)
+
+    cycle = karp(G)
+    mu = mean_cycle_weight(G, cycle)
+
+    # Should pick the more negative mean cycle
+    assert mu < -2  # weaker but robust: ensures it's not the -1 cycle
+    assert math.isclose(mu, (-10 + 1) / 2, rel_tol=0, abs_tol=1e-12)

--- a/networkx/algorithms/cycles/tests/test_karp.py
+++ b/networkx/algorithms/cycles/tests/test_karp.py
@@ -3,7 +3,7 @@ import math
 import pytest
 
 import networkx as nx
-from networkx.algorithms.cycles import karp
+from networkx.algorithms.cycles.karp import karp
 
 
 def mean_cycle_weight(G, cycle, weight="weight"):

--- a/networkx/algorithms/cycles/tests/test_karp.py
+++ b/networkx/algorithms/cycles/tests/test_karp.py
@@ -3,7 +3,6 @@ import math
 import pytest
 
 import networkx as nx
-from networkx.algorithms.cycles.karp import karp
 
 
 def mean_cycle_weight(G, cycle, weight="weight"):
@@ -24,7 +23,7 @@ def mean_cycle_weight(G, cycle, weight="weight"):
 def test_karp_raises_on_empty_graph():
     G = nx.DiGraph()
     with pytest.raises(nx.NetworkXError, match="Empty graph"):
-        karp(G)
+        nx.karp(G)
 
 
 def test_karp_finds_negative_self_loop():
@@ -32,7 +31,7 @@ def test_karp_finds_negative_self_loop():
     G = nx.DiGraph()
     G.add_edge("A", "A", weight=-2)
 
-    cycle = karp(G)
+    cycle = nx.karp(G)
     assert cycle[0] == "A" and cycle[-1] == "A"
     assert len(cycle) == 2  # ["A","A"]
 
@@ -47,7 +46,7 @@ def test_karp_raises_when_no_negative_mean_cycle():
     G.add_weighted_edges_from([(0, 1, 1), (1, 2, 1), (2, 0, 1)], weight="weight")
 
     with pytest.raises(nx.NetworkXError, match="No negative mean cycle found"):
-        karp(G)
+        nx.karp(G)
 
 
 def test_karp_multidigraph_keeps_min_weight_parallel_edge():
@@ -59,7 +58,7 @@ def test_karp_multidigraph_keeps_min_weight_parallel_edge():
         "v", "u", weight=1
     )  # completes a cycle: u->v->u mean = (-10 + 1)/2 = -4.5
 
-    cycle = karp(MG)
+    cycle = nx.karp(MG)
     # After preprocessing, cycle should exist and be negative
     # Convert to simple DiGraph with min edge chosen to compute mean:
     G = nx.DiGraph()
@@ -87,7 +86,7 @@ def test_karp_prefers_more_negative_mean_among_multiple_cycles():
     G.add_edge("x", "y", weight=-10)
     G.add_edge("y", "x", weight=1)
 
-    cycle = karp(G)
+    cycle = nx.karp(G)
     mu = mean_cycle_weight(G, cycle)
 
     # Should pick the more negative mean cycle

--- a/networkx/algorithms/cycles/tests/test_karp.py
+++ b/networkx/algorithms/cycles/tests/test_karp.py
@@ -4,91 +4,198 @@ import pytest
 
 import networkx as nx
 
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
 
 def mean_cycle_weight(G, cycle, weight="weight"):
     """
-    Helper: compute mean edge weight for a cycle returned as a node list
-    that includes the closing node (e.g., [a,b,c,a]).
+    Compute mean edge weight for a closed cycle [a, b, ..., a].
+    For MultiDiGraph uses the minimum-weight parallel edge (mirrors karp internals).
     """
     if len(cycle) < 2:
         raise ValueError("Cycle too short")
     total = 0.0
-    m = 0
     for u, v in zip(cycle, cycle[1:]):
-        total += G[u][v].get(weight, 0)
-        m += 1
-    return total / m
-
-
-def test_karp_raises_on_empty_graph():
-    G = nx.DiGraph()
-    with pytest.raises(nx.NetworkXError, match="Empty graph"):
-        nx.karp(G)
-
-
-def test_karp_finds_negative_self_loop():
-    # Negative self-loop is a negative mean cycle with mean = weight itself.
-    G = nx.DiGraph()
-    G.add_edge("A", "A", weight=-2)
-
-    cycle = nx.karp(G)
-    assert cycle[0] == "A" and cycle[-1] == "A"
-    assert len(cycle) == 2  # ["A","A"]
-
-    mu = mean_cycle_weight(G, cycle)
-    assert mu < 0
-    assert math.isclose(mu, -2.0, rel_tol=0, abs_tol=1e-12)
-
-
-def test_karp_raises_when_no_negative_mean_cycle():
-    # Simple directed 3-cycle with positive mean
-    G = nx.DiGraph()
-    G.add_weighted_edges_from([(0, 1, 1), (1, 2, 1), (2, 0, 1)], weight="weight")
-
-    with pytest.raises(nx.NetworkXError, match="No negative mean cycle found"):
-        nx.karp(G)
-
-
-def test_karp_multidigraph_keeps_min_weight_parallel_edge():
-    # MultiDiGraph with two parallel edges u->v; preprocessing should keep the cheapest one.
-    MG = nx.MultiDiGraph()
-    MG.add_edge("u", "v", weight=5)  # expensive
-    MG.add_edge("u", "v", weight=-10)  # cheap
-    MG.add_edge(
-        "v", "u", weight=1
-    )  # completes a cycle: u->v->u mean = (-10 + 1)/2 = -4.5
-
-    cycle = nx.karp(MG)
-    # After preprocessing, cycle should exist and be negative
-    # Convert to simple DiGraph with min edge chosen to compute mean:
-    G = nx.DiGraph()
-    for u, v, data in MG.edges(data=True):
-        w = data.get("weight", 0)
-        if G.has_edge(u, v):
-            G[u][v]["weight"] = min(G[u][v]["weight"], w)
+        if isinstance(G, nx.MultiDiGraph):
+            total += min(d.get(weight, 0) for d in G[u][v].values())
         else:
-            G.add_edge(u, v, weight=w)
-
-    mu = mean_cycle_weight(G, cycle)
-    assert mu < 0
-    assert math.isclose(mu, (-10 + 1) / 2, rel_tol=0, abs_tol=1e-12)
+            total += G[u][v].get(weight, 0)
+    return total / (len(cycle) - 1)
 
 
-def test_karp_prefers_more_negative_mean_among_multiple_cycles():
-    # Two disjoint negative cycles; algorithm should return the one with smaller (more negative) mean.
-    G = nx.DiGraph()
+def assert_valid_cycle(G, cycle):
+    """Assert that cycle is closed and every edge exists in G."""
+    assert len(cycle) >= 2, "Cycle must have at least 2 nodes"
+    assert cycle[0] == cycle[-1], "Cycle must be closed (first == last node)"
+    for u, v in zip(cycle, cycle[1:]):
+        assert G.has_edge(u, v), f"Edge ({u}, {v}) not in graph"
 
-    # Cycle 1: mean = (-2 + 0)/2 = -1
-    G.add_edge("a", "b", weight=-2)
-    G.add_edge("b", "a", weight=0)
 
-    # Cycle 2: mean = (-10 + 1)/2 = -4.5  (more negative)
-    G.add_edge("x", "y", weight=-10)
-    G.add_edge("y", "x", weight=1)
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
 
-    cycle = nx.karp(G)
-    mu = mean_cycle_weight(G, cycle)
 
-    # Should pick the more negative mean cycle
-    assert mu < -2  # weaker but robust: ensures it's not the -1 cycle
-    assert math.isclose(mu, (-10 + 1) / 2, rel_tol=0, abs_tol=1e-12)
+class TestKarp:
+    # --- Input validation ---------------------------------------------------
+
+    def test_raises_on_empty_graph(self):
+        """karp raises NetworkXError on a graph with no nodes."""
+        G = nx.DiGraph()
+        with pytest.raises(nx.NetworkXError, match="Empty graph"):
+            nx.karp(G)
+
+    def test_raises_on_undirected_graph(self):
+        """karp raises TypeError for undirected graphs."""
+        G = nx.Graph()
+        G.add_edge(0, 1, weight=-1)
+        with pytest.raises(TypeError):
+            nx.karp(G)
+
+    def test_raises_when_no_negative_mean_cycle(self):
+        """karp raises NetworkXError when all cycles have non-negative mean."""
+        G = nx.DiGraph()
+        G.add_weighted_edges_from([(0, 1, 1), (1, 2, 1), (2, 0, 1)])
+        with pytest.raises(nx.NetworkXError, match="No negative mean cycle found"):
+            nx.karp(G)
+
+    def test_raises_on_dag_no_cycle(self):
+        """karp raises when there are no cycles at all (DAG)."""
+        G = nx.DiGraph()
+        G.add_weighted_edges_from([(0, 1, -5), (1, 2, -5)])
+        with pytest.raises(nx.NetworkXError):
+            nx.karp(G)
+
+    # --- Correctness: cycle properties --------------------------------------
+
+    def test_negative_self_loop(self):
+        """A negative self-loop is a valid negative mean cycle."""
+        G = nx.DiGraph()
+        G.add_edge("A", "A", weight=-2)
+        cycle = nx.karp(G)
+        assert_valid_cycle(G, cycle)
+        assert mean_cycle_weight(G, cycle) < 0
+
+    def test_simple_two_node_negative_cycle(self):
+        """A 2-node cycle with negative total weight is detected."""
+        G = nx.DiGraph()
+        G.add_edge(0, 1, weight=-3)
+        G.add_edge(1, 0, weight=1)
+        cycle = nx.karp(G)
+        assert_valid_cycle(G, cycle)
+        assert mean_cycle_weight(G, cycle) < 0
+
+    def test_cycle_is_closed(self):
+        """Returned cycle always starts and ends at the same node."""
+        G = nx.DiGraph()
+        G.add_weighted_edges_from([(0, 1, -1), (1, 2, -1), (2, 0, -1)])
+        cycle = nx.karp(G)
+        assert cycle[0] == cycle[-1]
+
+    def test_all_edges_exist_in_graph(self):
+        """Every consecutive pair in the returned cycle must be an edge in G."""
+        G = nx.DiGraph()
+        G.add_weighted_edges_from([(0, 1, 2), (1, 2, -10), (2, 0, 1)])
+        cycle = nx.karp(G)
+        assert_valid_cycle(G, cycle)
+
+    # --- Minimum mean selection ---------------------------------------------
+
+    def test_prefers_more_negative_mean_among_multiple_cycles(self):
+        """
+        With two disjoint negative cycles, karp returns the one with smaller mean.
+        Cycle 1: (a->b->a) mean = (-2 + 0) / 2 = -1.0
+        Cycle 2: (x->y->x) mean = (-10 + 1) / 2 = -4.5  ← more negative
+        """
+        G = nx.DiGraph()
+        G.add_edge("a", "b", weight=-2)
+        G.add_edge("b", "a", weight=0)
+        G.add_edge("x", "y", weight=-10)
+        G.add_edge("y", "x", weight=1)
+        cycle = nx.karp(G)
+        assert_valid_cycle(G, cycle)
+        mu = mean_cycle_weight(G, cycle)
+        assert math.isclose(mu, -4.5, rel_tol=0, abs_tol=1e-9)
+
+    @pytest.mark.parametrize(
+        "neg_weight,pos_weight,expected_mean",
+        [
+            (-4, 2, -1.0),
+            (-10, 4, -3.0),
+            (-1, 0, -0.5),
+        ],
+    )
+    def test_mean_value_correctness(self, neg_weight, pos_weight, expected_mean):
+        """Mean of the found cycle matches the analytically computed value."""
+        G = nx.DiGraph()
+        G.add_edge(0, 1, weight=neg_weight)
+        G.add_edge(1, 0, weight=pos_weight)
+        cycle = nx.karp(G)
+        assert_valid_cycle(G, cycle)
+        mu = mean_cycle_weight(G, cycle)
+        assert math.isclose(mu, expected_mean, rel_tol=0, abs_tol=1e-9)
+
+    # --- MultiDiGraph support -----------------------------------------------
+
+    def test_multigraph_uses_min_weight_parallel_edge(self):
+        """
+        For MultiDiGraph with parallel edges u->v, karp picks the min-weight one.
+        Edges: u->v (weight=5), u->v (weight=-10), v->u (weight=1)
+        Effective cycle mean: (-10 + 1) / 2 = -4.5
+        """
+        MG = nx.MultiDiGraph()
+        MG.add_edge("u", "v", weight=5)
+        MG.add_edge("u", "v", weight=-10)
+        MG.add_edge("v", "u", weight=1)
+        cycle = nx.karp(MG)
+        # Validate against the original multigraph
+        assert_valid_cycle(MG, cycle)
+        mu = mean_cycle_weight(MG, cycle)
+        assert math.isclose(mu, -4.5, rel_tol=0, abs_tol=1e-9)
+
+    def test_multigraph_single_negative_edge(self):
+        """MultiDiGraph with one negative and one positive parallel edge finds negative cycle."""
+        MG = nx.MultiDiGraph()
+        MG.add_edge(0, 1, weight=100)
+        MG.add_edge(0, 1, weight=-5)
+        MG.add_edge(1, 0, weight=2)
+        cycle = nx.karp(MG)
+        assert_valid_cycle(MG, cycle)
+        assert mean_cycle_weight(MG, cycle) < 0
+
+    # --- Custom weight attribute --------------------------------------------
+
+    def test_custom_weight_attribute(self):
+        """karp respects a non-default weight attribute name."""
+        G = nx.DiGraph()
+        G.add_edge(0, 1, cost=-3)
+        G.add_edge(1, 0, cost=-1)
+        cycle = nx.karp(G, weight="cost")
+        assert_valid_cycle(G, cycle)
+        mu = mean_cycle_weight(G, cycle, weight="cost")
+        assert mu < 0
+
+    # --- Graph structure edge cases -----------------------------------------
+
+    def test_larger_cycle(self):
+        """karp detects a negative cycle in a longer path-structured graph."""
+        G = nx.DiGraph()
+        # Positive path: 0→1→2→3→4
+        G.add_weighted_edges_from([(0, 1, 1), (1, 2, 1), (2, 3, 1), (3, 4, 1)])
+        # Negative back-edge that creates a cycle: 4→2 (mean of 2→3→4→2 = (1+1-5)/3)
+        G.add_edge(4, 2, weight=-5)
+        cycle = nx.karp(G)
+        assert_valid_cycle(G, cycle)
+        assert mean_cycle_weight(G, cycle) < 0
+
+    @pytest.mark.parametrize("n", [3, 5, 10])
+    def test_negative_n_cycle(self, n):
+        """A directed n-cycle with all-negative weights is always detected."""
+        G = nx.cycle_graph(n, create_using=nx.DiGraph())
+        for u, v in G.edges():
+            G[u][v]["weight"] = -1
+        cycle = nx.karp(G)
+        assert_valid_cycle(G, cycle)
+        assert mean_cycle_weight(G, cycle) < 0

--- a/networkx/algorithms/cycles/tests/test_minimum_weight_mean_cycle.py
+++ b/networkx/algorithms/cycles/tests/test_minimum_weight_mean_cycle.py
@@ -1,0 +1,201 @@
+import math
+
+import pytest
+
+import networkx as nx
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def mean_cycle_weight(G, cycle, weight="weight"):
+    """
+    Compute mean edge weight for a closed cycle [a, b, ..., a].
+    For MultiDiGraph uses the minimum-weight parallel edge (mirrors karp internals).
+    """
+    if len(cycle) < 2:
+        raise ValueError("Cycle too short")
+    total = 0.0
+    for u, v in zip(cycle, cycle[1:]):
+        if isinstance(G, nx.MultiDiGraph):
+            total += min(d.get(weight, 0) for d in G[u][v].values())
+        else:
+            total += G[u][v].get(weight, 0)
+    return total / (len(cycle) - 1)
+
+
+def assert_valid_cycle(G, cycle):
+    """Assert that cycle is closed and every edge exists in G."""
+    assert len(cycle) >= 2, "Cycle must have at least 2 nodes"
+    assert cycle[0] == cycle[-1], "Cycle must be closed (first == last node)"
+    for u, v in zip(cycle, cycle[1:]):
+        assert G.has_edge(u, v), f"Edge ({u}, {v}) not in graph"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestKarp:
+    # --- Input validation ---------------------------------------------------
+
+    def test_raises_on_empty_graph(self):
+        """karp raises NetworkXError on a graph with no nodes."""
+        G = nx.DiGraph()
+        with pytest.raises(nx.NetworkXError, match="Empty graph"):
+            nx.minimum_weight_mean_cycle(G)
+
+    def test_raises_on_undirected_graph(self):
+        """karp raises TypeError for undirected graphs."""
+        G = nx.Graph()
+        G.add_edge(0, 1, weight=-1)
+        with pytest.raises(TypeError):
+            nx.minimum_weight_mean_cycle(G)
+
+    def test_raises_when_no_negative_mean_cycle(self):
+        """karp raises NetworkXError when all cycles have non-negative mean."""
+        G = nx.DiGraph()
+        G.add_weighted_edges_from([(0, 1, 1), (1, 2, 1), (2, 0, 1)])
+        with pytest.raises(nx.NetworkXError, match="No negative mean cycle found"):
+            nx.minimum_weight_mean_cycle(G)
+
+    def test_raises_on_dag_no_cycle(self):
+        """karp raises when there are no cycles at all (DAG)."""
+        G = nx.DiGraph()
+        G.add_weighted_edges_from([(0, 1, -5), (1, 2, -5)])
+        with pytest.raises(nx.NetworkXError):
+            nx.minimum_weight_mean_cycle(G)
+
+    # --- Correctness: cycle properties --------------------------------------
+
+    def test_negative_self_loop(self):
+        """A negative self-loop is a valid negative mean cycle."""
+        G = nx.DiGraph()
+        G.add_edge("A", "A", weight=-2)
+        cycle = nx.minimum_weight_mean_cycle(G)
+        assert_valid_cycle(G, cycle)
+        assert mean_cycle_weight(G, cycle) < 0
+
+    def test_simple_two_node_negative_cycle(self):
+        """A 2-node cycle with negative total weight is detected."""
+        G = nx.DiGraph()
+        G.add_edge(0, 1, weight=-3)
+        G.add_edge(1, 0, weight=1)
+        cycle = nx.minimum_weight_mean_cycle(G)
+        assert_valid_cycle(G, cycle)
+        assert mean_cycle_weight(G, cycle) < 0
+
+    def test_cycle_is_closed(self):
+        """Returned cycle always starts and ends at the same node."""
+        G = nx.DiGraph()
+        G.add_weighted_edges_from([(0, 1, -1), (1, 2, -1), (2, 0, -1)])
+        cycle = nx.minimum_weight_mean_cycle(G)
+        assert cycle[0] == cycle[-1]
+
+    def test_all_edges_exist_in_graph(self):
+        """Every consecutive pair in the returned cycle must be an edge in G."""
+        G = nx.DiGraph()
+        G.add_weighted_edges_from([(0, 1, 2), (1, 2, -10), (2, 0, 1)])
+        cycle = nx.minimum_weight_mean_cycle(G)
+        assert_valid_cycle(G, cycle)
+
+    # --- Minimum mean selection ---------------------------------------------
+
+    def test_prefers_more_negative_mean_among_multiple_cycles(self):
+        """
+        With two disjoint negative cycles, karp returns the one with smaller mean.
+        Cycle 1: (a->b->a) mean = (-2 + 0) / 2 = -1.0
+        Cycle 2: (x->y->x) mean = (-10 + 1) / 2 = -4.5  ← more negative
+        """
+        G = nx.DiGraph()
+        G.add_edge("a", "b", weight=-2)
+        G.add_edge("b", "a", weight=0)
+        G.add_edge("x", "y", weight=-10)
+        G.add_edge("y", "x", weight=1)
+        cycle = nx.minimum_weight_mean_cycle(G)
+        assert_valid_cycle(G, cycle)
+        mu = mean_cycle_weight(G, cycle)
+        assert math.isclose(mu, -4.5, rel_tol=0, abs_tol=1e-9)
+
+    @pytest.mark.parametrize(
+        "neg_weight,pos_weight,expected_mean",
+        [
+            (-4, 2, -1.0),
+            (-10, 4, -3.0),
+            (-1, 0, -0.5),
+        ],
+    )
+    def test_mean_value_correctness(self, neg_weight, pos_weight, expected_mean):
+        """Mean of the found cycle matches the analytically computed value."""
+        G = nx.DiGraph()
+        G.add_edge(0, 1, weight=neg_weight)
+        G.add_edge(1, 0, weight=pos_weight)
+        cycle = nx.minimum_weight_mean_cycle(G)
+        assert_valid_cycle(G, cycle)
+        mu = mean_cycle_weight(G, cycle)
+        assert math.isclose(mu, expected_mean, rel_tol=0, abs_tol=1e-9)
+
+    # --- MultiDiGraph support -----------------------------------------------
+
+    def test_multigraph_uses_min_weight_parallel_edge(self):
+        """
+        For MultiDiGraph with parallel edges u->v, karp picks the min-weight one.
+        Edges: u->v (weight=5), u->v (weight=-10), v->u (weight=1)
+        Effective cycle mean: (-10 + 1) / 2 = -4.5
+        """
+        MG = nx.MultiDiGraph()
+        MG.add_edge("u", "v", weight=5)
+        MG.add_edge("u", "v", weight=-10)
+        MG.add_edge("v", "u", weight=1)
+        cycle = nx.minimum_weight_mean_cycle(MG)
+        # Validate against the original multigraph
+        assert_valid_cycle(MG, cycle)
+        mu = mean_cycle_weight(MG, cycle)
+        assert math.isclose(mu, -4.5, rel_tol=0, abs_tol=1e-9)
+
+    def test_multigraph_single_negative_edge(self):
+        """MultiDiGraph with one negative and one positive parallel edge finds negative cycle."""
+        MG = nx.MultiDiGraph()
+        MG.add_edge(0, 1, weight=100)
+        MG.add_edge(0, 1, weight=-5)
+        MG.add_edge(1, 0, weight=2)
+        cycle = nx.minimum_weight_mean_cycle(MG)
+        assert_valid_cycle(MG, cycle)
+        assert mean_cycle_weight(MG, cycle) < 0
+
+    # --- Custom weight attribute --------------------------------------------
+
+    def test_custom_weight_attribute(self):
+        """karp respects a non-default weight attribute name."""
+        G = nx.DiGraph()
+        G.add_edge(0, 1, cost=-3)
+        G.add_edge(1, 0, cost=-1)
+        cycle = nx.minimum_weight_mean_cycle(G, weight="cost")
+        assert_valid_cycle(G, cycle)
+        mu = mean_cycle_weight(G, cycle, weight="cost")
+        assert mu < 0
+
+    # --- Graph structure edge cases -----------------------------------------
+
+    def test_larger_cycle(self):
+        """karp detects a negative cycle in a longer path-structured graph."""
+        G = nx.DiGraph()
+        # Positive path: 0→1→2→3→4
+        G.add_weighted_edges_from([(0, 1, 1), (1, 2, 1), (2, 3, 1), (3, 4, 1)])
+        # Negative back-edge that creates a cycle: 4→2 (mean of 2→3→4→2 = (1+1-5)/3)
+        G.add_edge(4, 2, weight=-5)
+        cycle = nx.minimum_weight_mean_cycle(G)
+        assert_valid_cycle(G, cycle)
+        assert mean_cycle_weight(G, cycle) < 0
+
+    @pytest.mark.parametrize("n", [3, 5, 10])
+    def test_negative_n_cycle(self, n):
+        """A directed n-cycle with all-negative weights is always detected."""
+        G = nx.cycle_graph(n, create_using=nx.DiGraph())
+        for u, v in G.edges():
+            G[u][v]["weight"] = -1
+        cycle = nx.minimum_weight_mean_cycle(G)
+        assert_valid_cycle(G, cycle)
+        assert mean_cycle_weight(G, cycle) < 0

--- a/networkx/algorithms/flow/cycle_cancelling.py
+++ b/networkx/algorithms/flow/cycle_cancelling.py
@@ -57,7 +57,7 @@ def cycle_cancelling(
             raise ValueError(f"Edge ({u},{v}) has negative weight ({data[weight]}).")
 
     if negative_cycle_func is None:
-        from networkx.algorithms.cycles.mean_cycle import karp
+        from networkx.algorithms.cycles.karp import karp
 
         negative_cycle_func = karp
 

--- a/networkx/algorithms/flow/cycle_cancelling.py
+++ b/networkx/algorithms/flow/cycle_cancelling.py
@@ -1,0 +1,184 @@
+import math
+from copy import deepcopy
+
+import networkx as nx
+from networkx.exception import NetworkXError, NetworkXUnbounded
+
+
+def cycle_cancelling(
+    G,
+    s,
+    t,
+    weight="weight",
+    flow_func=None,
+    capacity="capacity",
+    negative_cycle_func=None,
+):
+    """
+    Cycle-Cancelling algorithm for Minimum-Cost Flow.
+
+    Parameters:
+        G : directed graph (DiGraph)
+        s : source node
+        t : target node
+        weight : edge attribute for cost
+        capacity : edge attribute for capacity
+        flow_func : flow function to use in finding the maximum flow
+        negative_cycle_func : function to fins the negative cycles
+
+
+    Returns:
+        (flow_dict, min_cost)
+    """
+
+    # --------------------------------------------------------
+    # 1. PARAMETER VALIDATION
+    # --------------------------------------------------------
+
+    if not isinstance(G, nx.DiGraph):
+        raise TypeError("Input graph must be a directed graph (DiGraph).")
+
+    if s not in G.nodes:
+        raise ValueError("Source node does not exist in graph.")
+
+    if t not in G.nodes:
+        raise ValueError("Target node does not exist in graph.")
+
+    for u, v, data in G.edges(data=True):
+        if capacity not in data:
+            raise ValueError(f"Edge ({u},{v}) missing capacity attribute.")
+        if data[capacity] < 0:
+            raise ValueError(f"Edge ({u},{v}) has negative capacity.")
+
+        if weight not in data:
+            raise ValueError(f"Edge ({u},{v}) missing weight attribute.")
+        # the algorithm can run on negative too - think of delete it
+        if data[weight] < 0:
+            raise ValueError(f"Edge ({u},{v}) has negative weight ({data[weight]}).")
+
+    if negative_cycle_func is None:
+        from networkx.algorithms.cycles.mean_cycle import karp
+
+        negative_cycle_func = karp
+
+    if not callable(negative_cycle_func):
+        raise nx.NetworkXError("finding negative cycle func has to be callable.")
+
+    # --------------------------------------------------------
+    # 2. INITIAL MAX-FLOW (IGNORE COSTS)
+    # --------------------------------------------------------
+
+    # We temporarily build a capacity-only graph
+    G_cap = nx.DiGraph()
+    for u, v, data in G.edges(data=True):
+        G_cap.add_edge(u, v, capacity=data[capacity])
+
+    max_flow_return = nx.maximum_flow(
+        G_cap, s, t, flow_func=None
+    )  # flow_dict is a nested dict
+    flow_dict = max_flow_return[1]
+
+    for u, v in G_cap.edges():
+        # If node u has no outgoing flow dict, create one
+        if u not in flow_dict:
+            flow_dict[u] = {}
+
+        # If edge (u, v) not assigned by max-flow, its flow is 0
+        if v not in flow_dict[u]:
+            flow_dict[u][v] = 0
+
+    # --------------------------------------------------------
+    # 3. BUILD INITIAL RESIDUAL GRAPH
+    # --------------------------------------------------------
+
+    def build_residual(G, flow):
+        # We use MultiDiGraph because u->v might have a forward residual edge
+        # AND a backward residual edge from the opposite original edge v->u.
+        R = nx.DiGraph()
+        for u, v, data in G.edges(data=True):
+            cap = data[capacity]
+            w = data[weight]
+            f = flow.get(u, {}).get(v, 0)
+
+            # Forward residual edge: can push (cap - f) more flow at cost 'w'
+            # for negative cycle, we need only the bwd edge, otherwise we work with an edge without flow
+            if f < cap:
+                if R.has_edge(u, v):
+                    if R[u][v]["type"] == "bwd":
+                        continue
+                else:
+                    R.add_edge(u, v, weight=w, capacity=cap - f, type="fwd")
+
+            # Backward residual edge: can push 'f' back at cost '-w'
+            if f > 0:
+                if R.has_edge(v, u):
+                    if R[v][u]["type"] == "fwd":
+                        R.remove_edge(v, u)
+                R.add_edge(v, u, weight=-w, capacity=f, type="bwd")
+
+        return R
+
+    # --------------------------------------------------------
+    # Helper: increase flow on edges of a cycle
+    # --------------------------------------------------------
+
+    def augment_cycle(flow, cycle, bottleneck):
+        """Increase flow along cycle edges by bottleneck."""
+        for i in range(len(cycle) - 1):
+            u = cycle[i]
+            v = cycle[i + 1]
+
+            if G.has_edge(u, v) and R.has_edge(u, v) and R[u][v]["type"] == "fwd":
+                # forward edge (u→v)
+                flow.setdefault(u, {}).setdefault(v, 0)
+                flow[u][v] += bottleneck
+
+            elif G.has_edge(v, u) and R.has_edge(u, v) and R[u][v]["type"] == "bwd":
+                # backward edge (v→u)
+                flow.setdefault(v, {}).setdefault(u, 0)
+                flow[v][u] -= bottleneck  # reduce forward flow
+
+            else:
+                raise RuntimeError("Cycle edge not found in original graph.")
+
+    # --------------------------------------------------------
+    # 4. MAIN LOOP — CANCEL NEGATIVE CYCLES
+    # --------------------------------------------------------
+
+    while True:
+        R = build_residual(G, flow_dict)
+
+        try:
+            # Try to find a negative cycle in graph R
+            cycle = negative_cycle_func(R, s, weight="weight")
+        except nx.NetworkXError:
+            cycle = None
+
+        if not cycle:
+            break  # terminate
+
+        # ---- your bottleneck & augment logic, now "per SCC" ----
+        bottleneck = float("inf")
+        for i in range(len(cycle) - 1):
+            u = cycle[i]
+            v = cycle[i + 1]
+            cap = R[u][v]["capacity"]
+            if cap < bottleneck:
+                bottleneck = cap
+        if bottleneck <= 0:
+            raise RuntimeError(
+                "Residual bottleneck is non-positive (should not happen)."
+            )
+
+        augment_cycle(flow_dict, cycle, bottleneck)
+
+    # --------------------------------------------------------
+    # 5. COMPUTE FINAL MINIMUM COST
+    # --------------------------------------------------------
+    min_cost = 0
+    for u, nbrs in flow_dict.items():
+        for v, f in nbrs.items():
+            if f > 0:  # only forward flows
+                min_cost += f * G[u][v][weight]
+
+    return flow_dict, min_cost

--- a/networkx/algorithms/flow/cycle_cancelling.py
+++ b/networkx/algorithms/flow/cycle_cancelling.py
@@ -1,10 +1,10 @@
-import math
-from copy import deepcopy
-
 import networkx as nx
-from networkx.exception import NetworkXError, NetworkXUnbounded
+from networkx.exception import NetworkXError
+from networkx.utils import not_implemented_for
 
 
+@not_implemented_for("undirected")
+@nx._dispatchable
 def cycle_cancelling(
     G,
     s,
@@ -57,9 +57,7 @@ def cycle_cancelling(
             raise ValueError(f"Edge ({u},{v}) has negative weight ({data[weight]}).")
 
     if negative_cycle_func is None:
-        from networkx.algorithms.cycles.karp import karp
-
-        negative_cycle_func = karp
+        negative_cycle_func = nx.karp
 
     if not callable(negative_cycle_func):
         raise nx.NetworkXError("finding negative cycle func has to be callable.")
@@ -74,7 +72,7 @@ def cycle_cancelling(
         G_cap.add_edge(u, v, capacity=data[capacity])
 
     max_flow_return = nx.maximum_flow(
-        G_cap, s, t, flow_func=None
+        G_cap, s, t, flow_func=flow_func
     )  # flow_dict is a nested dict
     flow_dict = max_flow_return[1]
 

--- a/networkx/algorithms/flow/tests/test_cycle_cancelling.py
+++ b/networkx/algorithms/flow/tests/test_cycle_cancelling.py
@@ -1,0 +1,248 @@
+import random
+
+import pytest
+
+import networkx as nx
+from networkx.algorithms.flow import cycle_cancelling
+
+# -------------------------
+# Helpers
+# -------------------------
+
+
+def _assert_flow_conservation(flow, s, t):
+    """
+    For an s-t flow dict {u:{v:f}}, check flow conservation at internal nodes:
+    inflow == outflow for all nodes except s and t.
+    """
+    nodes = set(flow.keys())
+    for u in flow:
+        nodes.update(flow[u].keys())
+
+    # Compute net flow: out - in
+    net = {v: 0 for v in nodes}
+    for u, nbrs in flow.items():
+        for v, f in nbrs.items():
+            net[u] += f
+            net[v] -= f
+
+    for v in nodes:
+        if v in (s, t):
+            continue
+        assert net[v] == 0, f"Flow conservation violated at node {v}: net={net[v]}"
+
+
+def _assert_capacity_constraints(G, flow, capacity="capacity"):
+    """
+    Check 0 <= f(u,v) <= cap(u,v) for all original edges in G.
+    Also ensure no flow on non-edges.
+    """
+    for u, nbrs in flow.items():
+        for v, f in nbrs.items():
+            # In many flow dicts, neighbors include only edges that exist in G.
+            assert G.has_edge(u, v), f"Flow has value on non-edge ({u},{v})"
+            cap = G[u][v].get(capacity, None)
+            assert cap is not None, f"Missing capacity attribute on edge ({u},{v})"
+            assert 0 <= f <= cap, f"Capacity violated on ({u},{v}): f={f}, cap={cap}"
+
+
+def _flow_value(flow, s):
+    """
+    Total flow sent out of s in a flow dict.
+    """
+    return sum(flow.get(s, {}).values())
+
+
+# -------------------------
+# Deterministic graph builders
+# -------------------------
+
+
+def build_graph_small_1():
+    """
+    A small graph with multiple s-t paths and differing costs.
+    """
+    G = nx.DiGraph()
+    # Two main routes: 0-1-3 and 0-2-3
+    G.add_edge(0, 1, capacity=3, weight=1)
+    G.add_edge(1, 3, capacity=3, weight=1)
+
+    G.add_edge(0, 2, capacity=3, weight=5)
+    G.add_edge(2, 3, capacity=3, weight=1)
+
+    # Cross edge allows mixing
+    G.add_edge(1, 2, capacity=2, weight=0)
+    return G, 0, 3
+
+
+def build_graph_small_2_with_negative_cycle_in_residual():
+    """
+    A graph where cycle-canceling may encounter negative cycles in the *residual*.
+    (This can happen after sending some flow.)
+    Still, the optimal min-cost max-flow should match NetworkX.
+
+    Structure:
+      0 -> 1 -> 3
+      0 -> 2 -> 3
+      1 -> 2 cheap edge, 2 -> 1 expensive edge (creates potential for residual negative cycle adjustments)
+    """
+    G = nx.DiGraph()
+    G.add_edge(0, 1, capacity=2, weight=2)
+    G.add_edge(1, 3, capacity=2, weight=2)
+
+    G.add_edge(0, 2, capacity=2, weight=2)
+    G.add_edge(2, 3, capacity=2, weight=2)
+
+    G.add_edge(1, 2, capacity=2, weight=-5)
+    G.add_edge(2, 1, capacity=2, weight=10)
+    return G, 0, 3
+
+
+def build_graph_parallel_edges_multidigraph():
+    """
+    MultiDiGraph with parallel edges; your Karp preprocessing keeps min-weight per (u,v).
+    For cycle-cancelling, you likely convert residual MultiDiGraph to DiGraph for Karp,
+    so we test that the algorithm still matches NetworkX on the original simple DiGraph.
+
+    For fairness, we define both:
+      - MG: MultiDiGraph for your algorithm (if you support it)
+      - G_ref: DiGraph oracle used by NetworkX max_flow_min_cost
+    """
+    MG = nx.MultiDiGraph()
+    # parallel edges 0->1: choose cheaper (weight=1) effectively
+    MG.add_edge(0, 1, capacity=2, weight=7)
+    MG.add_edge(0, 1, capacity=2, weight=1)
+    MG.add_edge(1, 2, capacity=2, weight=1)
+
+    MG.add_edge(0, 2, capacity=2, weight=10)
+
+    # Reference simple graph: keep min weight per direction
+    G_ref = nx.DiGraph()
+    G_ref.add_edge(0, 1, capacity=2, weight=1)
+    G_ref.add_edge(1, 2, capacity=2, weight=1)
+    G_ref.add_edge(0, 2, capacity=2, weight=10)
+
+    return MG, G_ref, 0, 2
+
+
+# -------------------------
+# Tests
+# -------------------------
+
+
+def test_cycle_cancelling_matches_networkx_on_small_graph_1():
+    G, s, t = build_graph_small_1()
+
+    # Oracle: NetworkX min-cost max-flow for single-source/single-sink
+    flow_ref = nx.max_flow_min_cost(G, s, t, capacity="capacity", weight="weight")
+    cost_ref = nx.cost_of_flow(G, flow_ref, weight="weight")
+    val_ref = _flow_value(flow_ref, s)
+
+    flow_cc, cost_cc = cycle_cancelling(
+        G.copy(), s, t, capacity="capacity", weight="weight"
+    )
+
+    assert cost_cc == cost_ref
+    assert _flow_value(flow_cc, s) == val_ref
+    _assert_flow_conservation(flow_cc, s, t)
+    _assert_capacity_constraints(G, flow_cc, capacity="capacity")
+
+
+def test_cycle_cancelling_matches_networkx_on_small_graph_2():
+    G, s, t = build_graph_small_2_with_negative_cycle_in_residual()
+
+    flow_ref = nx.max_flow_min_cost(G, s, t, capacity="capacity", weight="weight")
+    cost_ref = nx.cost_of_flow(G, flow_ref, weight="weight")
+    val_ref = _flow_value(flow_ref, s)
+
+    flow_cc, cost_cc = cycle_cancelling(
+        G.copy(), s, t, capacity="capacity", weight="weight"
+    )
+
+    assert cost_cc == cost_ref
+    assert _flow_value(flow_cc, s) == val_ref
+    _assert_flow_conservation(flow_cc, s, t)
+    _assert_capacity_constraints(G, flow_cc, capacity="capacity")
+
+
+def test_cycle_cancelling_rejects_non_digraph():
+    UG = nx.Graph()
+    UG.add_edge(0, 1, capacity=1, weight=1)
+    with pytest.raises((TypeError, nx.NetworkXError)):
+        cycle_cancelling(UG, 0, 1, capacity="capacity", weight="weight")
+
+
+def test_cycle_cancelling_raises_on_missing_capacity():
+    G = nx.DiGraph()
+    G.add_edge(0, 1, weight=1)  # missing capacity
+    with pytest.raises((ValueError, nx.NetworkXError, KeyError)):
+        cycle_cancelling(G, 0, 1, capacity="capacity", weight="weight")
+
+
+def test_cycle_cancelling_raises_on_missing_weight():
+    G = nx.DiGraph()
+    G.add_edge(0, 1, capacity=1)  # missing weight
+    with pytest.raises((ValueError, nx.NetworkXError, KeyError)):
+        cycle_cancelling(G, 0, 1, capacity="capacity", weight="weight")
+
+
+def test_cycle_cancelling_multidigraph_parallel_edges_matches_reference():
+    MG, G_ref, s, t = build_graph_parallel_edges_multidigraph()
+
+    # Oracle on the reference DiGraph
+    flow_ref = nx.max_flow_min_cost(G_ref, s, t, capacity="capacity", weight="weight")
+    cost_ref = nx.cost_of_flow(G_ref, flow_ref, weight="weight")
+    val_ref = _flow_value(flow_ref, s)
+
+    # Your algorithm run on MultiDiGraph (if supported). If not supported, change to expect TypeError.
+    flow_cc, cost_cc = cycle_cancelling(
+        MG.copy(), s, t, capacity="capacity", weight="weight"
+    )
+
+    assert cost_cc == cost_ref
+    assert _flow_value(flow_cc, s) == val_ref
+
+
+def test_cycle_cancelling_random_small_fixed_seed_matches_networkx():
+    """
+    Small randomized regression test with fixed seed.
+    Keep it small to avoid flaky/slow tests in CI.
+    """
+    rng = random.Random(12345)
+
+    for _ in range(10):
+        n = 6
+        s, t = 0, n - 1
+        G = nx.DiGraph()
+
+        # Build a sparse-ish random digraph with guaranteed s->t path
+        for u in range(n):
+            for v in range(n):
+                if u == v:
+                    continue
+                if rng.random() < 0.25:
+                    G.add_edge(
+                        u,
+                        v,
+                        capacity=rng.randint(1, 5),
+                        weight=rng.randint(-3, 6),
+                    )
+
+        # Ensure at least one simple s->t chain
+        chain = [0, 2, 4, 5]
+        for u, v in zip(chain, chain[1:]):
+            if not G.has_edge(u, v):
+                G.add_edge(u, v, capacity=rng.randint(1, 5), weight=rng.randint(-3, 6))
+
+        flow_ref = nx.max_flow_min_cost(G, s, t, capacity="capacity", weight="weight")
+        cost_ref = nx.cost_of_flow(G, flow_ref, weight="weight")
+        val_ref = _flow_value(flow_ref, s)
+
+        flow_cc, cost_cc = cycle_cancelling(
+            G.copy(), s, t, capacity="capacity", weight="weight"
+        )
+
+        assert cost_cc == cost_ref
+        assert _flow_value(flow_cc, s) == val_ref
+        _assert_flow_conservation(flow_cc, s, t)
+        _assert_capacity_constraints(G, flow_cc, capacity="capacity")

--- a/networkx/algorithms/flow/tests/test_cycle_cancelling.py
+++ b/networkx/algorithms/flow/tests/test_cycle_cancelling.py
@@ -3,7 +3,7 @@ import random
 import pytest
 
 import networkx as nx
-from networkx.algorithms.flow import cycle_cancelling
+from networkx.algorithms.flow.cycle_cancelling import cycle_cancelling
 
 # -------------------------
 # Helpers

--- a/networkx/algorithms/flow/tests/test_cycle_cancelling.py
+++ b/networkx/algorithms/flow/tests/test_cycle_cancelling.py
@@ -3,7 +3,6 @@ import random
 import pytest
 
 import networkx as nx
-from networkx.algorithms.flow.cycle_cancelling import cycle_cancelling
 
 # -------------------------
 # Helpers
@@ -138,7 +137,7 @@ def test_cycle_cancelling_matches_networkx_on_small_graph_1():
     cost_ref = nx.cost_of_flow(G, flow_ref, weight="weight")
     val_ref = _flow_value(flow_ref, s)
 
-    flow_cc, cost_cc = cycle_cancelling(
+    flow_cc, cost_cc = nx.cycle_cancelling(
         G.copy(), s, t, capacity="capacity", weight="weight"
     )
 
@@ -155,7 +154,7 @@ def test_cycle_cancelling_matches_networkx_on_small_graph_2():
     cost_ref = nx.cost_of_flow(G, flow_ref, weight="weight")
     val_ref = _flow_value(flow_ref, s)
 
-    flow_cc, cost_cc = cycle_cancelling(
+    flow_cc, cost_cc = nx.cycle_cancelling(
         G.copy(), s, t, capacity="capacity", weight="weight"
     )
 
@@ -169,21 +168,21 @@ def test_cycle_cancelling_rejects_non_digraph():
     UG = nx.Graph()
     UG.add_edge(0, 1, capacity=1, weight=1)
     with pytest.raises((TypeError, nx.NetworkXError)):
-        cycle_cancelling(UG, 0, 1, capacity="capacity", weight="weight")
+        nx.cycle_cancelling(UG, 0, 1, capacity="capacity", weight="weight")
 
 
 def test_cycle_cancelling_raises_on_missing_capacity():
     G = nx.DiGraph()
     G.add_edge(0, 1, weight=1)  # missing capacity
     with pytest.raises((ValueError, nx.NetworkXError, KeyError)):
-        cycle_cancelling(G, 0, 1, capacity="capacity", weight="weight")
+        nx.cycle_cancelling(G, 0, 1, capacity="capacity", weight="weight")
 
 
 def test_cycle_cancelling_raises_on_missing_weight():
     G = nx.DiGraph()
     G.add_edge(0, 1, capacity=1)  # missing weight
     with pytest.raises((ValueError, nx.NetworkXError, KeyError)):
-        cycle_cancelling(G, 0, 1, capacity="capacity", weight="weight")
+        nx.cycle_cancelling(G, 0, 1, capacity="capacity", weight="weight")
 
 
 def test_cycle_cancelling_multidigraph_parallel_edges_matches_reference():
@@ -195,7 +194,7 @@ def test_cycle_cancelling_multidigraph_parallel_edges_matches_reference():
     val_ref = _flow_value(flow_ref, s)
 
     # Your algorithm run on MultiDiGraph (if supported). If not supported, change to expect TypeError.
-    flow_cc, cost_cc = cycle_cancelling(
+    flow_cc, cost_cc = nx.cycle_cancelling(
         MG.copy(), s, t, capacity="capacity", weight="weight"
     )
 
@@ -238,7 +237,7 @@ def test_cycle_cancelling_random_small_fixed_seed_matches_networkx():
         cost_ref = nx.cost_of_flow(G, flow_ref, weight="weight")
         val_ref = _flow_value(flow_ref, s)
 
-        flow_cc, cost_cc = cycle_cancelling(
+        flow_cc, cost_cc = nx.cycle_cancelling(
             G.copy(), s, t, capacity="capacity", weight="weight"
         )
 

--- a/networkx/algorithms/flow/tests/test_cycle_cancelling.py
+++ b/networkx/algorithms/flow/tests/test_cycle_cancelling.py
@@ -1,247 +1,331 @@
-import random
+import math
 
 import pytest
 
 import networkx as nx
 
-# -------------------------
+# ---------------------------------------------------------------------------
 # Helpers
-# -------------------------
+# ---------------------------------------------------------------------------
 
 
-def _assert_flow_conservation(flow, s, t):
+def make_edge(G, u, v, capacity, weight):
+    G.add_edge(u, v, capacity=capacity, weight=weight)
+
+
+def total_flow_out(flow_dict, s):
+    """Sum of flow leaving source s."""
+    return sum(flow_dict.get(s, {}).values())
+
+
+def assert_flow_conservation(flow_dict, G, s, t):
     """
-    For an s-t flow dict {u:{v:f}}, check flow conservation at internal nodes:
-    inflow == outflow for all nodes except s and t.
+    For every node except s and t: flow_in == flow_out.
+    For s: net flow out >= 0.
+    For t: net flow in >= 0.
     """
-    nodes = set(flow.keys())
-    for u in flow:
-        nodes.update(flow[u].keys())
-
-    # Compute net flow: out - in
-    net = {v: 0 for v in nodes}
-    for u, nbrs in flow.items():
-        for v, f in nbrs.items():
-            net[u] += f
-            net[v] -= f
-
-    for v in nodes:
-        if v in (s, t):
+    for node in G.nodes():
+        if node in (s, t):
             continue
-        assert net[v] == 0, f"Flow conservation violated at node {v}: net={net[v]}"
-
-
-def _assert_capacity_constraints(G, flow, capacity="capacity"):
-    """
-    Check 0 <= f(u,v) <= cap(u,v) for all original edges in G.
-    Also ensure no flow on non-edges.
-    """
-    for u, nbrs in flow.items():
-        for v, f in nbrs.items():
-            # In many flow dicts, neighbors include only edges that exist in G.
-            assert G.has_edge(u, v), f"Flow has value on non-edge ({u},{v})"
-            cap = G[u][v].get(capacity, None)
-            assert cap is not None, f"Missing capacity attribute on edge ({u},{v})"
-            assert 0 <= f <= cap, f"Capacity violated on ({u},{v}): f={f}, cap={cap}"
-
-
-def _flow_value(flow, s):
-    """
-    Total flow sent out of s in a flow dict.
-    """
-    return sum(flow.get(s, {}).values())
-
-
-# -------------------------
-# Deterministic graph builders
-# -------------------------
-
-
-def build_graph_small_1():
-    """
-    A small graph with multiple s-t paths and differing costs.
-    """
-    G = nx.DiGraph()
-    # Two main routes: 0-1-3 and 0-2-3
-    G.add_edge(0, 1, capacity=3, weight=1)
-    G.add_edge(1, 3, capacity=3, weight=1)
-
-    G.add_edge(0, 2, capacity=3, weight=5)
-    G.add_edge(2, 3, capacity=3, weight=1)
-
-    # Cross edge allows mixing
-    G.add_edge(1, 2, capacity=2, weight=0)
-    return G, 0, 3
-
-
-def build_graph_small_2_with_negative_cycle_in_residual():
-    """
-    A graph where cycle-canceling may encounter negative cycles in the *residual*.
-    (This can happen after sending some flow.)
-    Still, the optimal min-cost max-flow should match NetworkX.
-
-    Structure:
-      0 -> 1 -> 3
-      0 -> 2 -> 3
-      1 -> 2 cheap edge, 2 -> 1 expensive edge (creates potential for residual negative cycle adjustments)
-    """
-    G = nx.DiGraph()
-    G.add_edge(0, 1, capacity=2, weight=2)
-    G.add_edge(1, 3, capacity=2, weight=2)
-
-    G.add_edge(0, 2, capacity=2, weight=2)
-    G.add_edge(2, 3, capacity=2, weight=2)
-
-    G.add_edge(1, 2, capacity=2, weight=-5)
-    G.add_edge(2, 1, capacity=2, weight=10)
-    return G, 0, 3
-
-
-def build_graph_parallel_edges_multidigraph():
-    """
-    MultiDiGraph with parallel edges; your Karp preprocessing keeps min-weight per (u,v).
-    For cycle-cancelling, you likely convert residual MultiDiGraph to DiGraph for Karp,
-    so we test that the algorithm still matches NetworkX on the original simple DiGraph.
-
-    For fairness, we define both:
-      - MG: MultiDiGraph for your algorithm (if you support it)
-      - G_ref: DiGraph oracle used by NetworkX max_flow_min_cost
-    """
-    MG = nx.MultiDiGraph()
-    # parallel edges 0->1: choose cheaper (weight=1) effectively
-    MG.add_edge(0, 1, capacity=2, weight=7)
-    MG.add_edge(0, 1, capacity=2, weight=1)
-    MG.add_edge(1, 2, capacity=2, weight=1)
-
-    MG.add_edge(0, 2, capacity=2, weight=10)
-
-    # Reference simple graph: keep min weight per direction
-    G_ref = nx.DiGraph()
-    G_ref.add_edge(0, 1, capacity=2, weight=1)
-    G_ref.add_edge(1, 2, capacity=2, weight=1)
-    G_ref.add_edge(0, 2, capacity=2, weight=10)
-
-    return MG, G_ref, 0, 2
-
-
-# -------------------------
-# Tests
-# -------------------------
-
-
-def test_cycle_cancelling_matches_networkx_on_small_graph_1():
-    G, s, t = build_graph_small_1()
-
-    # Oracle: NetworkX min-cost max-flow for single-source/single-sink
-    flow_ref = nx.max_flow_min_cost(G, s, t, capacity="capacity", weight="weight")
-    cost_ref = nx.cost_of_flow(G, flow_ref, weight="weight")
-    val_ref = _flow_value(flow_ref, s)
-
-    flow_cc, cost_cc = nx.cycle_cancelling(
-        G.copy(), s, t, capacity="capacity", weight="weight"
-    )
-
-    assert cost_cc == cost_ref
-    assert _flow_value(flow_cc, s) == val_ref
-    _assert_flow_conservation(flow_cc, s, t)
-    _assert_capacity_constraints(G, flow_cc, capacity="capacity")
-
-
-def test_cycle_cancelling_matches_networkx_on_small_graph_2():
-    G, s, t = build_graph_small_2_with_negative_cycle_in_residual()
-
-    flow_ref = nx.max_flow_min_cost(G, s, t, capacity="capacity", weight="weight")
-    cost_ref = nx.cost_of_flow(G, flow_ref, weight="weight")
-    val_ref = _flow_value(flow_ref, s)
-
-    flow_cc, cost_cc = nx.cycle_cancelling(
-        G.copy(), s, t, capacity="capacity", weight="weight"
-    )
-
-    assert cost_cc == cost_ref
-    assert _flow_value(flow_cc, s) == val_ref
-    _assert_flow_conservation(flow_cc, s, t)
-    _assert_capacity_constraints(G, flow_cc, capacity="capacity")
-
-
-def test_cycle_cancelling_rejects_non_digraph():
-    UG = nx.Graph()
-    UG.add_edge(0, 1, capacity=1, weight=1)
-    with pytest.raises((TypeError, nx.NetworkXError)):
-        nx.cycle_cancelling(UG, 0, 1, capacity="capacity", weight="weight")
-
-
-def test_cycle_cancelling_raises_on_missing_capacity():
-    G = nx.DiGraph()
-    G.add_edge(0, 1, weight=1)  # missing capacity
-    with pytest.raises((ValueError, nx.NetworkXError, KeyError)):
-        nx.cycle_cancelling(G, 0, 1, capacity="capacity", weight="weight")
-
-
-def test_cycle_cancelling_raises_on_missing_weight():
-    G = nx.DiGraph()
-    G.add_edge(0, 1, capacity=1)  # missing weight
-    with pytest.raises((ValueError, nx.NetworkXError, KeyError)):
-        nx.cycle_cancelling(G, 0, 1, capacity="capacity", weight="weight")
-
-
-def test_cycle_cancelling_multidigraph_parallel_edges_matches_reference():
-    MG, G_ref, s, t = build_graph_parallel_edges_multidigraph()
-
-    # Oracle on the reference DiGraph
-    flow_ref = nx.max_flow_min_cost(G_ref, s, t, capacity="capacity", weight="weight")
-    cost_ref = nx.cost_of_flow(G_ref, flow_ref, weight="weight")
-    val_ref = _flow_value(flow_ref, s)
-
-    # Your algorithm run on MultiDiGraph (if supported). If not supported, change to expect TypeError.
-    flow_cc, cost_cc = nx.cycle_cancelling(
-        MG.copy(), s, t, capacity="capacity", weight="weight"
-    )
-
-    assert cost_cc == cost_ref
-    assert _flow_value(flow_cc, s) == val_ref
-
-
-def test_cycle_cancelling_random_small_fixed_seed_matches_networkx():
-    """
-    Small randomized regression test with fixed seed.
-    Keep it small to avoid flaky/slow tests in CI.
-    """
-    rng = random.Random(12345)
-
-    for _ in range(10):
-        n = 6
-        s, t = 0, n - 1
-        G = nx.DiGraph()
-
-        # Build a sparse-ish random digraph with guaranteed s->t path
-        for u in range(n):
-            for v in range(n):
-                if u == v:
-                    continue
-                if rng.random() < 0.25:
-                    G.add_edge(
-                        u,
-                        v,
-                        capacity=rng.randint(1, 5),
-                        weight=rng.randint(-3, 6),
-                    )
-
-        # Ensure at least one simple s->t chain
-        chain = [0, 2, 4, 5]
-        for u, v in zip(chain, chain[1:]):
-            if not G.has_edge(u, v):
-                G.add_edge(u, v, capacity=rng.randint(1, 5), weight=rng.randint(-3, 6))
-
-        flow_ref = nx.max_flow_min_cost(G, s, t, capacity="capacity", weight="weight")
-        cost_ref = nx.cost_of_flow(G, flow_ref, weight="weight")
-        val_ref = _flow_value(flow_ref, s)
-
-        flow_cc, cost_cc = nx.cycle_cancelling(
-            G.copy(), s, t, capacity="capacity", weight="weight"
+        flow_in = sum(flow_dict.get(u, {}).get(node, 0) for u in G.nodes())
+        flow_out = sum(flow_dict.get(node, {}).values())
+        assert flow_in == flow_out, (
+            f"Flow conservation violated at node {node}: in={flow_in}, out={flow_out}"
         )
 
-        assert cost_cc == cost_ref
-        assert _flow_value(flow_cc, s) == val_ref
-        _assert_flow_conservation(flow_cc, s, t)
-        _assert_capacity_constraints(G, flow_cc, capacity="capacity")
+
+def assert_capacity_respected(flow_dict, G, capacity="capacity"):
+    """Every edge flow must be >= 0 and <= its capacity."""
+    for u, v, data in G.edges(data=True):
+        f = flow_dict.get(u, {}).get(v, 0)
+        assert f >= 0, f"Negative flow on edge ({u},{v}): {f}"
+        assert f <= data[capacity], (
+            f"Flow {f} exceeds capacity {data[capacity]} on edge ({u},{v})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCycleCancellingInputValidation:
+    """Tests for parameter validation — all should raise before doing any work."""
+
+    def test_raises_on_undirected_graph(self):
+        G = nx.Graph()
+        G.add_edge(0, 1, capacity=5, weight=1)
+        with pytest.raises(TypeError, match="directed"):
+            nx.cycle_cancelling(G, 0, 1)
+
+    def test_raises_on_missing_source(self):
+        G = nx.DiGraph()
+        G.add_edge(0, 1, capacity=5, weight=1)
+        with pytest.raises(ValueError, match="Source"):
+            nx.cycle_cancelling(G, 99, 1)
+
+    def test_raises_on_missing_target(self):
+        G = nx.DiGraph()
+        G.add_edge(0, 1, capacity=5, weight=1)
+        with pytest.raises(ValueError, match="Target"):
+            nx.cycle_cancelling(G, 0, 99)
+
+    def test_raises_on_missing_capacity_attribute(self):
+        G = nx.DiGraph()
+        G.add_edge(0, 1, weight=1)  # no capacity
+        G.add_node(1)
+        with pytest.raises(ValueError, match="capacity"):
+            nx.cycle_cancelling(G, 0, 1)
+
+    def test_raises_on_missing_weight_attribute(self):
+        G = nx.DiGraph()
+        G.add_edge(0, 1, capacity=5)  # no weight
+        G.add_node(1)
+        with pytest.raises(ValueError, match="weight"):
+            nx.cycle_cancelling(G, 0, 1)
+
+    def test_raises_on_negative_capacity(self):
+        G = nx.DiGraph()
+        G.add_edge(0, 1, capacity=-1, weight=1)
+        G.add_node(1)
+        with pytest.raises(ValueError, match="capacity"):
+            nx.cycle_cancelling(G, 0, 1)
+
+    def test_raises_on_non_callable_negative_cycle_func(self):
+        G = nx.DiGraph()
+        G.add_edge(0, 1, capacity=5, weight=1)
+        with pytest.raises(nx.NetworkXError, match="callable"):
+            nx.cycle_cancelling(G, 0, 1, negative_cycle_func="not_a_function")
+
+
+class TestCycleCancellingReturnStructure:
+    """Tests that verify the shape and type of what is returned."""
+
+    def test_returns_tuple_of_two(self):
+        G = nx.DiGraph()
+        make_edge(G, 0, 1, capacity=10, weight=2)
+        result = nx.cycle_cancelling(G, 0, 1)
+        assert isinstance(result, tuple) and len(result) == 2
+
+    def test_flow_dict_is_dict(self):
+        G = nx.DiGraph()
+        make_edge(G, 0, 1, capacity=10, weight=2)
+        flow_dict, _ = nx.cycle_cancelling(G, 0, 1)
+        assert isinstance(flow_dict, dict)
+
+    def test_min_cost_is_numeric(self):
+        G = nx.DiGraph()
+        make_edge(G, 0, 1, capacity=10, weight=2)
+        _, cost = nx.cycle_cancelling(G, 0, 1)
+        assert isinstance(cost, int | float)
+
+    def test_min_cost_non_negative(self):
+        """With non-negative weights, min cost must be >= 0."""
+        G = nx.DiGraph()
+        make_edge(G, 0, 1, capacity=5, weight=3)
+        make_edge(G, 0, 1, capacity=3, weight=7)
+        _, cost = nx.cycle_cancelling(G, 0, 1)
+        assert cost >= 0
+
+
+class TestCycleCancellingFlowProperties:
+    """Tests that verify flow conservation and capacity constraints."""
+
+    def test_flow_conservation_simple(self):
+        """On a simple path graph, flow is conserved at every internal node."""
+        G = nx.DiGraph()
+        make_edge(G, 0, 1, capacity=10, weight=1)
+        make_edge(G, 1, 2, capacity=10, weight=1)
+        flow_dict, _ = nx.cycle_cancelling(G, 0, 2)
+        assert_flow_conservation(flow_dict, G, 0, 2)
+
+    def test_capacity_respected_simple(self):
+        G = nx.DiGraph()
+        make_edge(G, 0, 1, capacity=5, weight=2)
+        flow_dict, _ = nx.cycle_cancelling(G, 0, 1)
+        assert_capacity_respected(flow_dict, G)
+
+    def test_flow_conservation_diamond(self):
+        """Diamond graph: two parallel paths from s to t."""
+        G = nx.DiGraph()
+        make_edge(G, "s", "a", capacity=4, weight=1)
+        make_edge(G, "s", "b", capacity=6, weight=2)
+        make_edge(G, "a", "t", capacity=4, weight=1)
+        make_edge(G, "b", "t", capacity=6, weight=2)
+        flow_dict, _ = nx.cycle_cancelling(G, "s", "t")
+        assert_flow_conservation(flow_dict, G, "s", "t")
+        assert_capacity_respected(flow_dict, G)
+
+    def test_flow_conservation_with_internal_nodes(self):
+        """Multi-hop path: every intermediate node must conserve flow."""
+        G = nx.DiGraph()
+        for u, v in [(0, 1), (1, 2), (2, 3), (3, 4)]:
+            make_edge(G, u, v, capacity=8, weight=1)
+        flow_dict, _ = nx.cycle_cancelling(G, 0, 4)
+        assert_flow_conservation(flow_dict, G, 0, 4)
+        assert_capacity_respected(flow_dict, G)
+
+
+class TestCycleCancellingCostCorrectness:
+    """Tests that verify the minimum cost is computed correctly."""
+
+    def test_single_edge_cost(self):
+        """
+        Single edge s→t with capacity 5, weight 3.
+        Max flow = 5, min cost = 5 * 3 = 15.
+        """
+        G = nx.DiGraph()
+        make_edge(G, "s", "t", capacity=5, weight=3)
+        flow_dict, cost = nx.cycle_cancelling(G, "s", "t")
+        assert cost == 15
+        assert flow_dict["s"]["t"] == 5
+
+    def test_two_parallel_paths_picks_cheaper(self):
+        """
+        s→a→t (weight 1+1=2 per unit) vs s→b→t (weight 10+10=20 per unit).
+        Both have capacity 5. Algorithm must route as much as possible through cheap path.
+        Min cost flow = 5*2 + 5*20 = 110  (max flow uses both).
+        """
+        G = nx.DiGraph()
+        make_edge(G, "s", "a", capacity=5, weight=1)
+        make_edge(G, "a", "t", capacity=5, weight=1)
+        make_edge(G, "s", "b", capacity=5, weight=10)
+        make_edge(G, "b", "t", capacity=5, weight=10)
+        _, cost = nx.cycle_cancelling(G, "s", "t")
+        # Total flow = 10 (max), cheapest split: all 5 via a, all 5 via b
+        assert cost == 5 * 2 + 5 * 20
+
+    def test_bottleneck_capacity_limits_flow(self):
+        """
+        s→m (cap=2) → t (cap=10). Bottleneck is 2.
+        Cost = 2 * (weight_sm + weight_mt).
+        """
+        G = nx.DiGraph()
+        make_edge(G, "s", "m", capacity=2, weight=3)
+        make_edge(G, "m", "t", capacity=10, weight=4)
+        flow_dict, cost = nx.cycle_cancelling(G, "s", "t")
+        assert flow_dict.get("s", {}).get("m", 0) == 2
+        assert cost == 2 * (3 + 4)
+
+    def test_zero_capacity_edge_carries_no_flow(self):
+        """An edge with capacity=0 should carry 0 flow."""
+        G = nx.DiGraph()
+        make_edge(G, "s", "a", capacity=0, weight=1)
+        make_edge(G, "s", "t", capacity=5, weight=2)
+        flow_dict, cost = nx.cycle_cancelling(G, "s", "t")
+        assert flow_dict.get("s", {}).get("a", 0) == 0
+        assert cost == 5 * 2
+
+    def test_cost_equals_sum_of_flow_times_weight(self):
+        """Verify returned cost matches manually computed flow * weight sum."""
+        G = nx.DiGraph()
+        make_edge(G, 0, 1, capacity=3, weight=2)
+        make_edge(G, 0, 2, capacity=4, weight=5)
+        make_edge(G, 1, 3, capacity=3, weight=1)
+        make_edge(G, 2, 3, capacity=4, weight=2)
+        flow_dict, cost = nx.cycle_cancelling(G, 0, 3)
+        manual_cost = sum(
+            flow_dict.get(u, {}).get(v, 0) * G[u][v]["weight"]
+            for u, v in G.edges()
+            if flow_dict.get(u, {}).get(v, 0) > 0
+        )
+        assert cost == manual_cost
+
+
+class TestCycleCancellingKnownAnswers:
+    """
+    Tests against textbook examples with known optimal costs.
+    These are the most important correctness tests for a contribution.
+    """
+
+    def test_simple_known_optimal(self):
+        """
+        s→a (cap=10, w=2), a→t (cap=10, w=3).
+        Only path: cost = 10 * (2+3) = 50.
+        """
+        G = nx.DiGraph()
+        make_edge(G, "s", "a", capacity=10, weight=2)
+        make_edge(G, "a", "t", capacity=10, weight=3)
+        _, cost = nx.cycle_cancelling(G, "s", "t")
+        assert cost == 50
+
+    def test_two_node_graph(self):
+        """Minimal graph: just s and t connected by one edge."""
+        G = nx.DiGraph()
+        make_edge(G, "s", "t", capacity=7, weight=4)
+        flow_dict, cost = nx.cycle_cancelling(G, "s", "t")
+        assert flow_dict["s"]["t"] == 7
+        assert cost == 28
+
+    @pytest.mark.parametrize("cap,w", [(1, 1), (5, 3), (10, 7), (100, 2)])
+    def test_single_edge_parametrized(self, cap, w):
+        """Single edge cost always equals capacity * weight."""
+        G = nx.DiGraph()
+        make_edge(G, 0, 1, capacity=cap, weight=w)
+        _, cost = nx.cycle_cancelling(G, 0, 1)
+        assert cost == cap * w
+
+
+class TestCycleCancellingCustomParameters:
+    """Tests for optional parameters: weight, capacity, negative_cycle_func."""
+
+    def test_custom_weight_attribute(self):
+        """cycle_cancelling respects a custom weight attribute name."""
+        G = nx.DiGraph()
+        G.add_edge(0, 1, capacity=5, cost=3)
+        _, cost = nx.cycle_cancelling(G, 0, 1, weight="cost")
+        assert cost == 15
+
+    def test_custom_capacity_attribute(self):
+        """cycle_cancelling respects a custom capacity attribute name."""
+        G = nx.DiGraph()
+        G.add_edge(0, 1, cap=4, weight=2)
+        _, cost = nx.cycle_cancelling(G, 0, 1, capacity="cap")
+        assert cost == 8
+
+    def test_custom_negative_cycle_func_is_called(self):
+        """A custom negative_cycle_func is actually used when provided."""
+        called = {"count": 0}
+        from karp import karp as real_karp
+
+        def tracking_karp(G, *args, **kwargs):
+            called["count"] += 1
+            return real_karp(G, *args, **kwargs)
+
+        G = nx.DiGraph()
+        make_edge(G, 0, 1, capacity=5, weight=1)
+        nx.cycle_cancelling(G, 0, 1, negative_cycle_func=tracking_karp)
+        assert called["count"] >= 1
+
+    def test_default_negative_cycle_func_is_karp(self):
+        """When no negative_cycle_func is provided, karp is used by default."""
+        G = nx.DiGraph()
+        make_edge(G, 0, 1, capacity=3, weight=2)
+        # Should not raise — karp is the default and handles this graph
+        flow_dict, cost = nx.cycle_cancelling(G, 0, 1)
+        assert cost == 6
+
+
+class TestCycleCancellingEdgeCases:
+    """Edge cases and boundary conditions."""
+
+    def test_large_capacity_single_edge(self):
+        """Large capacity should not cause overflow or correctness issues."""
+        G = nx.DiGraph()
+        make_edge(G, 0, 1, capacity=10_000, weight=1)
+        _, cost = nx.cycle_cancelling(G, 0, 1)
+        assert cost == 10_000
+
+    def test_string_node_labels(self):
+        """Graph with string node labels works correctly."""
+        G = nx.DiGraph()
+        make_edge(G, "source", "sink", capacity=5, weight=3)
+        flow_dict, cost = nx.cycle_cancelling(G, "source", "sink")
+        assert cost == 15
+
+    def test_integer_and_float_weights(self):
+        """Float weights are handled without error."""
+        G = nx.DiGraph()
+        G.add_edge(0, 1, capacity=4, weight=1.5)
+        _, cost = nx.cycle_cancelling(G, 0, 1)
+        assert math.isclose(cost, 6.0, rel_tol=1e-9)


### PR DESCRIPTION
Folllowing your  team comment on PR #8542, we are splitting the PR into 2 differents PRs.
We changed the name of the karp function to your proposed name: minimum_weight_mean_cycle

What is being proposed?
Karp's algorithm finds the minimum mean weight cycle in a directed weighted graph. Given a digraph G=(V,E)
G=(V,E) with edge weights, it returns the cycle whose average edge weight is minimized, using a dynamic programming formulation that runs in O(nm) time, where n is the number of nodes and m the number of edges.

Karp's algorithm is similarly a classical result in graph theory with broad applications beyond min-cost flow, including performance analysis of circuits, scheduling with ratio objectives, and mean-payoff games. It is a well-known algorithm taught in algorithms courses worldwide and is notably absent from NetworkX's current cycle-related functionality.
