### PR TITLE
PERF: Implement array-based fast path for unweighted betweenness centrality

### DIFF
--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -429,6 +429,7 @@ def _single_source_shortest_path_basic(G, s):
                 P[w].append(v)  # predecessors
     return S, P, sigma, D
 
+
 def _fast_unweighted_betweenness(G, nodes):
     """
     Optimized array-based betweenness centrality for unweighted graphs.
@@ -439,7 +440,7 @@ def _fast_unweighted_betweenness(G, nodes):
     V = list(G.nodes())
     n = len(V)
     node_to_idx = {node: i for i, node in enumerate(V)}
-    
+
     # Compile step: Build array-based adjacency list
     adj = [[] for _ in range(n)]
     for u, v in G.edges():
@@ -451,7 +452,7 @@ def _fast_unweighted_betweenness(G, nodes):
     sources = [node_to_idx[n] for n in nodes]
 
     cb = [0.0] * n
-    
+
     # Execution step: Brandes' algorithm via fast array indexing
     for s in sources:
         S = []
@@ -461,7 +462,7 @@ def _fast_unweighted_betweenness(G, nodes):
         D = [-1] * n
         D[s] = 0
         Q = deque([s])
-        
+
         while Q:
             v = Q.popleft()
             S.append(v)
@@ -472,7 +473,7 @@ def _fast_unweighted_betweenness(G, nodes):
                 if D[w] == D[v] + 1:
                     sigma[w] += sigma[v]
                     P[w].append(v)
-        
+
         delta = [0.0] * n
         while S:
             w = S.pop()
@@ -484,6 +485,7 @@ def _fast_unweighted_betweenness(G, nodes):
     # Translation step: Map results back to original node IDs
     betweenness = {V[i]: cb[i] for i in range(n)}
     return betweenness
+
 
 def _single_source_dijkstra_path_basic(G, s, weight):
     weight = _weight_function(G, weight)


### PR DESCRIPTION
I was looking into the performance of `betweenness_centrality` on larger unweighted graphs and noticed that an enormous amount of time is spent on dictionary lookups (`G[u]`) during the BFS traversal in Brandes' algorithm. 

I've added a "fast path" specifically for the most common use case: unweighted graphs where `endpoints=False`. 

Before running the main loop, it temporarily maps the graph's nodes to integers and builds a standard Python list-of-lists adjacency array. This allows the inner BFS loop to use direct array indexing (`adj[v]`) instead of hitting the dictionary hash map over and over. At the end, it translates the integer indices back to the original node IDs.

By bypassing the hashing overhead, this pure-Python structural change yields a considerable speedup (shaving about 4 seconds off a 14-second run on the Drug Interaction network) without needing C-extensions. 

I made sure that weighted graphs or calls that need endpoint calculations strictly fall back to the existing dictionary-based logic. It is 100% backward compatible and all tests pass perfectly.

Ran `asv continuous main perf/array-based-betweenness -b betweenness` locally (Python 3.12):

| Graph | `main` (9bf80928) | `PR` (dbeff95f) | Speedup |
| :--- | :--- | :--- | :--- |
| Erdos Renyi (100, 0.1) | 15.6 ± 0.2ms | 10.4 ± 0.06ms | **~1.50x** |
| Erdos Renyi (100, 0.5) | 44.6 ± 0.2ms | 38.6 ± 0.8ms | **~1.15x** |
| Erdos Renyi (100, 0.9) | 55.4 ± 0.7ms | 50.2 ± 0.2ms | **~1.10x** |
| Drug Interaction network | 14.1 ± 0.09s | 10.1 ± 0.02s | **~1.40x** |

- [x] I have formatted the code using `pre-commit run --all-files`
- [x] I have run the test suite using `pytest`
- [x] I have run the ASV benchmarks