### PR TITLE
DOC: Remove Good First Issue references from docs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,10 +19,6 @@ NetworkX
     :target: https://pypi.python.org/pypi/networkx
 
 .. image::
-    https://img.shields.io/github/labels/networkx/networkx/good%20first%20issue?color=green&label=contribute
-    :target: https://github.com/networkx/networkx/contribute
-
-.. image::
     https://insights.linuxfoundation.org/api/badge/health-score?project=networkx
     :target: https://insights.linuxfoundation.org/project/networkx
 

--- a/doc/developer/new_contributor_faq.rst
+++ b/doc/developer/new_contributor_faq.rst
@@ -25,15 +25,9 @@ interests!
 That said, a few places to check for ideas on where to get started:
 
  - `The issue tracker <https://github.com/networkx/networkx/issues>`_ lists
-   known bugs and feature requests. Of particular interest for first-time
-   contributors are issues that have been tagged with the `Good First Issue`_
-   or `Sprint`_ labels.
+   known bugs and feature requests.
  - The `Algorithms discussion`_ includes a listing of algorithms that users
    would like to have but that are not yet included in NetworkX.
-
-.. _Good First Issue: https://github.com/networkx/networkx/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Issue%22
-
-.. _Sprint: https://github.com/networkx/networkx/issues?q=is%3Aopen+is%3Aissue+label%3ASprint
 
 .. _Algorithms discussion: https://github.com/networkx/networkx/discussions/categories/algorithms
 


### PR DESCRIPTION
This removes references to "Good First Issue", we don't have that many open and we don't really groom them that well.
This also seems to attract lots of AI/LLM generated content.

I removed "Sprint" too as we don't have any issue tagged as that.