### PR TITLE
Update maximal_independent_set docstring

### DIFF
--- a/networkx/algorithms/mis.py
+++ b/networkx/algorithms/mis.py
@@ -90,6 +90,12 @@ def maximal_independent_set(G, nodes=None, seed=None):
     Notes
     -----
     This algorithm does not solve the maximum independent set problem.
+
+    See Also
+    --------
+    :func:`~networkx.algorithms.approximation.clique.maximum_independent_set` :
+        Algorithm for approximating the maximum independent set, i.e. a
+        maximal independent set of maximum cardinality.
     """
     if not nodes:
         nodes = {seed.choice(list(G))}


### PR DESCRIPTION
Inspired by/alternative to #8435 and (arguably) closes #5568

My main goal was to improve the examples section of the docstring to really hammer on the difference between a *maximal* independent set and the *maximum* independent set. The tack I took was to highlight front-and-center that graphs very often have multiple maximal independent sets, and include the recipe for finding all of them (i.e. enumerating cliques in the complement graph) in the docstring. The main difference with #8435 is that the focus is kept on *maximal* independent sets inside the docstring examples. I did also add a See Also link the the maximum independent set approximation, with additional context for how it relates to maximal independent sets.

I think there's still plenty of opportunity to improve the docs w.r.t independent sets and the relationship with cliques, but IMO this is enough to at least address some of the maximal/maximum confusion and close #5568