### PR TITLE
Added example for `SpanningTreeIterator` to find min spanning trees

### DIFF
--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -992,38 +992,34 @@ class SpanningTreeIterator:
 
     Examples
     ---------
-    We can use `SpanningTreeIterator` to find all minimum or maximum spanning
-    trees of a graph. For example, consider the following graph:
+    `SpanningTreeIterator` can be used to find all minimum or maximum spanning
+    trees of a graph:
 
+    >>> import itertools
     >>> G = nx.cycle_graph(3)
-    >>> min_cost = None
-    >>> min_spanning_trees = []
-    >>> for tree in nx.SpanningTreeIterator(G):
-    ...     tree_cost = tree.size(weight="weight")
-    ...     if min_cost is None:
-    ...         min_cost = tree_cost
-    ...     elif tree_cost > min_cost:
-    ...         break
-    ...     min_spanning_trees.append(tree)
-    >>> sorted(t.edges for t in min_spanning_trees)
+    >>> trees_by_weight = itertools.groupby(
+    ...     nx.SpanningTreeIterator(G), key=lambda t: t.size(weight="weight")
+    ... )
+    >>> min_wt, min_wt_trees = next(trees_by_weight)
+    >>> min_wt
+    2.0
+    >>> sorted(t.edges for t in min_wt_trees)
     [EdgeView([(0, 1), (0, 2)]), EdgeView([(0, 2), (1, 2)]), EdgeView([(0, 1), (1, 2)])]
 
-    Another example with only one possible maximum spanning tree:
+    The ``minimum=False`` option yields trees by weight in descending order:
 
     >>> G = nx.Graph()
     >>> G.add_edge("A", "B", weight=3)
     >>> G.add_edge("A", "C", weight=2)
     >>> G.add_edge("B", "C", weight=1)
-    >>> max_cost = None
-    >>> max_spanning_trees = []
-    >>> for tree in nx.SpanningTreeIterator(G, minimum=False):
-    ...     tree_cost = tree.size(weight="weight")
-    ...     if max_cost is None:
-    ...         max_cost = tree_cost
-    ...     elif tree_cost < max_cost:
-    ...         break
-    ...     max_spanning_trees.append(tree)
-    >>> sorted(t.edges for t in max_spanning_trees)
+    >>> trees_by_weight = itertools.groupby(
+    ...     nx.SpanningTreeIterator(G, minimum=False),
+    ...     key=lambda t: t.size(weight="weight"),
+    ... )
+    >>> max_wt, max_wt_trees = next(trees_by_weight)
+    >>> max_wt
+    5.0
+    >>> sorted(t.edges for t in max_wt_trees)
     [EdgeView([('A', 'B'), ('A', 'C')])]
 
     References


### PR DESCRIPTION
As mentioned in #7985, `SpanningTreeIterator` can be used to find all minimum or maximum spanning trees as the output of the iterator is sorted based on size.

Added example on how to use `SpanningTreeIterator` to find all minimum spanning trees.
