### PR TITLE
Change maximal_independent_set to return set instead of list

### DIFF
--- a/networkx/algorithms/mis.py
+++ b/networkx/algorithms/mis.py
@@ -35,8 +35,8 @@ def maximal_independent_set(G, nodes=None, seed=None):
 
     Returns
     -------
-    indep_nodes : list
-       List of nodes that are part of a maximal independent set.
+    indep_nodes : set
+       Set of nodes that are part of a maximal independent set.
 
     Raises
     ------
@@ -106,10 +106,10 @@ def maximal_independent_set(G, nodes=None, seed=None):
     neighbors = set.union(*[set(G.adj[v]) for v in nodes])
     if set.intersection(neighbors, nodes):
         raise nx.NetworkXUnfeasible(f"{nodes} is not an independent set of G")
-    indep_nodes = list(nodes)
+    indep_nodes = set(nodes)
     available_nodes = set(G.nodes()).difference(neighbors.union(nodes))
     while available_nodes:
         node = seed.choice(list(available_nodes))
-        indep_nodes.append(node)
+        indep_nodes.add(node)
         available_nodes.difference_update(list(G.adj[node]) + [node])
     return indep_nodes

--- a/networkx/algorithms/tests/test_mis.py
+++ b/networkx/algorithms/tests/test_mis.py
@@ -12,13 +12,13 @@ import networkx as nx
 
 def test_random_seed():
     G = nx.empty_graph(5)
-    assert nx.maximal_independent_set(G, seed=1) == [1, 0, 3, 2, 4]
+    assert nx.maximal_independent_set(G, seed=1) == {1, 0, 3, 2, 4}
 
 
 @pytest.mark.parametrize("graph", [nx.complete_graph(5), nx.complete_graph(55)])
 def test_K5(graph):
     """Maximal independent set for complete graphs"""
-    assert all(nx.maximal_independent_set(graph, [n]) == [n] for n in graph)
+    assert all(nx.maximal_independent_set(graph, [n]) == {n} for n in graph)
 
 
 def test_exceptions():


### PR DESCRIPTION
## Summary
- Fix #8554 
- Changed `maximal_independent_set()` return type from `list` to `set`
- Updated tests to expect `set` instead of `list`

All tests pass, including:
- `test_mis.py` (7 tests)
- Coloring module tests (17 tests) - uses internal `_maximal_independent_set`, unaffected