### PR TITLE
Gallery: split simple graph example into two separate ones

### DIFF
--- a/examples/basic/plot_basic_directed.py
+++ b/examples/basic/plot_basic_directed.py
@@ -1,0 +1,34 @@
+"""
+==============
+Directed Graph
+==============
+
+Basic visualization of a directed graph with manual layout.
+"""
+
+import networkx as nx
+import matplotlib.pyplot as plt
+
+G = nx.DiGraph([(0, 3), (1, 3), (2, 4), (3, 5), (3, 6), (4, 6), (5, 6)])
+
+options = {
+    "font_size": 36,
+    "node_size": 3000,
+    "node_color": "white",
+    "edgecolors": "black",
+    "linewidths": 5,
+    "width": 5,
+}
+
+# group nodes by column
+left_nodes = [0, 1, 2]
+middle_nodes = [3, 4]
+right_nodes = [5, 6]
+
+# set the position according to column (x-coord)
+pos = {n: (0, i) for i, n in enumerate(left_nodes)}
+pos.update({n: (1, i + 0.5) for i, n in enumerate(middle_nodes)})
+pos.update({n: (2, i + 0.5) for i, n in enumerate(right_nodes)})
+
+nx.draw(G, pos, with_labels=True, **options)
+plt.show()

--- a/examples/basic/plot_simple_graph.py
+++ b/examples/basic/plot_simple_graph.py
@@ -23,26 +23,4 @@ options = {
     "width": 5,
 }
 nx.draw(G, pos, with_labels=True, **options)
-
-# %%
-# A directed graph
-
-G = nx.DiGraph([(0, 3), (1, 3), (2, 4), (3, 5), (3, 6), (4, 6), (5, 6)])
-
-# group nodes by column
-left_nodes = [0, 1, 2]
-middle_nodes = [3, 4]
-right_nodes = [5, 6]
-
-# set the position according to column (x-coord)
-pos = {n: (0, i) for i, n in enumerate(left_nodes)}
-pos.update({n: (1, i + 0.5) for i, n in enumerate(middle_nodes)})
-pos.update({n: (2, i + 0.5) for i, n in enumerate(right_nodes)})
-
-nx.draw_networkx(G, pos, **options)
-
-# Set margins for the axes so that nodes aren't clipped
-ax = plt.gca()
-ax.margins(0.20)
-plt.axis("off")
 plt.show()


### PR DESCRIPTION
The main motivation of this PR is to split the [plot_simple_graph](https://networkx.org/documentation/latest/auto_examples/basic/plot_simple_graph.html) example into two separate examples. The `plot_simple_graph` example currently has two separate visualization examples inside it: one for a simple graph (the one in the thumbnail) and a directed example. Both of these are nice visualizations and highlight features of visualizing both directed and undirected graphs. *However* as sphinx-gallery chooses the first image in an example as the thumbnail by default, the directed sample gets buried a bit.

By pulling the directed example into it's own `plot_basic_directed` example, it gets its own thumbnail in the gallery and improves discoverability.

The main change here is the split into two examples, but there are two other minor changes:
 - Condense the construction of the example graph (5f982cc), replacing multiple `add_edge` calls with passing an edgelist directly to the `Graph` constructor
 - Replacing `draw_networkx` with `draw`, which gives better defaults for the axis parameters (i.e. wider margins, turns off the axis bounding box) and eliminates the need of setting these things manually.

Note that this PR does not deal with `display` - I have been working through that separately (draft PR incoming) and will summarize my impressions there.