### PR TITLE
Gallery: Fix and update `basic_properties` example

### DIFF
--- a/examples/basic/plot_properties.py
+++ b/examples/basic/plot_properties.py
@@ -37,11 +37,13 @@ pprint({pl: num // 2 for pl, num in path_length_distribution.items()})
 
 # %%
 # Basic distance measures. In some cases it is possible to pass in pre-computed
-# eccesntricity values to speed up subsequent computations.
+# eccentricity values to speed up subsequent computations.
 # Re-using computed values may significantly improve computation times for
 # larger graphs
 
-print(f"\neccentricity: {(eccentricity := nx.eccentricity(G))}")
+
+eccentricity = nx.eccentricity(G)
+print(f"\neccentricity: {eccentricity}")
 print(f"radius: {nx.radius(G, e=eccentricity)}")
 print(f"diameter: {nx.diameter(G, e=eccentricity)}")
 print(f"center: {nx.center(G, e=eccentricity)}")


### PR DESCRIPTION
Several proposed improvements/fixes to the `plot_basic_properties` gallery example. The individual changes are mostly encapsulated in the individual commits:
 - c313b3d : replaces the "custom" for-loop recipe that repeatedly calls `nx.single_source_shortest_path_length` (and constructs a custom list-of-lists of path lengths) with `all_pairs_shortest_path_length`.
 - 1a212c1 : related to the above - it turns out the average shortest path length (as computed from the custom list-of-lists) was incorrect! I've replaced it with `nx.average_shortest_path_length` mostly to highlight the existence of that function; though it may be worth showing how to compute it manually from the all-pairs-shortest-path-length dict that has already been computed.
 - c2b7e78 : Another replacement of a custom for-loop, this time for computing the distribution of shortest-path lengths. Replaces the for-loop with a recipe using `itertools` and `Counter`, and also adds some explanatory text re: the fact that each path is counted twice.
 - f88f405 : Adds the relatively new `nx.describe` - this gallery example seems like a perfect place to highlight this functionality!
 - and finally, 8defe9a proposes highlighting the feature of `distance_measures` where pre-computed eccentricity can be used to improve computation times for the other measures. My motivation here is mostly to highlight that this feature exists; however, I'd certainly understood if others thought it was too much nuance for a simple example. Happy to back this (or any other change deemed contentions) out!