### PR TITLE
Proposal: Add density to `nx.describe` defaults.

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -1503,6 +1503,7 @@ def describe(G, describe_hook=None):
     Bipartite                      : True
     Average degree (min, max)      : 1.60 (1, 2)
     Number of connected components : 1
+    Density                        : 0.4
 
     >>> def augment_description(G):
     ...     return {"Average Shortest Path Length": nx.average_shortest_path_length(G)}
@@ -1515,6 +1516,7 @@ def describe(G, describe_hook=None):
     Bipartite                      : True
     Average degree (min, max)      : 1.60 (1, 2)
     Number of connected components : 1
+    Density                        : 0.4
     Average Shortest Path Length   : 2.0
 
     >>> G.name = "Path Graph of 5 nodes"
@@ -1528,6 +1530,7 @@ def describe(G, describe_hook=None):
     Bipartite                      : True
     Average degree (min, max)      : 1.60 (1, 2)
     Number of connected components : 1
+    Density                        : 0.4
 
     """
     info_dict = _create_describe_info_dict(G)
@@ -1572,4 +1575,6 @@ def _create_describe_info_dict(G):
         )
     else:
         info["Number of connected components"] = nx.number_connected_components(G)
+    # Add density after number of components
+    info["Density"] = nx.density(G)
     return info

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -32,6 +32,7 @@ class TestFunction:
         assert info_dict["Number of edges"] == 5
         assert info_dict["Average degree (min, max)"] == "2.00 (0, 4)"
         assert info_dict["Number of connected components"] == 2
+        assert info_dict["Density"] == 0.5
 
     def test_nodes(self):
         assert nodes_equal(self.G.nodes(), list(nx.nodes(self.G)))


### PR DESCRIPTION
I propose to add `nx.density` to the list of *default* properties reported in `nx.describe`. Of course, it's already possible to get the density by explicitly passing it in via the property hooks. I think it's worth being included as a default property though: it's relatively cheap to compute and provides valuable information. For example, if you were a user considering converting to an adjacency matrix, you might look at the density to quickly decide whether a sparse or dense representation made more sense.

Anyways - this is purely subjective; happy to close if a lighter `describe` output is preferred!