### PR TITLE
Gallery: Update basic read/write example

### DIFF
--- a/examples/basic/plot_read_write.py
+++ b/examples/basic/plot_read_write.py
@@ -21,8 +21,17 @@ nx.write_edgelist(G, path=fh, delimiter=":")
 print(fh.getvalue().decode())
 # read edgelist from file
 fh.seek(0)
-H = nx.read_edgelist(path=fh, delimiter=":")
 
-pos = nx.spring_layout(H, seed=200)
-nx.draw(H, pos)
+# %%
+# Note that the original graph `G` had tuples as nodes. In order to recover
+# the original node type, the data read from file must be properly interpreted
+# using the `nodetype` kwarg
+H = nx.read_edgelist(
+    path=fh,
+    # Convert from a string back to a tuple-of-int
+    nodetype=lambda s: tuple(int(v) for v in s[1:-1].split(",")),
+    delimiter=":",
+)
+
+nx.draw(H, pos={n: n for n in H})
 plt.show()


### PR DESCRIPTION
I hit an interesting corner in this one...

My original motivation was simply to replace the creation of the dummy-file by using `io.BytesIO` instead. This was done in 9cba679 ; however, if there's a preference for using tempfile instead (to preserve the `with open(...` part of the example) I'd be okay with that[^1].

I also thought it'd be worthwhile to use the nodes of the grid graph (which are tuples representing 2D coordinates) directly as the layout rather than computing a spring layout. Doing so ended up dredging up one of the most common gotchas with roundtripping Python objects to disk: serializing/deserializing data (i.e. stringifying/destringifying). While it makes the example a bit more complicated, I *do* think it is worthwhile to tackle it in the example as this crops up quite frequently with essentially all read/write methods.

So - fb54943 includes both the switch from `spring_layout` to using the grid-graph nodes as the layout, as well as the added `nodetype` usage to convert the data read in from file back into 2-tuples.

[^1]: This is one of my biggest pet-peeves with using `io` in documentation illustrating filehandling, as the buffers don't work with `open`, so the example code ends up looking different than it would in practice.