### PR TITLE
Add examples to `degree_histogram` docstring

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -181,7 +181,7 @@ def degree_histogram(G):
     >>> Counter(d for _, d in G.degree)
     Counter({1: 5, 5: 1})
     """
-    counts = Counter(d for _, d in G.degree())
+    counts = Counter(d for _, d in G.degree)
     return [counts.get(i, 0) for i in range(max(counts) + 1 if counts else 0)]
 
 


### PR DESCRIPTION
A few examples to highlight various uses of degree histogram, and an example demonstrating using `Counter` directly for a "sparse" representation of the degree frequency distribution.