### PR TITLE
MAINT: Minor readability tweaks to pagerank

### DIFF
--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -459,7 +459,8 @@ def _pagerank_scipy(
     nodelist = list(G)
     A = nx.to_scipy_sparse_array(G, nodelist=nodelist, weight=weight, dtype=float)
     S = A.sum(axis=1)
-    S[S != 0] = 1.0 / S[S != 0]
+    dangling_nodes = S == 0
+    S[~dangling_nodes] = 1.0 / S[~dangling_nodes]
     Q = sp.sparse.dia_array((S, 0), shape=A.shape).tocsr()
     A = Q @ A
 
@@ -485,13 +486,12 @@ def _pagerank_scipy(
         # Convert the dangling dictionary into an array in nodelist order
         dangling_weights = np.array([dangling.get(n, 0) for n in nodelist], dtype=float)
         dangling_weights /= dangling_weights.sum()
-    is_dangling = np.where(S == 0)[0]
 
     # power iteration: make up to max_iter iterations
     for _ in range(max_iter):
         xlast = x
         x = (
-            alpha * (x @ A + np.sum(x[is_dangling]) * dangling_weights)
+            alpha * (x @ A + np.sum(x[dangling_nodes]) * dangling_weights)
             + (1 - alpha) * p
         )
         # check convergence, l1 norm


### PR DESCRIPTION
I spent the afternoon reading/thinking about pagerank (specifically as a target for `singledispatch`) and as a result ended up reading through the code several times.

Here are two minor things I came across in my reading:
 - 65d1ce3 : remove an unnecessary `.T` of a 1-D array resulting from summing along an axis
 - b5c0efa : The indices (i.e. row/col) corresponding to "dangling" nodes is computed multiple times independently. This commit consolidates those masking operations into a single mask (called `dangling_nodes`) and reuses the result.

The first change should be unobjectionable (almost certainly a remnant of sparse matrix); the second is subjective - happy to back it out if it's too much churn!