### PR TITLE
Fix all_node_cuts: correct Even-Tarjan reduction for Kanevsky's algorithm

### DIFF
--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -2,7 +2,6 @@
 Kanevsky all minimum node k cutsets algorithm.
 """
 
-import copy
 from collections import defaultdict
 from operator import itemgetter
 
@@ -93,7 +92,6 @@ def all_node_cuts(G, k=None, flow_func=None):
 
     # Address some corner cases first.
     # For complete Graphs
-
     if nx.density(G) == 1:
         yield from ()
         return
@@ -106,9 +104,15 @@ def all_node_cuts(G, k=None, flow_func=None):
     H = build_auxiliary_node_connectivity(G)
     H_nodes = H.nodes  # for speed
     mapping = H.graph["mapping"]
-    # Keep a copy of original predecessors, H will be modified later.
-    # Shallow copy is enough.
-    original_H_pred = copy.copy(H._pred)
+    # The Even-Tarjan reduction requires infinite capacity on external
+    # edges (edges between different original nodes) and capacity 1 on
+    # internal edges (vA -> vB). build_auxiliary_node_connectivity sets
+    # capacity=1 on all edges, which is sufficient for computing the
+    # node connectivity value but not for Kanevsky's algorithm, which
+    # depends on the residual graph structure.
+    for u, w, d in H.edges(data=True):
+        if H_nodes[u]["id"] != H_nodes[w]["id"]:
+            d["capacity"] = float("inf")
     R = build_residual_network(H, "capacity")
     kwargs = {"capacity": "capacity", "residual": R}
     # Define default flow function
@@ -135,25 +139,29 @@ def all_node_cuts(G, k=None, flow_func=None):
         for v in non_adjacent:
             # step 4: compute maximum flow in an Even-Tarjan reduction H of G
             # and step 5: build the associated residual network R
-            R = flow_func(H, f"{mapping[x]}B", f"{mapping[v]}A", **kwargs)
+            # After adding edges in previous iterations, there may be
+            # infinite-capacity paths between x and v, which means no
+            # finite min-cut exists for this pair. Skip in that case.
+            try:
+                R = flow_func(H, f"{mapping[x]}B", f"{mapping[v]}A", **kwargs)
+            except nx.NetworkXUnbounded:
+                continue
             flow_value = R.graph["flow_value"]
 
             if flow_value == k:
-                # Find the nodes incident to the flow.
-                E1 = flowed_edges = [
-                    (u, w) for (u, w, d) in R.edges(data=True) if d["flow"] != 0
-                ]
-                VE1 = incident_nodes = {n for edge in E1 for n in edge}
-                # Remove saturated edges form the residual network.
-                # Note that reversed edges are introduced with capacity 0
-                # in the residual graph and they need to be removed too.
+                # Remove edges with zero residual capacity from R.
+                # Residual capacity = capacity - flow.
+                # For saturated forward edges: cap == flow > 0 -> removed.
+                # For inactive reverse edges: cap == flow == 0 -> removed.
+                # For active reverse edges: cap=0, flow < 0 -> cap != flow
+                #   -> kept (these have positive residual capacity and
+                #   represent cancellable flow in the residual graph).
                 saturated_edges = [
                     (u, w, d)
                     for (u, w, d) in R.edges(data=True)
-                    if d["capacity"] == d["flow"] or d["capacity"] == 0
+                    if d["capacity"] == d["flow"]
                 ]
                 R.remove_edges_from(saturated_edges)
-                R_closure = nx.transitive_closure(R)
                 # step 6: shrink the strongly connected components of
                 # residual flow network R and call it L.
                 L = nx.condensation(R)
@@ -161,62 +169,53 @@ def all_node_cuts(G, k=None, flow_func=None):
                 inv_cmap = defaultdict(list)
                 for n, scc in cmap.items():
                     inv_cmap[scc].append(n)
-                # Find the incident nodes in the condensed graph.
-                VE1 = {cmap[n] for n in VE1}
+                # Compute the transitive closure of L for successor lookups.
+                # Per Picard-Queyranne, each antichain of L corresponds to
+                # a successor-closed set (the antichain plus all successors),
+                # which defines the source side of a minimum s-t cut.
+                L_closure = nx.transitive_closure(L)
                 # step 7: Compute all antichains of L;
                 # they map to closed sets in H.
-                # Any edge in H that links a closed set is part of a cutset.
                 for antichain in nx.antichains(L):
-                    # Only antichains that are subsets of incident nodes counts.
-                    # Lemma 8 in reference.
-                    if not set(antichain).issubset(VE1):
+                    if not antichain:
                         continue
-                    # Nodes in an antichain of the condensation graph of
-                    # the residual network map to a closed set of nodes that
-                    # define a node partition of the auxiliary digraph H
-                    # through taking all of antichain's predecessors in the
-                    # transitive closure.
+                    # Build the successor-closed set in L from the antichain.
+                    S_L = set(antichain)
+                    for scc_node in antichain:
+                        S_L.update(L_closure[scc_node])
+                    # Expand SCC nodes back to R/H nodes.
                     S = set()
-                    for scc in antichain:
-                        S.update(inv_cmap[scc])
-                    S_ancestors = set()
-                    for n in S:
-                        S_ancestors.update(R_closure._pred[n])
-                    S.update(S_ancestors)
+                    for scc_node in S_L:
+                        S.update(inv_cmap[scc_node])
+                    # S must contain the source and not the sink.
                     if f"{mapping[x]}B" not in S or f"{mapping[v]}A" in S:
                         continue
-                    # Find the cutset that links the node partition (S,~S) in H
+                    # Find the cutset: edges from S to ~S in H.
                     cutset = set()
                     for u in S:
-                        cutset.update((u, w) for w in original_H_pred[u] if w not in S)
-                    # The edges in H that form the cutset are internal edges
-                    # (ie edges that represent a node of the original graph G)
-                    if any(H_nodes[u]["id"] != H_nodes[w]["id"] for u, w in cutset):
+                        cutset.update((u, w) for w in H[u] if w not in S)
+                    if not cutset:
                         continue
                     node_cut = {H_nodes[u]["id"] for u, _ in cutset}
 
-                    if len(node_cut) == k:
-                        # The cut is invalid if it includes internal edges of
-                        # end nodes. The other half of Lemma 8 in ref.
-                        if x in node_cut or v in node_cut:
-                            continue
-                        if node_cut not in seen:
-                            yield node_cut
-                            seen.append(node_cut)
+                    if node_cut not in seen:
+                        yield node_cut
+                        seen.append(node_cut)
 
                 # Add an edge (x, v) to make sure that we do not
                 # find this cutset again. This is equivalent
                 # of adding the edge in the input graph
                 # G.add_edge(x, v) and then regenerate H and R:
                 # Add edges to the auxiliary digraph.
+                # External edges get infinite capacity.
+                H.add_edge(f"{mapping[x]}B", f"{mapping[v]}A", capacity=float("inf"))
+                H.add_edge(f"{mapping[v]}B", f"{mapping[x]}A", capacity=float("inf"))
+                # Add edges to the residual network.
                 # See build_residual_network for convention we used
                 # in residual graphs.
-                H.add_edge(f"{mapping[x]}B", f"{mapping[v]}A", capacity=1)
-                H.add_edge(f"{mapping[v]}B", f"{mapping[x]}A", capacity=1)
-                # Add edges to the residual network.
-                R.add_edge(f"{mapping[x]}B", f"{mapping[v]}A", capacity=1)
+                R.add_edge(f"{mapping[x]}B", f"{mapping[v]}A", capacity=R.graph["inf"])
                 R.add_edge(f"{mapping[v]}A", f"{mapping[x]}B", capacity=0)
-                R.add_edge(f"{mapping[v]}B", f"{mapping[x]}A", capacity=1)
+                R.add_edge(f"{mapping[v]}B", f"{mapping[x]}A", capacity=R.graph["inf"])
                 R.add_edge(f"{mapping[x]}A", f"{mapping[v]}B", capacity=0)
 
                 # Add again the saturated edges to reuse the residual network

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -8,7 +8,7 @@ import networkx as nx
 from networkx.algorithms import flow
 from networkx.algorithms.connectivity.kcutsets import _is_separating_set
 
-MAX_CUTSETS_TO_TEST = 4  # originally 100. cut to decrease testing time
+MAX_CUTSETS_TO_TEST = 100
 
 flow_funcs = [
     flow.boykov_kolmogorov,
@@ -133,7 +133,6 @@ def _check_separating_sets(G):
             assert not nx.is_connected(nx.restricted_view(G, cut, []))
 
 
-@pytest.mark.slow
 def test_torrents_and_ferraro_graph():
     G = torrents_and_ferraro_graph()
     _check_separating_sets(G)
@@ -207,7 +206,6 @@ def test_disconnected_graph():
     pytest.raises(nx.NetworkXError, next, cuts)
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize("G", [nx.grid_2d_graph(4, 4), nx.cycle_graph(5)])
 @pytest.mark.parametrize("flow_func", flow_funcs)
 def test_alternative_flow_functions(G, flow_func):


### PR DESCRIPTION
The Even-Tarjan auxiliary digraph built by build_auxiliary_node_connectivity sets capacity=1 on all edges. This is correct for computing the node connectivity value, but Kanevsky's algorithm depends on the structure of the residual graph, which requires infinite capacity on external edges as the original Even-Tarjan reduction specifies.

With unit-capacity external edges, these edges get saturated by the flow, producing a residual graph with the wrong structure. The condensation DAG has too many nodes, and the antichain count explodes exponentially.

This bug (introduced by me in the original NetworkX implementation) was not identified when correctness bugs were reported in #3025. The fix in PR #3039 addressed the symptoms (missing cuts) by adding compensating filters: VE1 incident-node filtering, transitive closure on the full residual graph, and internal-edge validation; and also introduced two additional bugs:

- Removing backward arcs from the residual graph (capacity=0 edges with negative flow that represent cancellable flow and must be preserved)
- Building closed sets using predecessors instead of successors in the condensation DAG, producing the wrong side of the cut partition

These filters discarded most of the millions of spurious antichains generated by the broken condensation DAG, making results mostly correct but at enormous computational cost.

This fix addresses the root cause and restores the algorithm to match the paper's specification:
- Set infinite capacity on external edges before building the residual
- Remove only edges with zero residual capacity (capacity == flow)
- Build successor-closed sets from antichins of the condensation DAG
- Find cut edges from S to ~S using H successors.

The compensating code is no longer needed and has been removed.

Performance on grid_2d_graph(11,11) improves from 180s to 0.16s (n=121) (1000x+), and now scales polynomially as predicted by the paper. Results verified identical to igraph's C implementation.

Fixes #7994.

Tests previously marked @pytest.mark.slow are now fast enough to run by default, and MAX_CUTSETS_TO_TEST is restored from 4 to 100.

As a AI disclaimer: I used Claude to explore the problem, build many scripts that printed step by step the state of the data structures used, create benchmarks that compare time and correctness between the old implementation, these fixes, and iGraph. In summary, Claude has been instrumental for fixing this long standing bug (introduced by yours truly nine years ago).

For instance, a really nice benchmark that shows that this implementation is now two times faster than iGraph for a grid 25x25

```python
import timeit
import igraph as ig
import networkx as nx


def runit(i):
    g = nx.grid_2d_graph(i, i)
    k = nx.node_connectivity(g)
    h = ig.Graph.from_networkx(g)

    # Time both
    nx_cuts = []
    def run_nx():
        nx_cuts.clear()
        nx_cuts.extend(list(nx.all_node_cuts(g)))
    t_nx = timeit.timeit(run_nx, number=1)

    ig_cuts = []
    def run_ig():
        ig_cuts.clear()
        ig_cuts.extend(ig.GraphBase.minimum_size_separators(h))
    t_ig = timeit.timeit(run_ig, number=1)

    # Compare results: igraph returns lists of integer indices,
    # nx returns sets of (row, col) tuples. Build a mapping.
    # ig.Graph.from_networkx preserves node order from nx iteration.
    node_list = list(g.nodes())
    ig_as_sets = [frozenset(node_list[idx] for idx in cut) for cut in ig_cuts]
    nx_as_sets = [frozenset(cut) for cut in nx_cuts]

    ig_set = set(ig_as_sets)
    nx_set = set(nx_as_sets)
    match = ig_set == nx_set
    missing = ig_set - nx_set
    extra = nx_set - ig_set

    return dict(i=i, k=k, n=len(g), nx_t=t_nx, ig_t=t_ig,
                nx_count=len(nx_set), ig_count=len(ig_set),
                match=match, missing=len(missing), extra=len(extra))


print(f"{'i':>3} {'k':>2} {'n':>5} {'NX (s)':>10} {'ig (s)':>10} "
      f"{'NX/ig':>7} {'#NX':>4} {'#ig':>4} {'match':>6}")
print("-" * 62)
for i in range(2, 26):
    r = runit(i)
    ratio = r['nx_t'] / r['ig_t']
    status = "OK" if r['match'] else f"DIFF +{r['extra']}/-{r['missing']}"
    print(f"{r['i']:>3} {r['k']:>2} {r['n']:>5} {r['nx_t']:>10.4f} "
          f"{r['ig_t']:>10.4f} {ratio:>6.1f}x {r['nx_count']:>4} "
          f"{r['ig_count']:>4} {status:>6}", flush=True)
```   
Output:
```
  i  k     n     NX (s)     ig (s)   NX/ig  #NX  #ig  match
--------------------------------------------------------------
  2  2     4     0.0025     0.0003    8.2x    2    2     OK
  3  2     9     0.0026     0.0005    5.6x    4    4     OK
  4  2    16     0.0056     0.0012    4.9x    4    4     OK
  5  2    25     0.0126     0.0030    4.2x    4    4     OK
  6  2    36     0.0256     0.0065    3.9x    4    4     OK
  7  2    49     0.0463     0.0134    3.4x    4    4     OK
  8  2    64     0.0675     0.0169    4.0x    4    4     OK
  9  2    81     0.0712     0.0263    2.7x    4    4     OK
 10  2   100     0.1052     0.0458    2.3x    4    4     OK
 11  2   121     0.1532     0.0769    2.0x    4    4     OK
 12  2   144     0.2168     0.1236    1.8x    4    4     OK
 13  2   169     0.2989     0.1914    1.6x    4    4     OK
 14  2   196     0.4082     0.2908    1.4x    4    4     OK
 15  2   225     0.5433     0.4316    1.3x    4    4     OK
 16  2   256     0.7039     0.6240    1.1x    4    4     OK
 17  2   289     0.9136     0.8796    1.0x    4    4     OK
 18  2   324     1.1356     1.2304    0.9x    4    4     OK
 19  2   361     1.4254     1.6834    0.8x    4    4     OK
 20  2   400     1.7636     2.2417    0.8x    4    4     OK
 21  2   441     2.1633     3.0230    0.7x    4    4     OK
 22  2   484     2.6171     3.9758    0.7x    4    4     OK
 23  2   529     3.2116     5.2050    0.6x    4    4     OK
 24  2   576     3.7976     6.4947    0.6x    4    4     OK
 25  2   625     4.4806     8.1915    0.5x    4    4     OK
```