### PR TITLE
Bugfix optimal_edit_paths + randomized test

### DIFF
--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -207,7 +207,9 @@ def graph_edit_distance(
     return bestcost
 
 
-@nx._dispatchable(graphs={"G1": 0, "G2": 1})
+@nx._dispatchable(
+    graphs={"G1": 0, "G2": 1}, preserve_edge_attrs=True, preserve_node_attrs=True
+)
 def optimal_edit_paths(
     G1,
     G2,
@@ -383,7 +385,9 @@ def optimal_edit_paths(
     return paths, bestcost
 
 
-@nx._dispatchable(graphs={"G1": 0, "G2": 1})
+@nx._dispatchable(
+    graphs={"G1": 0, "G2": 1}, preserve_edge_attrs=True, preserve_node_attrs=True
+)
 def optimize_graph_edit_distance(
     G1,
     G2,

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -866,30 +866,37 @@ def optimize_edit_paths(
         # assert Cv.C.shape == (m + n, m + n)
 
         # 1) a vertex mapping from optimal linear sum assignment
-        i, j = min(
-            (k, l) for k, l in zip(Cv.lsa_row_ind, Cv.lsa_col_ind) if k < m or l < n
+        lsa_assignments = (
+            (i, j) for i, j in zip(Cv.lsa_row_ind, Cv.lsa_col_ind) if i < m or j < n
         )
-        xy, localCe = match_edges(
-            pending_u[i] if i < m else None,
-            pending_v[j] if j < n else None,
-            pending_g,
-            pending_h,
-            Ce,
-            matched_uv,
-        )
-        Ce_xy = reduce_Ce(Ce, xy, len(pending_g), len(pending_h))
-        # assert Ce.ls <= localCe.ls + Ce_xy.ls
-        if prune(matched_cost + Cv.ls + localCe.ls + Ce_xy.ls):
-            pass
-        else:
-            # get reduced Cv efficiently
+
+        # Evaluate each assignment with its edge costs
+        first_candidates = []
+        for i, j in lsa_assignments:
+            xy, localCe = match_edges(
+                pending_u[i] if i < m else None,
+                pending_v[j] if j < n else None,
+                pending_g,
+                pending_h,
+                Ce,
+                matched_uv,
+            )
+            Ce_xy = reduce_Ce(Ce, xy, len(pending_g), len(pending_h))
+
+            if prune(matched_cost + Cv.ls + localCe.ls + Ce_xy.ls):
+                continue
+
+            # Use efficient Cv reduction
             Cv_ij = CostMatrix(
                 reduce_C(Cv.C, (i,), (j,), m, n),
                 reduce_ind(Cv.lsa_row_ind, (i, m + j)),
                 reduce_ind(Cv.lsa_col_ind, (j, n + i)),
                 Cv.ls - Cv.C[i, j],
             )
-            yield (i, j), Cv_ij, xy, Ce_xy, Cv.C[i, j] + localCe.ls
+            first_candidates.append(((i, j), Cv_ij, xy, Ce_xy, Cv.C[i, j] + localCe.ls))
+
+        # Sort by total cost estimate and yield most promising first
+        yield from sorted(first_candidates, key=lambda t: t[4] + t[1].ls + t[3].ls)
 
         # 2) other candidates, sorted by lower-bound cost estimate
         other = []

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -332,7 +332,7 @@ def optimal_edit_paths(
     >>> G2 = nx.wheel_graph(5)
     >>> paths, cost = nx.optimal_edit_paths(G1, G2)
     >>> len(paths)
-    40
+    378
     >>> cost
     5.0
 

--- a/networkx/algorithms/tests/test_similarity.py
+++ b/networkx/algorithms/tests/test_similarity.py
@@ -1173,8 +1173,7 @@ class TestGEDMinimalityRandom:
         for perm in itertools.permutations(nodes_H, len(nodes_G)):
             mapping = dict(zip(nodes_G, perm))
             total = sum(
-                node_cost(G.nodes[u_G], H.nodes[mapping[u_G]])
-                for u_G in nodes_G
+                node_cost(G.nodes[u_G], H.nodes[mapping[u_G]]) for u_G in nodes_G
             )
             for u_G, v_G in itertools.combinations(nodes_G, 2):
                 u_H = mapping[u_G]
@@ -1208,9 +1207,7 @@ class TestGEDMinimalityRandom:
                 graph.edges[e]["self"] = e
 
         _, ged_dist = nx.optimal_edit_paths(
-            G, H,
-            node_subst_cost=data_cost,
-            edge_subst_cost=data_cost
+            G, H, node_subst_cost=data_cost, edge_subst_cost=data_cost
         )
 
         upper_bound = self.naive_ged_upper_bound(G, H, data_cost, data_cost)

--- a/networkx/algorithms/tests/test_similarity.py
+++ b/networkx/algorithms/tests/test_similarity.py
@@ -1,3 +1,6 @@
+import itertools
+import random
+
 import pytest
 
 import networkx as nx
@@ -210,16 +213,13 @@ class TestSimilarity:
             else:
                 return 1.0
 
-        assert (
-            graph_edit_distance(
-                G1,
-                G2,
-                edge_subst_cost=edge_subst_cost,
-                edge_del_cost=edge_del_cost,
-                edge_ins_cost=edge_ins_cost,
-            )
-            == 0.23
-        )
+        assert graph_edit_distance(
+            G1,
+            G2,
+            edge_subst_cost=edge_subst_cost,
+            edge_del_cost=edge_del_cost,
+            edge_ins_cost=edge_ins_cost,
+        ) == pytest.approx(0.23)
 
     def test_graph_edit_distance_upper_bound(self):
         G1 = circular_ladder_graph(2)
@@ -233,7 +233,7 @@ class TestSimilarity:
         G2 = cycle_graph(3)
         paths, cost = optimal_edit_paths(G1, G2)
         assert cost == 1
-        assert len(paths) == 6
+        assert len(paths) == 15
 
         def canonical(vertex_path, edge_path):
             return (
@@ -1156,3 +1156,109 @@ class TestSimilarity:
                 f"panther_vector_similarity k={k_val} returned {len(result_vector)} results"
             )
             assert 1 not in result_vector, "Source node should not be in results"
+
+
+class TestGEDMinimalityRandom:
+    """Test GED minimality on random graphs by comparing it with a brute-force reference implementation"""
+
+    @staticmethod
+    def assign_node_attributes(graphs):
+        """Assign 'i' attribute to all nodes."""
+        for G in graphs:
+            for n in G.nodes():
+                G.nodes[n]["i"] = n
+
+    @staticmethod
+    def make_random_node_cost(G, H, rng):
+        """Return a function node_subst_cost(u,v) with random values."""
+        max_cost = max(len(G), len(H))
+        node_values = {}
+        for u in G.nodes():
+            for v in H.nodes():
+                node_values[(u, v)] = rng.uniform(0, max_cost)
+
+        def node_subst_cost(u, v):
+            return node_values[(u["i"], v["i"])]
+
+        return node_subst_cost
+
+    @staticmethod
+    def assign_edge_ids(Gs):
+        """Add a unique 'id' attribute to all edges in each graph."""
+        next_id = 0
+        for G in Gs:
+            for u, v in G.edges():
+                G.edges[u, v]["id"] = next_id
+                next_id += 1
+
+    @staticmethod
+    def make_random_edge_cost(G, H, rng):
+        """Return a random edge_subst_cost function using edge['id']."""
+        max_cost = max(len(G), len(H))
+        edge_ids_G = [G.edges[e]["id"] for e in G.edges()] + [None]
+        edge_ids_H = [H.edges[e]["id"] for e in H.edges()] + [None]
+
+        edge_values = {
+            (i, j): rng.uniform(0, max_cost) for i in edge_ids_G for j in edge_ids_H
+        }
+
+        def edge_subst_cost(e1, e2):
+            id1 = e1["id"] if e1 is not None else None
+            id2 = e2["id"] if e2 is not None else None
+            return edge_values[(id1, id2)]
+
+        return edge_subst_cost
+
+    def naive_ged_upper_bound(self, G, H, node_cost, edge_cost):
+        """Brute-force GED upper over all node permutations.
+
+        This method does not evaluate deletion nor additions, so it might not find the optimal solution.
+        """
+        nodes_G = list(G.nodes())
+        nodes_H = list(H.nodes())
+        min_cost = float("inf")
+
+        for mapping in itertools.permutations(nodes_H, len(nodes_G)):
+            total = sum(
+                node_cost(G.nodes[u], H.nodes[v]) for u, v in zip(nodes_G, mapping)
+            )
+            for u_idx, u in enumerate(nodes_G):
+                if total > min_cost:
+                    break
+                for v_idx, v in enumerate(nodes_G):
+                    if u < v:
+                        e1 = G.edges[u, v] if G.has_edge(u, v) else None
+                        e2 = (
+                            H.edges[mapping[u_idx], mapping[v_idx]]
+                            if H.has_edge(mapping[u_idx], mapping[v_idx])
+                            else None
+                        )
+                        total += edge_cost(e1, e2)
+
+            if total < min_cost:
+                min_cost = total
+
+        return min_cost
+
+    @pytest.mark.parametrize("size", [3, 4])
+    @pytest.mark.parametrize("seed", range(5))
+    def test_optimal_edit_paths_random_node_and_edge_substitutions(self, size, seed):
+        rng = random.Random(seed)
+
+        # Generate two complete graphs
+        G = nx.complete_graph(range(size))
+        H = nx.complete_graph(range(size))
+        self.assign_node_attributes([G, H])
+        self.assign_edge_ids([G, H])
+
+        # Random node substitution cost
+        node_cost = self.make_random_node_cost(G, H, rng)
+        edge_cost = self.make_random_edge_cost(G, H, rng)
+
+        _, ged_dist = nx.optimal_edit_paths(
+            G, H, node_subst_cost=node_cost, edge_subst_cost=edge_cost
+        )
+
+        upper_bound = self.naive_ged_upper_bound(G, H, node_cost, edge_cost)
+
+        assert ged_dist <= upper_bound + 1e-8

--- a/networkx/algorithms/tests/test_similarity.py
+++ b/networkx/algorithms/tests/test_similarity.py
@@ -1161,104 +1161,58 @@ class TestSimilarity:
 class TestGEDMinimalityRandom:
     """Test GED minimality on random graphs by comparing it with a brute-force reference implementation"""
 
-    @staticmethod
-    def assign_node_attributes(graphs):
-        """Assign 'i' attribute to all nodes."""
-        for G in graphs:
-            for n in G.nodes():
-                G.nodes[n]["i"] = n
-
-    @staticmethod
-    def make_random_node_cost(G, H, rng):
-        """Return a function node_subst_cost(u,v) with random values."""
-        max_cost = max(len(G), len(H))
-        node_values = {}
-        for u in G.nodes():
-            for v in H.nodes():
-                node_values[(u, v)] = rng.uniform(0, max_cost)
-
-        def node_subst_cost(u, v):
-            return node_values[(u["i"], v["i"])]
-
-        return node_subst_cost
-
-    @staticmethod
-    def assign_edge_ids(Gs):
-        """Add a unique 'id' attribute to all edges in each graph."""
-        next_id = 0
-        for G in Gs:
-            for u, v in G.edges():
-                G.edges[u, v]["id"] = next_id
-                next_id += 1
-
-    @staticmethod
-    def make_random_edge_cost(G, H, rng):
-        """Return a random edge_subst_cost function using edge['id']."""
-        max_cost = max(len(G), len(H))
-        edge_ids_G = [G.edges[e]["id"] for e in G.edges()] + [None]
-        edge_ids_H = [H.edges[e]["id"] for e in H.edges()] + [None]
-
-        edge_values = {
-            (i, j): rng.uniform(0, max_cost) for i in edge_ids_G for j in edge_ids_H
-        }
-
-        def edge_subst_cost(e1, e2):
-            id1 = e1["id"] if e1 is not None else None
-            id2 = e2["id"] if e2 is not None else None
-            return edge_values[(id1, id2)]
-
-        return edge_subst_cost
-
     def naive_ged_upper_bound(self, G, H, node_cost, edge_cost):
         """Brute-force GED upper over all node permutations.
 
         This method does not evaluate deletion nor additions, so it might not find the optimal solution.
         """
-        nodes_G = list(G.nodes())
-        nodes_H = list(H.nodes())
         min_cost = float("inf")
+        nodes_G = list(G)
+        nodes_H = list(H)
 
-        for mapping in itertools.permutations(nodes_H, len(nodes_G)):
+        for perm in itertools.permutations(nodes_H, len(nodes_G)):
+            mapping = dict(zip(nodes_G, perm))
             total = sum(
-                node_cost(G.nodes[u], H.nodes[v]) for u, v in zip(nodes_G, mapping)
+                node_cost(G.nodes[u_G], H.nodes[mapping[u_G]])
+                for u_G in nodes_G
             )
-            for u_idx, u in enumerate(nodes_G):
-                if total > min_cost:
+            for u_G, v_G in itertools.combinations(nodes_G, 2):
+                u_H = mapping[u_G]
+                v_H = mapping[v_G]
+                e_G = G.edges[u_G, v_G] if G.has_edge(u_G, v_G) else None
+                e_H = H.edges[u_H, v_H] if H.has_edge(u_H, v_H) else None
+                total += edge_cost(e_G, e_H)
+                if total >= min_cost:
                     break
-                for v_idx, v in enumerate(nodes_G):
-                    if u < v:
-                        e1 = G.edges[u, v] if G.has_edge(u, v) else None
-                        e2 = (
-                            H.edges[mapping[u_idx], mapping[v_idx]]
-                            if H.has_edge(mapping[u_idx], mapping[v_idx])
-                            else None
-                        )
-                        total += edge_cost(e1, e2)
 
             if total < min_cost:
                 min_cost = total
-
         return min_cost
 
     @pytest.mark.parametrize("size", [3, 4])
     @pytest.mark.parametrize("seed", range(5))
     def test_optimal_edit_paths_random_node_and_edge_substitutions(self, size, seed):
-        rng = random.Random(seed)
+        G = nx.complete_graph(size)
+        H = nx.complete_graph(size)
 
-        # Generate two complete graphs
-        G = nx.complete_graph(range(size))
-        H = nx.complete_graph(range(size))
-        self.assign_node_attributes([G, H])
-        self.assign_edge_ids([G, H])
+        def data_cost(data1, data2):
+            self1 = None if data1 is None else data1["self"]
+            self2 = None if data2 is None else data2["self"]
+            return size * random.Random(f"{self1}|{self2}|{seed}").random()
 
-        # Random node substitution cost
-        node_cost = self.make_random_node_cost(G, H, rng)
-        edge_cost = self.make_random_edge_cost(G, H, rng)
+        # self references are needed because data_cost receives data
+        for graph in (G, H):
+            for n in graph:
+                graph.nodes[n]["self"] = n
+            for e in graph.edges:
+                graph.edges[e]["self"] = e
 
         _, ged_dist = nx.optimal_edit_paths(
-            G, H, node_subst_cost=node_cost, edge_subst_cost=edge_cost
+            G, H,
+            node_subst_cost=data_cost,
+            edge_subst_cost=data_cost
         )
 
-        upper_bound = self.naive_ged_upper_bound(G, H, node_cost, edge_cost)
+        upper_bound = self.naive_ged_upper_bound(G, H, data_cost, data_cost)
 
         assert ged_dist <= upper_bound + 1e-8


### PR DESCRIPTION
Fixes https://github.com/networkx/networkx/issues/8099.

Revisiting https://github.com/networkx/networkx/pull/8421 by @VanitasCodes. I simplified the tests so only one small randomized test is enough to uncover the issue.

The test is based on generating random cost/edge substitutions and using a dummy brute force implementation as baseline. The dummy implementation is only based on performing node and edge substitutions so it is guaranteed to find an upper bound. On its current version it generates 10 test cases and it takes ~2.3seconds to run. I tested locally with more examples and all of them passsed.

```
================================================================================================ test session starts =================================================================================================
platform darwin -- Python 3.13.5, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/candioti/workplace/networkx
configfile: pyproject.toml
collected 9491 items / 9481 deselected / 3 skipped / 10 selected                                                                                                                                                     

networkx/algorithms/tests/test_similarity.py ..........                                                                                                                                                        [100%]

=================================================================================== 10 passed, 3 skipped, 9481 deselected in 2.34s ===================================================================================

```

