### PR TITLE
Fix: group_betweenness_centrality returns negative values on directed non-strongly-connected graphs

### DIFF
--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -124,6 +124,17 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
     if set_v - G.nodes:  # element(s) of C not in G
         raise nx.NodeNotFound(f"The node(s) {set_v - G.nodes} are in C but not in G.")
 
+    if (
+        nx.is_directed(G)
+        and not nx.is_strongly_connected(G)
+        and any(len(group) > 1 for group in C)
+    ):
+        raise nx.NetworkXNotImplemented(
+            "group_betweenness_centrality is not implemented for "
+            "multi-node groups on directed graphs that are not "
+            "strongly connected."
+        )
+
     # pre-processing
     PB, sigma, D = _group_preprocessing(G, set_v, weight)
 

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -180,10 +180,10 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
                 for group_node1 in group:
                     for node in D[group_node1]:
                         if node != group_node1:
-                            if node in group:
-                                scale += 1
-                            else:
-                                scale += 2
+                            scale += 1
+                    for node in G:
+                        if node != group_node1 and group_node1 in D[node]:
+                            scale += 1
             GBC_group -= scale
 
         # normalized
@@ -398,10 +398,10 @@ def prominent_group(
             for group_node1 in max_group:
                 for node in D[group_node1]:
                     if node != group_node1:
-                        if node in max_group:
-                            scale += 1
-                        else:
-                            scale += 2
+                        scale += 1
+                for node in G:
+                    if node != group_node1 and group_node1 in D[node]:
+                        scale += 1
         max_GBC -= scale
 
     # normalized

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -145,6 +145,9 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
                     dvxy = 0
                     if not (
                         sigma_m[x][y] == 0 or sigma_m[x][v] == 0 or sigma_m[v][y] == 0
+                    ) and (
+                        y in D[x] and v in D[x] and v in D[y]
+                        and x in D[v] and y in D[v]
                     ):
                         if D[x][v] == D[x][y] + D[y][v]:
                             dxyv = sigma_m[x][y] * sigma_m[y][v] / sigma_m[x][v]
@@ -480,6 +483,9 @@ def _heuristic(k, root, DF_tree, D, nodes, greedy):
                 root_node["sigma"][x][y] == 0
                 or root_node["sigma"][x][added_node] == 0
                 or root_node["sigma"][added_node][y] == 0
+            ) and (
+                y in D[x] and added_node in D[x] and added_node in D[y]
+                and x in D[added_node] and y in D[added_node]
             ):
                 if D[x][added_node] == D[x][y] + D[y][added_node]:
                     dxyv = (

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -157,8 +157,11 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
                     if not (
                         sigma_m[x][y] == 0 or sigma_m[x][v] == 0 or sigma_m[v][y] == 0
                     ) and (
-                        y in D[x] and v in D[x] and v in D[y]
-                        and x in D[v] and y in D[v]
+                        y in D[x]
+                        and v in D[x]
+                        and v in D[y]
+                        and x in D[v]
+                        and y in D[v]
                     ):
                         if D[x][v] == D[x][y] + D[y][v]:
                             dxyv = sigma_m[x][y] * sigma_m[y][v] / sigma_m[x][v]
@@ -495,8 +498,11 @@ def _heuristic(k, root, DF_tree, D, nodes, greedy):
                 or root_node["sigma"][x][added_node] == 0
                 or root_node["sigma"][added_node][y] == 0
             ) and (
-                y in D[x] and added_node in D[x] and added_node in D[y]
-                and x in D[added_node] and y in D[added_node]
+                y in D[x]
+                and added_node in D[x]
+                and added_node in D[y]
+                and x in D[added_node]
+                and y in D[added_node]
             ):
                 if D[x][added_node] == D[x][y] + D[y][added_node]:
                     dxyv = (

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -114,13 +114,12 @@ class TestGroupBetweennessCentrality:
             )
 
     def test_group_betweenness_directed_not_strongly_connected_multi_node(self):
-        """Multi-node group must not crash or go negative on a DAG."""
+        """Multi-node group on a non-strongly-connected digraph is not supported."""
         G = nx.path_graph(4, create_using=nx.DiGraph)  # 0->1->2->3
-        group_val = nx.group_betweenness_centrality(
-            G, [0, 2], normalized=False, endpoints=False
-        )
-        assert group_val >= 0
-        assert group_val == pytest.approx(1.0)
+        with pytest.raises(nx.NetworkXNotImplemented):
+            nx.group_betweenness_centrality(
+                G, [0, 2], normalized=False, endpoints=False
+            )
 
     def test_group_betweenness_directed_not_strongly_connected_normalized(self):
         """Normalized group betweenness must match on a DAG."""

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -100,6 +100,24 @@ class TestGroupBetweennessCentrality:
         b_answer = 5.0
         assert b == b_answer
 
+    def test_group_betweenness_directed_not_strongly_connected_single_node(self):
+        G = nx.path_graph(4, create_using=nx.DiGraph)
+        per_node = nx.betweenness_centrality(G, normalized=False, endpoints=False)
+
+        for node in G:
+            group_betweenness = nx.group_betweenness_centrality(
+                G, [node], normalized=False, endpoints=False
+            )
+            assert group_betweenness == per_node[node]
+
+    def test_group_betweenness_directed_not_strongly_connected_multi_node(self):
+        G = nx.path_graph(4, create_using=nx.DiGraph)
+        group_betweenness = nx.group_betweenness_centrality(
+            G, [0, 2], normalized=False, endpoints=False
+        )
+
+        assert group_betweenness == 1.0
+
 
 class TestProminentGroup:
     np = pytest.importorskip("numpy")

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -232,9 +232,7 @@ class TestProminentGroup:
     def test_prominent_group_directed_not_strongly_connected_greedy(self):
         """prominent_group greedy must not crash on a DAG."""
         G = nx.path_graph(4, create_using=nx.DiGraph)
-        b, g = nx.prominent_group(
-            G, 1, normalized=False, endpoints=False, greedy=True
-        )
+        b, g = nx.prominent_group(G, 1, normalized=False, endpoints=False, greedy=True)
         assert b >= 0
         assert len(g) == 1
 

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -101,22 +101,47 @@ class TestGroupBetweennessCentrality:
         assert b == b_answer
 
     def test_group_betweenness_directed_not_strongly_connected_single_node(self):
-        G = nx.path_graph(4, create_using=nx.DiGraph)
+        """group_betweenness({v}) must equal betweenness(v) on a DAG."""
+        G = nx.path_graph(4, create_using=nx.DiGraph)  # 0->1->2->3
         per_node = nx.betweenness_centrality(G, normalized=False, endpoints=False)
 
         for node in G:
-            group_betweenness = nx.group_betweenness_centrality(
+            group_val = nx.group_betweenness_centrality(
                 G, [node], normalized=False, endpoints=False
             )
-            assert group_betweenness == per_node[node]
+            assert group_val == pytest.approx(per_node[node]), (
+                f"node {node}: group={group_val}, per_node={per_node[node]}"
+            )
 
     def test_group_betweenness_directed_not_strongly_connected_multi_node(self):
-        G = nx.path_graph(4, create_using=nx.DiGraph)
-        group_betweenness = nx.group_betweenness_centrality(
+        """Multi-node group must not crash or go negative on a DAG."""
+        G = nx.path_graph(4, create_using=nx.DiGraph)  # 0->1->2->3
+        group_val = nx.group_betweenness_centrality(
             G, [0, 2], normalized=False, endpoints=False
         )
+        assert group_val >= 0
+        assert group_val == pytest.approx(1.0)
 
-        assert group_betweenness == 1.0
+    def test_group_betweenness_directed_not_strongly_connected_normalized(self):
+        """Normalized group betweenness must match on a DAG."""
+        G = nx.path_graph(4, create_using=nx.DiGraph)
+        per_node = nx.betweenness_centrality(G, normalized=True, endpoints=False)
+        for node in G:
+            group_val = nx.group_betweenness_centrality(
+                G, [node], normalized=True, endpoints=False
+            )
+            assert group_val == pytest.approx(per_node[node]), (
+                f"node {node}: group={group_val}, per_node={per_node[node]}"
+            )
+
+    def test_group_betweenness_nonnegative_on_dag(self):
+        """Group betweenness must never be negative."""
+        G = nx.path_graph(6, create_using=nx.DiGraph)
+        for v in G:
+            gv = nx.group_betweenness_centrality(
+                G, [v], normalized=False, endpoints=False
+            )
+            assert gv >= 0, f"Negative group betweenness for node {v}: {gv}"
 
 
 class TestProminentGroup:
@@ -197,6 +222,22 @@ class TestProminentGroup:
         b, g = nx.prominent_group(G, k, normalized=True, endpoints=True, greedy=True)
         b_answer, g_answer = 1.7, [6, 3]
         assert b == b_answer and g == g_answer
+
+    def test_prominent_group_directed_not_strongly_connected(self):
+        """prominent_group must not crash on a DAG."""
+        G = nx.path_graph(4, create_using=nx.DiGraph)  # 0->1->2->3
+        b, g = nx.prominent_group(G, 1, normalized=False, endpoints=False)
+        assert b >= 0
+        assert len(g) == 1
+
+    def test_prominent_group_directed_not_strongly_connected_greedy(self):
+        """prominent_group greedy must not crash on a DAG."""
+        G = nx.path_graph(4, create_using=nx.DiGraph)
+        b, g = nx.prominent_group(
+            G, 1, normalized=False, endpoints=False, greedy=True
+        )
+        assert b >= 0
+        assert len(g) == 1
 
 
 class TestGroupClosenessCentrality:


### PR DESCRIPTION
Fixes: https://github.com/networkx/networkx/issues/8559


> I think the Puzis algorithm implementation assumes all node pairs are mutually reachable (i.e., D[x][y] always exists). I added the guards you mentioned and also tried extend the cases in which the correction was applied but I couldn't generalize it to the multi node group case. So I threw an explicit error that we don't support this case for now instead of failing with a KeyError