### PR TITLE
Gallery: Improve plot_dag example

### DIFF
--- a/examples/graph/plot_dag_layout.py
+++ b/examples/graph/plot_dag_layout.py
@@ -31,7 +31,7 @@ layers = dict(enumerate(nx.topological_generations(G)))
 pos = nx.multipartite_layout(G, subset_key=layers)
 
 fig, ax = plt.subplots()
-nx.draw_networkx(G, pos=pos, ax=ax)
+nx.draw(G, pos=pos, ax=ax, with_labels=True)
 ax.set_title("DAG layout in topological order")
 fig.tight_layout()
 plt.show()


### PR DESCRIPTION
Updates the `plog_dag` example to highlight the feature added in #5179 where `subset_key` accepts a dict rather than requiring the data to be stored on the graph.

Also switch from `draw_networkx` -> `draw`, which disables the axes by default.