### PR TITLE
Add faces_from_orientable_embedding helper

### DIFF
--- a/networkx/algorithms/planarity.py
+++ b/networkx/algorithms/planarity.py
@@ -3,7 +3,12 @@ from copy import deepcopy
 
 import networkx as nx
 
-__all__ = ["check_planarity", "is_planar", "PlanarEmbedding"]
+__all__ = [
+    "check_planarity",
+    "faces_from_orientable_embedding",
+    "is_planar",
+    "PlanarEmbedding",
+]
 
 
 @nx._dispatchable
@@ -191,6 +196,71 @@ def get_counterexample_recursive(G):
                 subgraph.add_edge(u, v)
 
     return subgraph
+
+
+def faces_from_orientable_embedding(rotation_system):
+    """Generate faces from a simple orientable embedding.
+
+    Parameters
+    ----------
+    rotation_system : mapping
+        ``rotation_system[v]`` gives the cyclic order of the distinct
+        neighbors of ``v``. This representation assumes a simple graph:
+        self-loops and parallel edges are not supported.
+
+    Yields
+    ------
+    face : list
+        A facial boundary walk as a node sequence in cyclic order.
+        Walks are not guaranteed to be simple cycles: vertices can repeat,
+        for example around bridges or articulation points.
+
+    Notes
+    -----
+    This function traverses each directed half-edge exactly once.
+    The input must encode an orientable rotation system, so each edge must
+    appear in both directions.
+    For disconnected rotation systems, a unique global outer face is not
+    distinguished by the combinatorial data.
+    """
+    position = {}
+    for v, nbrs in rotation_system.items():
+        if len(nbrs) != len(set(nbrs)):
+            raise nx.NetworkXError(
+                "rotation_system[v] must contain distinct neighbors; "
+                "self-loops and parallel edges are not supported by this "
+                "representation"
+            )
+        position[v] = {u: i for i, u in enumerate(nbrs)}
+
+    for u, nbrs in rotation_system.items():
+        for v in nbrs:
+            if v not in rotation_system or u not in position[v]:
+                raise nx.NetworkXError(
+                    "rotation system must include each edge in both directions"
+                )
+
+    visited_half_edges = set()
+    for start_u, nbrs in rotation_system.items():
+        for start_v in nbrs:
+            if (start_u, start_v) in visited_half_edges:
+                continue
+
+            face = []
+            u, v = start_u, start_v
+            while True:
+                if (u, v) in visited_half_edges:
+                    if (u, v) != (start_u, start_v):
+                        raise nx.NetworkXError("Invalid rotation system.")
+                    break
+
+                visited_half_edges.add((u, v))
+                face.append(u)
+
+                i = position[v][u]
+                u, v = v, rotation_system[v][(i - 1) % len(rotation_system[v])]
+
+            yield face
 
 
 class Interval:

--- a/networkx/algorithms/tests/test_planarity.py
+++ b/networkx/algorithms/tests/test_planarity.py
@@ -5,6 +5,7 @@ import pytest
 import networkx as nx
 from networkx.algorithms.planarity import (
     check_planarity_recursive,
+    faces_from_orientable_embedding,
     get_counterexample,
     get_counterexample_recursive,
 )
@@ -419,6 +420,17 @@ def _assert_half_edge_partition(embedding, faces):
     assert all(count == 1 for count in Counter(face_half_edges).values())
 
 
+def _assert_half_edge_partition_from_orientable_embedding(rotation_system, faces):
+    face_half_edges = (
+        (u, f[i % len(f)]) for f in faces if f for i, u in enumerate(f, 1)
+    )
+    rotation_system_half_edges = (
+        (u, v) for u in rotation_system for v in rotation_system[u]
+    )
+    assert Counter(face_half_edges) == Counter(rotation_system_half_edges)
+    assert all(count == 1 for count in Counter(face_half_edges).values())
+
+
 class TestPlanarEmbeddingClass:
     def test_add_half_edge(self):
         embedding = nx.PlanarEmbedding()
@@ -616,3 +628,91 @@ class TestPlanarEmbeddingClass:
             ref = i
             embedding.add_half_edge(i, 0)
         return embedding
+
+
+class TestFacesFromOrientableEmbedding:
+    def test_empty_rotation_system_has_no_faces(self):
+        faces = list(faces_from_orientable_embedding({}))
+        assert faces == []
+
+    def test_cycle_graph_faces_and_half_edge_partition(self):
+        graph = nx.cycle_graph(4)
+        _, embedding = nx.check_planarity(graph)
+        rotation_system = embedding.get_data()
+
+        faces = list(faces_from_orientable_embedding(rotation_system))
+
+        assert len(faces) == 2
+        assert faces == list(embedding.faces())
+        _assert_half_edge_partition_from_orientable_embedding(rotation_system, faces)
+
+    def test_tree_has_single_face_walk_with_repeated_vertices(self):
+        graph = nx.path_graph(4)
+        _, embedding = nx.check_planarity(graph)
+        rotation_system = embedding.get_data()
+
+        faces = list(faces_from_orientable_embedding(rotation_system))
+
+        assert len(faces) == 1
+        assert faces == list(embedding.faces())
+        assert len(faces[0]) == 2 * graph.number_of_edges()
+        assert len(set(faces[0])) < len(faces[0])
+        _assert_half_edge_partition_from_orientable_embedding(rotation_system, faces)
+
+    def test_k4_faces_match_euler_formula(self):
+        graph = nx.complete_graph(4)
+        _, embedding = nx.check_planarity(graph)
+        rotation_system = embedding.get_data()
+
+        faces = list(faces_from_orientable_embedding(rotation_system))
+
+        assert len(faces) == graph.number_of_edges() - graph.number_of_nodes() + 2
+        assert faces == list(embedding.faces())
+        assert sorted(len(face) for face in faces) == [3, 3, 3, 3]
+        _assert_half_edge_partition_from_orientable_embedding(rotation_system, faces)
+
+    def test_disconnected_components_return_component_local_boundary_walks(self):
+        graph = nx.disjoint_union(nx.cycle_graph(3), nx.cycle_graph(3))
+        _, embedding = nx.check_planarity(graph)
+        rotation_system = embedding.get_data()
+
+        faces = list(faces_from_orientable_embedding(rotation_system))
+
+        assert len(faces) == 4
+        assert faces == list(embedding.faces())
+        _assert_half_edge_partition_from_orientable_embedding(rotation_system, faces)
+
+    def test_k33_torus_rotation_system_has_three_hexagonal_faces(self):
+        rotation_system = {
+            "a0": ["b0", "b1", "b2"],
+            "a1": ["b0", "b1", "b2"],
+            "a2": ["b0", "b1", "b2"],
+            "b0": ["a0", "a1", "a2"],
+            "b1": ["a0", "a1", "a2"],
+            "b2": ["a0", "a1", "a2"],
+        }
+
+        faces = list(faces_from_orientable_embedding(rotation_system))
+
+        assert len(faces) == 3
+        assert sorted(len(face) for face in faces) == [6, 6, 6]
+        num_edges = sum(len(nbrs) for nbrs in rotation_system.values()) // 2
+        assert len(rotation_system) - num_edges + len(faces) == 0
+        _assert_half_edge_partition_from_orientable_embedding(rotation_system, faces)
+
+    def test_isolated_nodes_have_no_faces(self):
+        rotation_system = {0: [], 1: [], 2: []}
+        faces = list(faces_from_orientable_embedding(rotation_system))
+        assert faces == []
+
+    def test_duplicate_neighbors_raise_networkx_error(self):
+        rotation_system = {0: [1, 1], 1: [0, 0]}
+        with pytest.raises(nx.NetworkXError, match="must contain distinct neighbors"):
+            list(faces_from_orientable_embedding(rotation_system))
+
+    def test_missing_reverse_half_edge_raises_networkx_error(self):
+        rotation_system = {0: [1], 1: []}
+        with pytest.raises(
+            nx.NetworkXError, match="must include each edge in both directions"
+        ):
+            list(faces_from_orientable_embedding(rotation_system))


### PR DESCRIPTION
## Summary
 
This PR adds ` faces_from_orientable_embedding(rotation_system)`, a helper for computing facial boundary walks from an orientable rotation system.
 
This builds on the recently added PlanarEmbedding.faces() method by supporting the case where an orientable rotation system is provided, allowing faces to be recovered from it.
 
## What this adds
 
- a new public helper: `faces_from_orientable_embedding(rotation_system)`
- lazy face generation
- validation that each edge appears in both directions in the rotation system
- validation that the input uses a simple-graph representation, with distinct neighbors at each vertex
 
## Notes
 
This function is intended for orientable rotation systems and does not support self-loops or parallel edges.
 
As in `PlanarEmbedding.faces()`, the returned face walks are not required to be simple cycles: vertices may repeat, for example in the presence of bridges or articulation points.
 
The correctness of this function follows from the fact that every rotation system defines a unique cellular embedding of a graph G on an orientable surface (up to homeomorphism).
 
## Tests
 
Added tests covering:
- cycle graph
- tree with repeated vertices in the face walk
- `K4`
- disconnected components
- isolated nodes
- invalid rotation systems
- a non-planar orientable example: a torus rotation system for `K3,3`
 
For planar embeddings, the new helper function provides consistent face extraction with PlanarEmbedding.faces() when applied to the embedding data returned by embedding.get_data().