### PR TITLE
DEP: Deprecate the `networkx.readwrite.p2g` module (#8195)

### DIFF
--- a/doc/developer/deprecations.rst
+++ b/doc/developer/deprecations.rst
@@ -77,3 +77,4 @@ Version 3.8
 Version 3.9
 ~~~~~~~~~~~
 * Remove ``bfs_predecessors`` from ``networkx.algorithms.traversal.breadth_first_searcph``.
+* Remove the ``networkx.readwrite.p2g`` module (``write_p2g``, ``read_p2g``, ``parse_p2g``) and its tests.

--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -124,6 +124,15 @@ def set_warnings():
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="\n\nbfs_predecessors"
     )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="\n\nwrite_p2g"
+    )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="\n\nread_p2g"
+    )
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="\n\nparse_p2g"
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/networkx/readwrite/p2g.py
+++ b/networkx/readwrite/p2g.py
@@ -2,6 +2,12 @@
 This module provides the following: read and write of p2g format
 used in metabolic pathway studies.
 
+.. deprecated:: 3.7
+   The ``p2g`` module is deprecated and will be removed in NetworkX 3.9.
+   The upstream KEGG pathway database and the Purdue page describing the
+   format are no longer online, so the format is effectively dead. See
+   :gh:`8195` for context.
+
 See:
 <https://web.archive.org/web/20080626113807/http://www.cs.purdue.edu/homes/koyuturk/pathway/>
 for a description.
@@ -34,6 +40,8 @@ itself. Indeed, self-loops are allowed. Node index starts from 0.
 
 """
 
+import warnings
+
 import networkx as nx
 from networkx.utils import open_file
 
@@ -46,7 +54,20 @@ def write_p2g(G, path, encoding="utf-8"):
     -----
     This format is meant to be used with directed graphs with
     possible self loops.
+
+    .. deprecated:: 3.7
+       ``write_p2g`` is deprecated and will be removed in NetworkX 3.9.
+       See :gh:`8195`.
     """
+    warnings.warn(
+        (
+            "\n\nwrite_p2g is deprecated and will be removed in NetworkX 3.9.\n"
+            "The p2g format is no longer documented or supported upstream; "
+            "see https://github.com/networkx/networkx/issues/8195."
+        ),
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
     path.write((f"{G.name}\n").encode(encoding))
     path.write((f"{G.order()} {G.size()}\n").encode(encoding))
     nodes = list(G)
@@ -78,9 +99,23 @@ def read_p2g(path, encoding="utf-8"):
     -----
     If you want a DiGraph (with no self loops allowed and no edge data)
     use D=nx.DiGraph(read_p2g(path))
+
+    .. deprecated:: 3.7
+       ``read_p2g`` is deprecated and will be removed in NetworkX 3.9.
+       See :gh:`8195`.
     """
+    warnings.warn(
+        (
+            "\n\nread_p2g is deprecated and will be removed in NetworkX 3.9.\n"
+            "The p2g format is no longer documented or supported upstream; "
+            "see https://github.com/networkx/networkx/issues/8195."
+        ),
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
     lines = (line.decode(encoding) for line in path)
-    G = parse_p2g(lines)
+    # Call the undecorated parse logic so we don't emit a second warning.
+    G = _parse_p2g(lines)
     return G
 
 
@@ -91,6 +126,29 @@ def parse_p2g(lines):
     Returns
     -------
     MultiDiGraph
+
+    Notes
+    -----
+    .. deprecated:: 3.7
+       ``parse_p2g`` is deprecated and will be removed in NetworkX 3.9.
+       See :gh:`8195`.
+    """
+    warnings.warn(
+        (
+            "\n\nparse_p2g is deprecated and will be removed in NetworkX 3.9.\n"
+            "The p2g format is no longer documented or supported upstream; "
+            "see https://github.com/networkx/networkx/issues/8195."
+        ),
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    return _parse_p2g(lines)
+
+
+def _parse_p2g(lines):
+    """Parse p2g format without emitting a deprecation warning.
+
+    Internal helper shared by :func:`read_p2g` and :func:`parse_p2g`.
     """
     description = next(lines).strip()
     # are multiedges (parallel edges) allowed?


### PR DESCRIPTION
Closes #8195.

## What

Adds a two-release deprecation cycle for the `networkx.readwrite.p2g` module (`write_p2g`, `read_p2g`, `parse_p2g`).

## Why

On #8195, @rossbar did the research on 2026-01-26 and concluded:

> Okay I did a little research and IMO p2g should just be deprecated.
>
> AFAICT, none of the locations on the web used to motivate the inclusion of p2g in networkx are active anymore. Links to the [description of the format](https://web.archive.org/web/20080704192005/http://www.cs.purdue.edu/homes/koyuturk/pathway/) haven't been active since 2008(!). Similarly, the KEGG database which defined the format [no longer exists](https://web.archive.org/web/20080625005119/http://www.kegg.com/) (or at least not in any sort of open/accessible format — the `kegg.com` URL now redirects to a Japanese company offering data licensing options).

This PR implements that direction.

## How

- **`networkx/readwrite/p2g.py`**
  - Added `.. deprecated:: 3.7` to the module docstring and to each public function's docstring.
  - `write_p2g`, `read_p2g`, and `parse_p2g` now emit a `DeprecationWarning` at call time via `warnings.warn(..., category=DeprecationWarning, stacklevel=2)`, matching the `metric_closure` / `bfs_predecessors` pattern from prior deprecations.
  - Factored the body of `parse_p2g` into a private `_parse_p2g` helper so `read_p2g` → `parse_p2g` doesn't emit two warnings per call. `_parse_p2g` is silent.
- **`networkx/conftest.py`** — added three `warnings.filterwarnings("ignore", …)` entries so the existing `tests/test_p2g.py` suite stays quiet.
- **`doc/developer/deprecations.rst`** — added a reminder under the existing `Version 3.9` section to remove the module, its tests, and the conftest filters during the 3.9 removal cycle.

## Versioning

Current `networkx.__version__` is `3.7rc0.dev0`, so the two-release cycle per `doc/developer/deprecations.rst` is 3.7 → 3.9 (warning in 3.7, removal in 3.9). This matches the `bfs_predecessors` entry already in the `Version 3.9` section.

## Verification

Verified locally that:

- `write_p2g`, `read_p2g`, `parse_p2g` each emit exactly one `DeprecationWarning` with the expected message pointing at #8195.
- `_parse_p2g` is silent (no warning when the internal helper is used directly).
- `read_p2g` no longer double-warns through the `parse_p2g` indirection.
- The `conftest.py` filter patterns match the emitted messages (all three use the `\n\n<funcname>` prefix the project already uses for `bfs_predecessors`).
- Module/`conftest.py` still pass `python -m py_compile`.

No behaviour change for existing callers — the module stays fully functional until 3.9.