### PR TITLE
Fixed incorrect description of modularity formula for directed graphs

### DIFF
--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -173,7 +173,7 @@ def modularity(G, communities, weight="weight", resolution=1):
     simply use gamma=1. More on the choice of gamma is in [4]_.
 
     The second formula is the one actually used in calculation of the modularity.
-    For directed graphs the second formula replaces $k_c$ with $k^{in}_c k^{out}_c$.
+    For directed graphs the second formula replaces $k_c^2$ with $k^{in}_c k^{out}_c$.
 
     Parameters
     ----------


### PR DESCRIPTION
The doc string for the function `modularity` has a typo which leads to a slightly incorrect description of the formula used to compute modularity for the case with directed graphs. This was pointed out by @dschult in a [comment](https://github.com/networkx/networkx/pull/8509/changes#r3061320126) in #8509.