### PR TITLE
fix multigraph isomorphism tests and fix support in ISMAGS and in VF2pp

### DIFF
--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -268,11 +268,31 @@ def color_degree_by_node(G, n_colors, e_colors):
                     e_colors[n, v] = None
     # undirected colored degree
     if not G.is_directed():
+        if G.is_multigraph():
+            return {
+                u: (
+                    n_colors[u],
+                    Counter((e_colors[u, v], len(G[u][v]), n_colors[v]) for v in nbrs),
+                )
+                for u, nbrs in G.adjacency()
+            }
         return {
             u: (n_colors[u], Counter((e_colors[u, v], n_colors[v]) for v in nbrs))
             for u, nbrs in G.adjacency()
         }
     # directed colored out and in degree
+    if G.is_multigraph():
+        return {
+            u: (
+                n_colors[u],
+                Counter((e_colors[u, v], len(G[u][v]), n_colors[v]) for v in nbrs),
+                Counter(
+                    (e_colors[v, u], len(kd), n_colors[v])
+                    for v, kd in G._pred[u].items()
+                ),
+            )
+            for u, nbrs in G.adjacency()
+        }
     return {
         u: (
             n_colors[u],
@@ -957,16 +977,21 @@ class ISMAGS:
                     sgn_nbrs = subgraph_adj[sgn]
                     not_gn_nbrs = graph_adj.keys() - graph_adj[gn].keys()
                     for sgn2 in left_to_map:
-                        # edge color must match when sgn2 connected to sgn
                         if sgn2 not in sgn_nbrs:
                             gn2_cands = not_gn_nbrs
                         else:
+                            # edge color must match when sgn2 connected to sgn
                             g_edges = self_ge_partition[self_sge_colors[sgn, sgn2]]
-                            gn2_cands = {n for e in g_edges if gn in e for n in e}
-                        # Node color compatibility should be taken care of by the
-                        # initial candidate lists made by find_subgraphs
-
-                        # Add gn2_cands to the right collection.
+                            # check if (gn, gn2) has same number of edges as (sgn, sgn2)
+                            sgn_multi_cnt = subgraph.number_of_edges(sgn, sgn2)
+                            gn2_cands = {
+                                n
+                                for e in g_edges
+                                if gn in e
+                                for n in e
+                                if n != gn
+                                if graph.number_of_edges(gn, n) == sgn_multi_cnt
+                            }
                         # Do not change the original set. So do not use |= operator
                         cand_sets[sgn2] = cand_sets[sgn2] | {frozenset(gn2_cands)}
                 else:  # directed
@@ -981,18 +1006,42 @@ class ISMAGS:
                             if sgn2 not in sgn_preds:
                                 gn2_cands = not_gn_nbrs
                             else:  # sgn2 in sgn_preds
+                                sgn_multi_in = subgraph.number_of_edges(sgn2, sgn)
                                 g_edges = self_ge_partition[self_sge_colors[sgn2, sgn]]
-                                gn2_cands = {e[0] for e in g_edges if gn == e[1]}
+                                gn2_cands = {
+                                    u
+                                    for u, v in g_edges
+                                    if gn == v
+                                    if graph.number_of_edges(u, gn) == sgn_multi_in
+                                }
                         else:
                             if sgn2 not in sgn_preds:
+                                sgn_multi_out = subgraph.number_of_edges(sgn, sgn2)
                                 g_edges = self_ge_partition[self_sge_colors[sgn, sgn2]]
-                                gn2_cands = {e[1] for e in g_edges if gn == e[0]}
+                                gn2_cands = {
+                                    v
+                                    for u, v in g_edges
+                                    if gn == u
+                                    if graph.number_of_edges(gn, v) == sgn_multi_out
+                                }
                             else:
+                                sgn_multi_out = subgraph.number_of_edges(sgn, sgn2)
+                                sgn_multi_in = subgraph.number_of_edges(sgn2, sgn)
                                 # gn2 must have correct color in both directions
                                 g_edges = self_ge_partition[self_sge_colors[sgn, sgn2]]
-                                gn2_cands = {e[1] for e in g_edges if gn == e[0]}
+                                gn2_cands = {
+                                    v
+                                    for u, v in g_edges
+                                    if gn == u
+                                    if graph.number_of_edges(gn, v) == sgn_multi_out
+                                }
                                 g_edges = self_ge_partition[self_sge_colors[sgn2, sgn]]
-                                gn2_cands &= {e[0] for e in g_edges if gn == e[1]}
+                                gn2_cands &= {
+                                    u
+                                    for u, v in g_edges
+                                    if gn == v
+                                    if graph.number_of_edges(u, gn) == sgn_multi_in
+                                }
                         # Do not change the original set. So do not use |= operator
                         cand_sets[sgn2] = cand_sets[sgn2] | {frozenset(gn2_cands)}
 

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -277,7 +277,7 @@ def color_degree_by_node(G, n_colors, e_colors):
                 for u, nbrs in G.adjacency()
             }
         return {
-            u: (n_colors[u], Counter((e_colors[u, v], n_colors[v]) for v in nbrs))
+            u: (n_colors[u], Counter((e_colors[u, v], 1, n_colors[v]) for v in nbrs))
             for u, nbrs in G.adjacency()
         }
     # directed colored out and in degree
@@ -296,8 +296,8 @@ def color_degree_by_node(G, n_colors, e_colors):
     return {
         u: (
             n_colors[u],
-            Counter((e_colors[u, v], n_colors[v]) for v in nbrs),
-            Counter((e_colors[v, u], n_colors[v]) for v in G._pred[u]),
+            Counter((e_colors[u, v], 1, n_colors[v]) for v in nbrs),
+            Counter((e_colors[v, u], 1, n_colors[v]) for v in G._pred[u]),
         )
         for u, nbrs in G.adjacency()
     }

--- a/networkx/algorithms/isomorphism/tests/test_common.py
+++ b/networkx/algorithms/isomorphism/tests/test_common.py
@@ -5,7 +5,7 @@ import pytest
 import networkx as nx
 from networkx.algorithms import isomorphism as iso
 
-graph_classes = [nx.Graph, nx.MultiGraph, nx.DiGraph, nx.MultiDiGraph]
+graph_classes = [nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph]
 
 labels_same = ["blue"]
 labels_many = [
@@ -70,7 +70,7 @@ def ismags_iter(G1, G2, node_label=None, edge_label=None, symmetry=False):
     return iso.ISMAGS(G1, G2, node_label, edge_label).isomorphisms_iter(symmetry)
 
 
-def ismags_subgraph_is_iso(G1, G2, node_label=None, edge_label=None, symmetry=False):
+def ismags_is_SG_iso(G1, G2, node_label=None, edge_label=None, symmetry=False):
     return iso.ISMAGS(G1, G2, node_label, edge_label).subgraph_is_isomorphic(
         symmetry=symmetry
     )
@@ -81,7 +81,7 @@ def ismags_subgraph_iter(G1, G2, node_label=None, edge_label=None, symmetry=Fals
     return gm.subgraph_isomorphisms_iter(symmetry=symmetry)
 
 
-def ismags_subgraph_is_mono(G1, G2, node_label=None, edge_label=None, symmetry=False):
+def ismags_is_SG_mono(G1, G2, node_label=None, edge_label=None, symmetry=False):
     pytest.xfail("ismags does not handle monomorphism yet")
 
 
@@ -103,7 +103,7 @@ def vf2_iter(G1, G2, node_label=None, edge_label=None, symmetry=False):
     return gm(G1, G2, node_label, edge_label).isomorphisms_iter()
 
 
-def vf2_subgraph_is_iso(G1, G2, node_label=None, edge_label=None, symmetry=False):
+def vf2_is_SG_iso(G1, G2, node_label=None, edge_label=None, symmetry=False):
     if symmetry:
         pytest.xfail("vf2 does not handle symmetries yet")
     gm = iso.GraphMatcher if not G1.is_directed() else iso.DiGraphMatcher
@@ -117,7 +117,7 @@ def vf2_subgraph_iter(G1, G2, node_label=None, edge_label=None, symmetry=False):
     return gm(G1, G2, node_label, edge_label).subgraph_isomorphisms_iter()
 
 
-def vf2_subgraph_is_mono(G1, G2, node_label=None, edge_label=None, symmetry=False):
+def vf2_is_SG_mono(G1, G2, node_label=None, edge_label=None, symmetry=False):
     if symmetry:
         pytest.xfail("vf2 does not handle symmetries yet")
     gm = iso.GraphMatcher if not G1.is_directed() else iso.DiGraphMatcher
@@ -155,7 +155,7 @@ def vf2pp_iter(G1, G2, node_label=None, edge_label=None, symmetry=False):
     return nx.vf2pp_all_isomorphisms(G1, G2, node_label)
 
 
-def vf2pp_subgraph_is_iso(G1, G2, node_label=None, edge_label=None, symmetry=False):
+def vf2pp_is_SG_iso(G1, G2, node_label=None, edge_label=None, symmetry=False):
     if symmetry:
         pytest.xfail("vf2pp does not handle symmetries yet")
         return nx.vf2pp_all_isomorphisms(G1, G2, symmetry=symmetry)
@@ -183,7 +183,7 @@ def vf2pp_subgraph_iter(G1, G2, node_label=None, edge_label=None, symmetry=False
     return nx.vf2pp_all_subgraph_isomorphisms(G1, G2, node_label)
 
 
-def vf2pp_subgraph_is_mono(G1, G2, node_label=None, edge_label=None, symmetry=False):
+def vf2pp_is_SG_mono(G1, G2, node_label=None, edge_label=None, symmetry=False):
     if symmetry:
         pytest.xfail("vf2pp does not handle symmetries yet")
         try:
@@ -225,14 +225,14 @@ is_funcs = {
     "ismags": (ismags_is_iso, ismags_iter),
 }
 SG_funcs = {
-    "vf2_subgraph": (vf2_subgraph_is_iso, vf2_subgraph_iter),
-    "vf2pp_subgraph": (vf2pp_subgraph_is_iso, vf2pp_subgraph_iter),
-    "ismags_subgraph": (ismags_subgraph_is_iso, ismags_subgraph_iter),
+    "vf2_SG": (vf2_is_SG_iso, vf2_subgraph_iter),
+    "vf2pp_SG": (vf2pp_is_SG_iso, vf2pp_subgraph_iter),
+    "ismags_SG": (ismags_is_SG_iso, ismags_subgraph_iter),
 }
 mono_funcs = {
-    "vf2_mono": (vf2_subgraph_is_mono, vf2_mono_iter),
-    "vf2pp_mono": (vf2pp_subgraph_is_mono, vf2pp_mono_iter),
-    "ismags_mono": (ismags_subgraph_is_mono, ismags_mono_iter),
+    "vf2_mono": (vf2_is_SG_mono, vf2_mono_iter),
+    "vf2pp_mono": (vf2pp_is_SG_mono, vf2pp_mono_iter),
+    "ismags_mono": (ismags_is_SG_mono, ismags_mono_iter),
 }
 morphism_funcs = is_funcs | SG_funcs | mono_funcs
 
@@ -241,7 +241,7 @@ mono_iters = [pytest.param(fn[1], id=id) for id, fn in mono_funcs.items()]
 morphic_and_mapping = [pytest.param(*fns, id=id) for id, fns in morphism_funcs.items()]
 
 is_iso_funcs = [pytest.param(fn[0], id=id) for id, fn in is_funcs.items()]
-subgraph_iso_funcs = [pytest.param(fn[0], id=id) for id, fn in SG_funcs.items()]
+is_SG_funcs = [pytest.param(fn[0], id=id) for id, fn in SG_funcs.items()]
 is_mono_funcs = [pytest.param(fn[0], id=id) for id, fn in mono_funcs.items()]
 
 
@@ -254,12 +254,26 @@ def asymm_3triangles_kite():
         [(1, 2), (1, 3), (1, 4), (2, 3), (3, 2), (2, 6), (3, 4), (1, 5), (2, 5)]
     )
     # for multiedges
-    G.add_edges_from([e for i, e in enumerate(G.edges) if i % 2 == 0])
+    G.add_edges_from([e for i, e in enumerate(G.edges()) if i % 2 == 0])
     # for selfloops (node 1, 2 and 3 mapped to selves)
     G.add_edges_from([(1, 1), (2, 2), (3, 3)])
 
     G.graph["name"] = "asymm_3triangles_kite"
-    G.graph["numb_symmetries"] = 1
+    G.graph["numb_symmetries"] = {g: 1 for g in graph_classes}
+    G.graph["mappings"] = {
+        nx.Graph: [  # USG  (undirected simple graph)
+            {1:1, 2:2, 3:3, 4:4, 6:6, 5:5},
+        ],
+        nx.DiGraph: [  # DSG  (undirected simple graph)
+            {1:1, 2:2, 3:3, 4:4, 6:6, 5:5},
+        ],
+        nx.MultiGraph: [  # UMG  (undirected multi graph)
+            {1:1, 2:2, 3:3, 4:4, 6:6, 5:5},
+        ],
+        nx.MultiDiGraph: [  # DMG  (directed multi graph)
+            {1:1, 2:2, 3:3, 4:4, 6:6, 5:5},
+        ],
+    }  # fmt: skip
     G.graph["show"] = r"""
    5-1-4
    |/ \|
@@ -273,12 +287,26 @@ def asymm_triangle_square_2tails():
         [(1, 2), (5, 1), (5, 6), (2, 3), (2, 4), (3, 4), (5, 4), (2, 7)]
     )
     # for multiedges
-    G.add_edges_from([e for i, e in enumerate(G.edges) if i % 2 == 0])
+    G.add_edges_from([e for i, e in enumerate(G.edges()) if i % 2 == 0])
     G.add_edges_from([(1, 1), (2, 2), (3, 3)])
 
     G.graph["name"] = "asymm_triangle_square_2tails"
-    G.graph["numb_symmetries"] = 1
+    G.graph["numb_symmetries"] = {g: 1 for g in graph_classes}
     G.graph["subgraph_nodes"] = [[2, 3, 4, 7], [1, 4, 5, 6]]
+    G.graph["mappings"] = {
+        nx.Graph: [  # USG  (undirected simple graph)
+            {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7},
+        ],
+        nx.DiGraph: [  # DSG  (undirected simple graph)
+            {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7},
+        ],
+        nx.MultiGraph: [  # UMG  (undirected multi graph)
+            {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7},
+        ],
+        nx.MultiDiGraph: [  # DMG  (directed multi graph)
+            {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7},
+        ],
+    }  # fmt: skip
     G.graph["show"] = r"""
   7-2-1
    /| |
@@ -292,13 +320,28 @@ def symm_water_tower():
         [(1, 2), (1, 3), (1, 4), (2, 3), (3, 2), (2, 6), (4, 3), (3, 7), (1, 5), (5, 2)]
     )
     # for multiedges
-    G.add_edges_from([e for i, e in enumerate(G.edges) if i % 2 == 0])
+    G.add_edges_from([e for i, e in enumerate(G.edges()) if i % 2 == 0])
     # for selfloops (node 1 is mapped to itself, nodes 2 and 3 to each other)
     G.add_edges_from([(1, 1), (2, 2), (3, 3)])
 
     G.graph["name"] = "symm_water_tower"
-    G.graph["numb_symmetries"] = 2
-    G.graph["mappings"] = [{1: 1, 2: 3, 3: 2, 4: 5, 5: 4, 6: 7, 7: 6}]
+    G.graph["numb_symmetries"] = dict(zip(graph_classes, (2, 2, 1, 1)))
+    G.graph["mappings"] = {
+        nx.Graph: [  # USG  (undirected simple graph)
+            {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7},
+            {1:1, 3:2, 2:3, 4:5, 5:4, 6:7, 7:6},
+        ],
+        nx.DiGraph: [  # DSG  (undirected simple graph)
+            {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7},
+            {1:1, 3:2, 2:3, 4:5, 5:4, 6:7, 7:6},
+        ],
+        nx.MultiGraph: [  # UMG  (undirected multi graph)
+            {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7},
+        ],
+        nx.MultiDiGraph: [  # DMG  (directed multi graph)
+            {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7},
+        ],
+    }  # fmt: skip
     G.graph["show"] = r"""
   5-1-4
   |/ \|    mapping: 1-7 <-> (1, 3, 2, 5, 4, 7, 6)
@@ -315,7 +358,7 @@ def symm_balloon():
     nx.add_cycle(G, [2, 3, 4, 5])
     nx.add_cycle(G, [5, 6, 7, 4, 9, 8])
     # for multiedges
-    G.add_edges_from([e for i, e in enumerate(G.edges) if i % 2 == 0])
+    G.add_edges_from([(6, 7)])
     # for selfloops (node 1 is mapped to itself, nodes 2 and 3 to each other)
     G.add_edges_from([(1, 1), (2, 2), (3, 3)])
     # make directed have mappings too
@@ -323,20 +366,26 @@ def symm_balloon():
     nx.add_cycle(G, [3, 2, 1])
 
     G.graph["name"] = "symm_balloon"
-    G.graph["numb_symmetries"] = 4
-    G.graph["numb_directed_symmetries"] = 2
-    G.graph["directed_mappings"] = [
-        {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 8, 7: 9, 9: 7, 8: 6},
-    ]
-    G.graph["mappings"] = [
-        # {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 9: 9, 8: 8},
-        {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 8: 6, 9: 7, 7: 9, 6: 8},
-        {1: 1, 3: 2, 2: 3, 5: 4, 4: 5, 9: 6, 8: 7, 6: 9, 7: 8},
-        {1: 1, 3: 2, 2: 3, 5: 4, 4: 5, 7: 6, 6: 7, 8: 9, 9: 8},
-        # {1: 1, 2: 3, 3: 2, 4: 5, 5: 4, 6: 8, 7: 9, 8: 6, 9: 7},
-        # {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 7, 7: 6, 8: 9, 9: 8},
-        # {1: 1, 2: 3, 3: 2, 4: 5, 5: 4, 6: 6, 7: 7, 8: 8, 9: 9},
-    ]
+    G.graph["numb_symmetries"] = dict(zip(graph_classes, (4, 2, 2, 1)))
+    G.graph["mappings"] = {
+        nx.Graph: [  # USG  (undirected simple graph)
+          {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 9:9, 8:8},
+          {1:1, 2:2, 3:3, 4:4, 5:5, 8:6, 9:7, 7:9, 6:8},
+          {1:1, 3:2, 2:3, 5:4, 4:5, 9:6, 8:7, 6:9, 7:8},
+          {1:1, 3:2, 2:3, 5:4, 4:5, 7:6, 6:7, 8:9, 9:8},
+        ],
+        nx.DiGraph: [  # DSG  (undirected simple graph)
+          {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 9:9, 8:8},
+          {1:1, 2:2, 3:3, 4:4, 5:5, 8:6, 9:7, 7:9, 6:8},
+        ],
+        nx.MultiGraph: [  # UMG  (undirected multi graph)
+          {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 9:9, 8:8},
+          {1:1, 3:2, 2:3, 5:4, 4:5, 7:6, 6:7, 8:9, 9:8},
+        ],
+        nx.MultiDiGraph: [  # DMG  (directed multi graph)
+          {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 9:9, 8:8},
+        ],
+    }  # fmt: skip
     G.graph["show"] = r"""
      3---4
     /|  /|\
@@ -353,19 +402,29 @@ def cyclic_ladder_4rungs():
     G = nx.cycle_graph([1, 2, 3, 7, 6, 5, 8, 4], create_using=nx.MultiDiGraph)
     G.add_edges_from([(1, 5), (6, 2), (3, 4), (7, 8), (2, 1)])
     # for multiedges
-    G.add_edges_from([e for i, e in enumerate(G.edges) if i % 2 == 0])
+    G.add_edges_from([e for i, e in enumerate(G.edges()) if i % 2 == 0])
     # for selfloops
     G.add_edges_from([(0, 0), (2, 2), (4, 4)])
 
     G.graph["name"] = "cyclic_ladder_4rungs"
-    G.graph["numb_symmetries"] = 4
-    G.graph["numb_directed_symmetries"] = 1
-    G.graph["directed_mappings"] = []
-    G.graph["mappings"] = [
-        {1: 1, 4: 2, 3: 3, 7: 7, 8: 6, 5: 5, 6: 8, 2: 4, 0: 0},
-        {3: 1, 2: 2, 1: 3, 5: 7, 6: 6, 7: 5, 8: 8, 4: 4, 0: 0},
-        {3: 1, 4: 2, 1: 3, 5: 7, 8: 6, 7: 5, 6: 8, 2: 4, 0: 0},
-    ]
+    G.graph["numb_symmetries"] = dict(zip(graph_classes, (4, 1, 1, 1)))
+    G.graph["mappings"] = {
+        nx.Graph: [
+          {1:1, 2:2, 3:3, 7:7, 6:6, 5:5, 8:8, 4:4, 0:0},
+          {1:1, 4:2, 3:3, 7:7, 8:6, 5:5, 6:8, 2:4, 0:0},
+          {3:1, 2:2, 1:3, 5:7, 6:6, 7:5, 8:8, 4:4, 0:0},
+          {3:1, 4:2, 1:3, 5:7, 8:6, 7:5, 6:8, 2:4, 0:0},
+        ],
+        nx.DiGraph: [
+          {1:1, 2:2, 3:3, 7:7, 6:6, 5:5, 8:8, 4:4, 0:0},
+        ],
+        nx.MultiGraph: [
+          {1:1, 2:2, 3:3, 7:7, 6:6, 5:5, 8:8, 4:4, 0:0},
+        ],
+        nx.MultiDiGraph: [
+          {1:1, 2:2, 3:3, 7:7, 6:6, 5:5, 8:8, 4:4, 0:0},
+        ],
+    }  # fmt: skip
     G.graph["show"] = r"""
       1
      /|\
@@ -387,13 +446,45 @@ def cycle6_plus_3_2paths():
     nx.add_path(G, [2, 8, 9])
     nx.add_path(G, [4, 10, 11])
     # for multiedges
-    G.add_edges_from([e for i, e in enumerate(G.edges) if i % 2 == 0])
+    G.add_edges_from([e for i, e in enumerate(G.edges()) if i % 2 == 0])
     # for selfloops
     G.add_edges_from([(0, 0), (2, 2), (4, 4)])
 
     G.graph["name"] = "cycle6_plus_3_2paths"
-    G.graph["show"] = "6-cycle with 2-paths stuck onto nodes 0, 2, 4"
-    G.graph["numb_symmetries"] = 6
+    G.graph["numb_symmetries"] = dict(zip(graph_classes, (6, 6, 1, 1)))
+    G.graph["mappings"] = {
+      nx.Graph: [
+        {0:0, 1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8, 9:9, 10:10, 11:11},
+        {0:0, 5:1, 4:2, 3:3, 2:4, 1:5, 6:6, 7:7, 10:8, 11:9, 8:10, 9:11},
+        {2:0, 1:1, 0:2, 5:3, 4:4, 3:5, 8:6, 9:7, 6:8, 7:9, 10:10, 11:11},
+        {2:0, 3:1, 4:2, 5:3, 0:4, 1:5, 8:6, 9:7, 10:8, 11:9, 6:10, 7:11},
+        {4:0, 3:1, 2:2, 1:3, 0:4, 5:5, 10:6, 11:7, 8:8, 9:9, 6:10, 7:11},
+        {4:0, 5:1, 0:2, 1:3, 2:4, 3:5, 10:6, 11:7, 6:8, 7:9, 8:10, 9:11},
+      ],
+      nx.DiGraph: [
+        {0:0, 1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8, 9:9, 10:10, 11:11},
+        {0:0, 5:1, 4:2, 3:3, 2:4, 1:5, 6:6, 7:7, 10:8, 11:9, 8:10, 9:11},
+        {2:0, 1:1, 0:2, 5:3, 4:4, 3:5, 8:6, 9:7, 6:8, 7:9, 10:10, 11:11},
+        {2:0, 3:1, 4:2, 5:3, 0:4, 1:5, 8:6, 9:7, 10:8, 11:9, 6:10, 7:11},
+        {4:0, 3:1, 2:2, 1:3, 0:4, 5:5, 10:6, 11:7, 8:8, 9:9, 6:10, 7:11},
+        {4:0, 5:1, 0:2, 1:3, 2:4, 3:5, 10:6, 11:7, 6:8, 7:9, 8:10, 9:11},
+      ],
+      nx.MultiGraph: [
+        {0:0, 1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8, 9:9, 10:10, 11:11},
+        ],
+      nx.MultiDiGraph: [
+        {0:0, 1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8, 9:9, 10:10, 11:11},
+      ],
+    }  # fmt: skip
+    G.graph["show"] = r"""
+          0-6-7
+         / \
+        1   5
+        |   |
+    8-9-2   4-10-11
+         \ /
+          3
+"""
     return G
 
 
@@ -422,21 +513,22 @@ def test_single_graph(G, Gclass, iso_ic, iso_iter, symmetry):
     assert iso_ic(G1, G1, symmetry=symmetry)
     assert list(iso_iter(G1, G1, symmetry=symmetry))
 
-    numb_key = "numb_directed_symmetries" if G1.is_directed() else "numb_symmetries"
-    sym = G1.graph.get(numb_key, None)
-    if sym is not None:
-        all_mappings = list(iso_iter(G1, G1, symmetry=symmetry))
-        assert len(all_mappings) == (1 if symmetry else sym)
+    all_mappings = list(iso_iter(G1, G1, symmetry=symmetry))
 
-    map_key = "directed_mappings" if G1.is_directed() else "mappings"
-    mappings = G1.graph.get(map_key, None)
-    if mappings is not None:
-        all_mappings = list(iso_iter(G1, G1, symmetry=symmetry))
+    sym = G1.graph.get("numb_symmetries", None)
+    mappings = G1.graph.get("mappings", None)
+
+    if sym is not None or mappings is not None:
         if symmetry:
             assert len(all_mappings) == 1
-        else:
-            assert all(m in all_mappings for m in mappings)
-            assert len(all_mappings) == len(mappings) + 1
+            return
+        g_type = G1.__class__
+        if sym is not None:
+            assert len(all_mappings) == sym[g_type]
+        if mappings is not None:
+            list_of_maps = mappings[g_type]
+            assert len(all_mappings) == len(list_of_maps)
+            assert all(m in all_mappings for m in list_of_maps)
 
     G2 = G1.copy()
     G2.remove_edge(2, 2)
@@ -492,11 +584,26 @@ def test_single_graph_node_and_edge_labels(G, Gclass, iso_ic, symmetry):
     # swap two node labels and two edge "foo" values
     nodes, edges = G2.nodes, G2.edges
     node1_d, node2_d = (nodes[n] for n in it.islice(nodes, 2))
-    edge1_d, edge2_d = (edges[n] for n in it.islice(edges, 2))
+    edge1_d, edge2_d = (edges[e] for e in it.islice(edges, 2))
     assert node1_d["label"] != node2_d["label"]
     assert edge1_d["foo"] != edge2_d["foo"]
     node2_d["label"], node1_d["label"] = node1_d["label"], node2_d["label"]
     edge2_d["foo"], edge1_d["foo"] = edge1_d["foo"], edge2_d["foo"]
+    if G2.is_multigraph():
+        e1, e2 = it.islice(edges, 2)
+        if e1[:2] == e2[:2]:
+            # test case where two multiedges on same nodes can swap labels
+            assert iso_ic(G1, G2, node_label=None, edge_label=em, symmetry=symmetry)
+            # now swap two edges without same nodes
+            edge2_d["foo"], edge1_d["foo"] = edge1_d["foo"], edge2_d["foo"]
+            e_iter = it.islice(edges, 2, None)
+            e2 = next(e_iter)
+            while e1[:2] == e2[:2]:
+                e2 = next(e_iter)
+            edge2_d = edges[e2]
+            edge2_d["foo"], edge1_d["foo"] = edge1_d["foo"], edge2_d["foo"]
+    # dont select first two to ensure not multiedges with same nodes
+    edge1_d, edge2_d = (edges[e] for e in it.islice(edges, 0, 3, 2))
 
     assert iso_ic(G1, G2, node_label=None, edge_label=None, symmetry=symmetry)
     assert not iso_ic(G1, G2, node_label=nm, edge_label=None, symmetry=symmetry)
@@ -516,7 +623,7 @@ def test_non_isomorphic_same_degree_sequence(iso_ic, symmetry, Gclass):
     nx.add_cycle(G, [5, 6, 7, 8])
     G.add_edge(1, 5)
     # for multiedges
-    G.add_edges_from([e for i, e in enumerate(G.edges) if i % 2 == 0])
+    G.add_edges_from([e for i, e in enumerate(G.edges()) if i % 2 == 0])
     G.add_edges_from([(1, 1), (3, 3), (6, 6)])
 
     G1 = G.copy()
@@ -536,18 +643,24 @@ def test_morph_triangle_square_2tails(iso_ic, symmetry, Gclass):
      /| |
     3-4-5-6
     """
-    G = asymm_triangle_square_2tails()
+    G = Gclass(asymm_triangle_square_2tails())
     G1 = G.subgraph([2, 3, 4, 7]).copy()
     G2 = G.subgraph([1, 4, 5, 6]).copy()
-    assert not iso_ic(Gclass(G1), Gclass(G2), symmetry=symmetry)
+    assert not iso_ic(G1, G2, symmetry=symmetry)
 
     G1.remove_edge(2, 2)
+    G1.add_edge(2, 3)  # adjust multiedge to match 1-5 multiedge
     G2.add_edge(1, 4)
-    assert iso_ic(Gclass(G1), Gclass(G2), symmetry=symmetry)
+    assert iso_ic(G1, G2, symmetry=symmetry)
 
     G1.add_edges_from([(3, 7), (4, 7)])
     G2.add_edges_from([(1, 6), (4, 6)])
-    assert iso_ic(Gclass(G1), Gclass(G2), symmetry=symmetry)
+    assert iso_ic(G1, G2, symmetry=symmetry)
+    # check todirected version (creates a symmetry in a DiGraph)
+    if G1.is_directed():
+        G1d = G1.to_undirected().to_directed()
+        G2d = G2.to_undirected().to_directed()
+        assert iso_ic(G1d, G2d, symmetry=symmetry)
 
 
 @pytest.mark.parametrize("Gclass", graph_classes)
@@ -559,23 +672,24 @@ def test_morph_3triangles_kite(iso_ic, symmetry, Gclass):
       |/ \|
     6-2---3
     """
-    G1 = asymm_3triangles_kite()
+    G1 = Gclass(asymm_3triangles_kite())
     G2 = G1.copy()
-    assert iso_ic(Gclass(G1), Gclass(G2), symmetry=symmetry)
+    simplegraph = not G1.is_multigraph()
+    assert iso_ic(G1, G2, symmetry=symmetry)
     G2.remove_edges_from([(2, 6)])
-    assert not iso_ic(Gclass(G1), Gclass(G2), symmetry=symmetry)
+    assert not iso_ic(G1, G2, symmetry=symmetry)
     G2.add_edges_from([(3, 7)])
-    assert not iso_ic(Gclass(G1), Gclass(G2), symmetry=symmetry)
+    assert not iso_ic(G1, G2, symmetry=symmetry)
     G2.remove_node(6)
-    assert iso_ic(Gclass(G1), Gclass(G2), symmetry=symmetry)
+    assert iso_ic(G1, G2, symmetry=symmetry) == simplegraph
 
     G2.add_edges_from([(5, 5), (5, 5), (1, 1)])
-    assert not iso_ic(Gclass(G1), Gclass(G2), symmetry=symmetry)
+    assert not iso_ic(G1, G2, symmetry=symmetry)
     G1.add_edges_from([(4, 4), (4, 4), (1, 1)])
-    assert iso_ic(Gclass(G1), Gclass(G2), symmetry=symmetry)
+    assert iso_ic(G1, G2, symmetry=symmetry) == simplegraph
     G2.remove_edge(1, 4)
     G1.remove_edge(1, 5)
-    assert iso_ic(Gclass(G1), Gclass(G2), symmetry=symmetry)
+    assert iso_ic(G1, G2, symmetry=symmetry) == simplegraph
 
 
 ## Subgraph iso and mono
@@ -583,20 +697,20 @@ def test_morph_3triangles_kite(iso_ic, symmetry, Gclass):
 
 @pytest.mark.parametrize("Gclass", graph_classes)
 @pytest.mark.parametrize("symmetry", [True, False])
-@pytest.mark.parametrize("iso_ic", subgraph_iso_funcs + is_mono_funcs)
+@pytest.mark.parametrize("iso_ic", is_SG_funcs + is_mono_funcs)
 def test_subgraph_triangle_square_2tails(iso_ic, symmetry, Gclass):
     r"""
     7-2-1
      /| |
-    3-4-5-6
+    3-4-5-6 multiedges on the square (1, 2), (2, 4), (5, 1), (5, 4)
     """
     mono = "mono" in iso_ic.__name__
     FG = asymm_triangle_square_2tails()
 
     SG = FG.subgraph([2, 3, 4, 7]).copy()
     assert iso_ic(Gclass(FG), Gclass(SG), symmetry=symmetry)
-    SG.remove_edge(2, 3)
 
+    SG.remove_edge(2, 3)
     assert mono == iso_ic(Gclass(FG), Gclass(SG), symmetry=symmetry)
 
     SG.add_edges_from([(7, 3), (7, 4)])
@@ -605,11 +719,11 @@ def test_subgraph_triangle_square_2tails(iso_ic, symmetry, Gclass):
 
 @pytest.mark.parametrize("Gclass", graph_classes)
 @pytest.mark.parametrize("symmetry", [False, True])
-@pytest.mark.parametrize("iso_ic", subgraph_iso_funcs + is_mono_funcs)
+@pytest.mark.parametrize("iso_ic", is_SG_funcs + is_mono_funcs)
 def test_monomorphism_path_in_cycle(iso_ic, symmetry, Gclass):
     FG = nx.cycle_graph(14, create_using=nx.MultiDiGraph)
     # for multiedges
-    FG.add_edges_from([e for i, e in enumerate(FG.edges) if i % 2 == 0])
+    FG.add_edges_from([e for i, e in enumerate(FG.edges()) if i % 2 == 0])
     # for selfloops (node 1, 2 and 3 mapped to selves)
     FG.add_edges_from([(1, 1), (2, 2), (3, 3)])
 
@@ -627,7 +741,7 @@ def test_monomorphism_path_in_cycle(iso_ic, symmetry, Gclass):
 def test_monomorphism_count_for_path_in_cycle(mono_iter, symmetry, Gclass):
     FG = nx.cycle_graph(14, create_using=nx.MultiDiGraph)
     # for multiedges
-    FG.add_edges_from([e for i, e in enumerate(FG.edges) if i % 2 == 0])
+    FG.add_edges_from([e for i, e in enumerate(FG.edges()) if i % 2 == 0])
     # for selfloops (node 1, 2 and 3 mapped to selves)
     FG.add_edges_from([(1, 1), (2, 2), (3, 3)])
 
@@ -639,7 +753,8 @@ def test_monomorphism_count_for_path_in_cycle(mono_iter, symmetry, Gclass):
     SG = Gclass(SG)
 
     mappings = mono_iter(FG, SG, symmetry=symmetry)
-    assert sum(1 for _ in mappings) == (1 if FG.is_directed() else 2)
+    ans = 1 if (FG.is_directed() or FG.is_multigraph()) else 2
+    assert sum(1 for _ in mappings) == ans
 
     # switch order of FG and SG (bigger cannot be subgraph)
     assert sum(1 for _ in mono_iter(SG, FG, symmetry=symmetry)) == 0
@@ -647,7 +762,7 @@ def test_monomorphism_count_for_path_in_cycle(mono_iter, symmetry, Gclass):
 
 @pytest.mark.parametrize("Gclass", graph_classes)
 @pytest.mark.parametrize("symmetry", [True, False])
-@pytest.mark.parametrize("SG_ic", subgraph_iso_funcs + is_mono_funcs)
+@pytest.mark.parametrize("SG_ic", is_SG_funcs + is_mono_funcs)
 def test_subgraph_mono(SG_ic, symmetry, Gclass):
     # wikipedia example
     FG = Gclass(
@@ -657,7 +772,7 @@ def test_subgraph_mono(SG_ic, symmetry, Gclass):
     # check that FG is always subgraph morphic to itself
     assert SG_ic(FG, FG, symmetry=symmetry)
 
-    # true if is_mono, false if subgraph_is_iso
+    # true if is_mono, false if is_SG
     assert SG_ic(FG, SG, symmetry=symmetry) == ("mono" in SG_ic.__name__)
 
     # switch order of FG and SG (bigger cannot be subgraph)
@@ -669,14 +784,14 @@ def test_subgraph_mono(SG_ic, symmetry, Gclass):
 
 @pytest.mark.parametrize("Gclass", graph_classes)
 @pytest.mark.parametrize("symmetry", [True, False])
-@pytest.mark.parametrize("SG_ic", subgraph_iso_funcs + is_mono_funcs + is_iso_funcs)
+@pytest.mark.parametrize("SG_ic", is_SG_funcs + is_mono_funcs + is_iso_funcs)
 def test_subgraph_mono_small(SG_ic, symmetry, Gclass):
     # small cycles
     FG = nx.cycle_graph("abcd", create_using=Gclass)
     SG = nx.path_graph(3, create_using=Gclass)
-    subgraph_morph = "subgraph" in SG_ic.__name__
-    mono_morph = "mono" in SG_ic.__name__
 
+    subgraph_morph = "SG" in SG_ic.__name__
+    mono_morph = "mono" in SG_ic.__name__
     # isolated node not in SG. is_iso => False, subgraph_is_* => True
     assert SG_ic(FG, SG, symmetry=symmetry) == subgraph_morph
 
@@ -691,45 +806,93 @@ def test_subgraph_mono_small(SG_ic, symmetry, Gclass):
 
 @pytest.mark.parametrize("Gclass", graph_classes)
 @pytest.mark.parametrize("symmetry", [True, False])
-@pytest.mark.parametrize("SG_ic", subgraph_iso_funcs + is_mono_funcs + is_iso_funcs)
+@pytest.mark.parametrize("SG_ic", is_SG_funcs + is_mono_funcs + is_iso_funcs)
 def test_multiedge_mono_subgraph(SG_ic, symmetry, Gclass):
     # small cycles
     FG = nx.cycle_graph("abcd", create_using=Gclass)
     SG = nx.path_graph(3, create_using=Gclass)
-    subgraph_morph = "subgraph" in SG_ic.__name__
+
+    subgraph_morph = "SG" in SG_ic.__name__  # induced iso or mono
     mono_morph = "mono" in SG_ic.__name__
-    not_multi = subgraph_morph and not SG.is_multigraph()
+    not_multi = not SG.is_multigraph()
+    multi_mono = mono_morph or (not_multi and subgraph_morph)
+
+    nm = nmatch
+    em = mematch if SG.is_multigraph() else ematch
 
     # add multiedges
     FG.add_edges_from(["ab", "ab"])
     SG.add_edges_from([(0, 1), (0, 1)])
-    assert SG_ic(FG, SG, symmetry=symmetry) == (not_multi or subgraph_morph)
+    assert SG_ic(FG, SG, symmetry=symmetry) == subgraph_morph
+    result = SG_ic(FG, SG, node_label=nm, edge_label=em, symmetry=symmetry)
+    assert result == subgraph_morph
+
+    # change color of one multiedge
+    if SG.is_multigraph():
+        SG[0][1][1]["foo"] = "pink"
+        assert not SG_ic(FG, SG, node_label=nm, edge_label=em, symmetry=symmetry)
+        del SG[0][1][1]["foo"]
+
+    # change number of multiedges
     FG.add_edges_from(["ab"])
 
-    # FIXME: check why fails ismags_SG with multigraphs but not vf2 or vf2pp
-    if "ismags" in SG_ic.__name__:
-        assert SG_ic(FG, SG, symmetry=symmetry) == (not_multi or subgraph_morph)
-        SG.add_edges_from([(0, 1), (0, 1)])
-        assert SG_ic(FG, SG, symmetry=symmetry) == (not_multi or subgraph_morph)
-    else:
-        assert SG_ic(FG, SG, symmetry=symmetry) == (not_multi or mono_morph)
-        SG.add_edges_from([(0, 1), (0, 1)])
-        assert SG_ic(FG, SG, symmetry=symmetry) == not_multi
+    assert SG_ic(FG, SG, symmetry=symmetry) == multi_mono
+    result = SG_ic(FG, SG, node_label=nm, edge_label=em, symmetry=symmetry)
+    assert result == multi_mono
 
+    # change SG to hve more multiedges than FG (not iso unless not multigraph)
+    SG.add_edges_from([(0, 1), (0, 1)])
+    assert SG_ic(FG, SG, symmetry=symmetry) == (not_multi and subgraph_morph)
+
+    # match multiedge count by adding edge to FG
     FG.add_edges_from(["ab"])
-    assert SG_ic(FG, SG, symmetry=symmetry) == (not_multi or subgraph_morph)
+    assert SG_ic(FG, SG, symmetry=symmetry) == subgraph_morph
 
 
 @pytest.mark.parametrize("Gclass", graph_classes)
 @pytest.mark.parametrize("symmetry", [True, False])
-@pytest.mark.parametrize("SG_ic", subgraph_iso_funcs + is_mono_funcs + is_iso_funcs)
-def test_twist(SG_ic, symmetry, Gclass):
-    FG = Gclass(
-        ["ag", "ah", "ai", "bg", "bh", "bj", "cg", "ci", "cj", "dh", "di", "dj"]
-    )
-    # change "ai" and "cj" to "ac" and "ij"
-    SG = Gclass(
-        ["ag", "ah", "ac", "bg", "bh", "bj", "cg", "ci", "ij", "dh", "di", "dj"]
-    )
+@pytest.mark.parametrize("SG_ic", is_SG_funcs + is_mono_funcs + is_iso_funcs)
+def test_multiedge_colors_like_multiple_graphs(SG_ic, symmetry, Gclass):
+    FG = nx.empty_graph(10, create_using=nx.MultiDiGraph)
+    SG = nx.empty_graph(10, create_using=nx.MultiDiGraph)
+    for i, G in enumerate(solo_graphs):
+        # The edges from each test graph are added with a different color
+        tmpG = G()
+        nx.set_edge_attributes(tmpG, i, "foo")
+        FG.add_edges_from(tmpG.edges(data="foo"))
+        # only some of the test graphs are added to the subgraph
+        if i < len(solo_graphs) / 2:
+            SG.add_edges_from(tmpG.edges(data="foo"))
 
-    assert not SG_ic(FG, SG, symmetry=symmetry)
+    FG = Gclass(FG)
+    SG = Gclass(SG)
+
+    mono_morph = "mono" in SG_ic.__name__
+
+    nm = nmatch
+    em = mematch if SG.is_multigraph() else ematch
+
+    assert SG_ic(SG, SG, symmetry=symmetry)
+    assert SG_ic(FG, FG, symmetry=symmetry)
+    assert SG_ic(FG, FG, node_label=nm, edge_label=em, symmetry=symmetry)
+    assert SG_ic(SG, SG, node_label=nm, edge_label=em, symmetry=symmetry)
+
+    assert not SG_ic(SG, FG, symmetry=symmetry)  # small graph is 1st input
+    assert SG_ic(FG, SG, symmetry=symmetry) == mono_morph
+    assert SG_ic(FG, SG, node_label=nm, edge_label=em, symmetry=symmetry) == mono_morph
+
+
+@pytest.mark.parametrize("symmetry", [True, False])
+@pytest.mark.parametrize("SG_ic", is_SG_funcs + is_mono_funcs + is_iso_funcs)
+def test_match_multiedge_to_simple_graph(SG_ic, symmetry):
+    MDG = cycle6_plus_3_2paths()
+    DG = nx.DiGraph(MDG)
+    MG = nx.MultiGraph(MDG)
+    G = nx.Graph(MDG)
+
+    mono_morph = "mono" in SG_ic.__name__
+
+    assert SG_ic(MDG, DG, symmetry=symmetry) == mono_morph
+    assert SG_ic(MG, G, symmetry=symmetry) == mono_morph
+    assert not SG_ic(DG, MDG, symmetry=symmetry)  # should be "not SG_ic..."
+    assert not SG_ic(G, MG, symmetry=symmetry)  # should be "not SG_ic..."

--- a/networkx/algorithms/isomorphism/tests/test_common.py
+++ b/networkx/algorithms/isomorphism/tests/test_common.py
@@ -882,17 +882,80 @@ def test_multiedge_colors_like_multiple_graphs(SG_ic, symmetry, Gclass):
     assert SG_ic(FG, SG, node_label=nm, edge_label=em, symmetry=symmetry) == mono_morph
 
 
+# test multidigraph without multiedges
+wikipedia_graph = nx.MultiDiGraph(
+    ["ag", "ah", "ai", "gb", "bh", "bj", "cg", "ci", "cj", "hd", "di", "dj"]
+)
+wikipedia_graph.name = "wikipedia_graph"
+
+
+@pytest.mark.parametrize("MDG", [cycle6_plus_3_2paths(), wikipedia_graph])
 @pytest.mark.parametrize("symmetry", [True, False])
 @pytest.mark.parametrize("SG_ic", is_SG_funcs + is_mono_funcs + is_iso_funcs)
-def test_match_multiedge_to_simple_graph(SG_ic, symmetry):
-    MDG = cycle6_plus_3_2paths()
+def test_match_multiedge_to_simple_graph(MDG, SG_ic, symmetry):
     DG = nx.DiGraph(MDG)
     MG = nx.MultiGraph(MDG)
     G = nx.Graph(MDG)
 
+    wiki_graph = "wikipedia_graph" == MDG.name
     mono_morph = "mono" in SG_ic.__name__
+    SG_morph = "SG" in SG_ic.__name__
 
-    assert SG_ic(MDG, DG, symmetry=symmetry) == mono_morph
-    assert SG_ic(MG, G, symmetry=symmetry) == mono_morph
-    assert not SG_ic(DG, MDG, symmetry=symmetry)  # should be "not SG_ic..."
-    assert not SG_ic(G, MG, symmetry=symmetry)  # should be "not SG_ic..."
+    # morphing between multi/simple graph types
+    assert SG_ic(MG, G, symmetry=symmetry) == (wiki_graph or mono_morph)
+    assert SG_ic(G, MG, symmetry=symmetry) == wiki_graph
+    assert SG_ic(MDG, DG, symmetry=symmetry) == (wiki_graph or mono_morph)
+    assert SG_ic(DG, MDG, symmetry=symmetry) == wiki_graph
+
+    # morphing between multi/simple graph types w/o multiedges
+    SMG = nx.MultiGraph(G)
+    assert SG_ic(SMG, G, symmetry=symmetry)
+    SMDG = nx.MultiDiGraph(DG)
+    assert SG_ic(SMDG, DG, symmetry=symmetry)
+
+
+@pytest.mark.parametrize("MDG", [cycle6_plus_3_2paths(), wikipedia_graph])
+@pytest.mark.parametrize("Gclass", graph_classes)
+@pytest.mark.parametrize("SG_ic", is_SG_funcs + is_mono_funcs + is_iso_funcs)
+@pytest.mark.parametrize("symmetry", [True, False])
+def test_subgraph_multiedge_to_simple_graph(Gclass, MDG, SG_ic, symmetry):
+    G = Gclass(MDG.edges())
+
+    wiki_graph = "wikipedia_graph" == MDG.name
+    mono_morph = "mono" in SG_ic.__name__
+    SG_or_mono_morph = mono_morph or ("SG" in SG_ic.__name__)
+    not_multi = not G.is_multigraph()
+
+    # create some simple graph types to compare with:
+    # - simpleG has single edge for each multiedge in G
+    # - pg is path graph (which appears inside both MDG graphs)
+    if not G.is_directed():
+        pg = nx.path_graph(5)
+        simpleG = nx.Graph(MDG.edges())
+    else:
+        pg = nx.path_graph(5, create_using=nx.DiGraph)
+        simpleG = nx.DiGraph(MDG.edges())
+    # PG is path graph with same graph type as G
+    PG = Gclass(pg.edges())
+
+    # test G vs simpleG
+    if wiki_graph:
+        assert SG_ic(G, simpleG, symmetry=symmetry)
+        assert SG_ic(simpleG, G, symmetry=symmetry)
+    else:
+        assert SG_ic(G, simpleG, symmetry=symmetry) == (not_multi or mono_morph)
+        assert SG_ic(simpleG, G, symmetry=symmetry) == not_multi
+
+    # find simple paths within G or simpleG
+    find_path = SG_or_mono_morph if wiki_graph else mono_morph
+    assert SG_ic(G, pg, symmetry=symmetry) == find_path
+    assert SG_ic(G, PG, symmetry=symmetry) == find_path
+
+    assert SG_ic(simpleG, pg, symmetry=symmetry) == find_path
+    assert SG_ic(simpleG, PG, symmetry=symmetry) == find_path
+
+    # Double all edges to ensure multiedges present for Multigraphs
+    PG.add_edges_from(pg.edges())
+    G.add_edges_from(MDG.edges())
+    assert SG_ic(G, PG, symmetry=symmetry) == find_path
+    assert SG_ic(simpleG, PG, symmetry=symmetry) == (find_path and not_multi)

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -424,8 +424,14 @@ class TestWikipediaExample:
         assert iso.ISMAGS(g1a, g2a).is_isomorphic()
         assert iso.ISMAGS(g1a, g2b).is_isomorphic()
 
-        assert iso.ISMAGS(g1a, nx.path_graph(range(5))).subgraph_is_isomorphic()
-        assert not iso.ISMAGS(g1a, nx.path_graph(range(6))).subgraph_is_isomorphic()
+        G = nx.path_graph(5, create_using=graph_constructor)
+        assert iso.ISMAGS(g1a, G).subgraph_is_isomorphic()
+        G.add_edge(4, 5)
+        assert not iso.ISMAGS(g1a, G).subgraph_is_isomorphic()
+
+        # now test the same graphs, but one multigraph and other graph
+        assert iso.ISMAGS(g1a, nx.path_graph(5)).subgraph_is_isomorphic()
+        assert not iso.ISMAGS(g1a, nx.path_graph(6)).subgraph_is_isomorphic()
 
     @pytest.mark.parametrize("graph_constructor", [nx.DiGraph, nx.MultiDiGraph])
     def test_digraph(self, graph_constructor):
@@ -440,9 +446,9 @@ class TestWikipediaExample:
         assert not iso.ISMAGS(g1a, g2a).is_isomorphic()
         assert not iso.ISMAGS(g1b, g2b).is_isomorphic()
 
-        P2 = nx.path_graph(range(2), create_using=graph_constructor)
+        P2 = nx.path_graph(2, create_using=graph_constructor)
         assert iso.ISMAGS(g1a, P2).subgraph_is_isomorphic()
-        P3 = nx.path_graph(range(3), create_using=graph_constructor)
+        P3 = nx.path_graph(3, create_using=graph_constructor)
         assert not iso.ISMAGS(g1a, P3).subgraph_is_isomorphic()
 
 

--- a/networkx/algorithms/isomorphism/vf2pp.py
+++ b/networkx/algorithms/isomorphism/vf2pp.py
@@ -811,7 +811,7 @@ def _feasible_look_ahead(u, v, graph_info, state_info):
                 # use sorted edge counts. cut if len_G < len(SG) for any count-pair
                 ucnts = sorted((SG.number_of_edges(u, x) for x in unbrs), reverse=True)
                 vcnts = sorted((FG.number_of_edges(v, x) for x in vnbrs), reverse=True)
-                if any(not MONO_fits(uc, vc) for uc, vc in zip(ucnts, vcnts)):
+                if any(not SG_fits(uc, vc) for uc, vc in zip(ucnts, vcnts)):
                     return False
             if not SG_fits(len(T1 & unbrs), len(T2 & vnbrs)):
                 return False
@@ -831,8 +831,7 @@ def _feasible_look_ahead(u, v, graph_info, state_info):
             if multigraph:
                 ucnts = sorted((SG.number_of_edges(u, x) for x in upred), reverse=True)
                 vcnts = sorted((FG.number_of_edges(v, x) for x in vpred), reverse=True)
-                mess = [(uc, vc) for uc, vc in zip(ucnts, vcnts)]
-                if any(not MONO_fits(uc, vc) for uc, vc in zip(ucnts, vcnts)):
+                if any(not SG_fits(uc, vc) for uc, vc in zip(ucnts, vcnts)):
                     return False
             if not SG_fits(len(T1 & upred), len(T2 & vpred)):
                 return False


### PR DESCRIPTION
The existing multigraph tests for isomorphism were flawed in that they never had any multiedges (see below). 

This PR updates the tests to ensure the multiedges intended to be created actually are making it into the graph. It also adds a few tests just for multigraphs. And it adds checks that all morphisms are found for the suite of graph tests. That means we have to know what all the morphisms are!  And I changed the names of many tests from `*_subgraph_*` to `*_SG_*` (cant help myself I guess)

The new tests revealed a couple of failures for ismags, which is expected because ismags only recently supported multigraphs and it wasn't being tested well. So the 2nd commit here adds code to account for multiedges in two critical places: when computing degree and when checking that the number of edges between two nodes matches for candidate node-pairs. That fixed the errors for ISMAGS.  There was also one failure for vf2pp multigraphs. The 3rd commit holds the fix for vf2pp.

After this PR `vf2pp` and `ismags` agree with `vf2` on all these tests. And the tests have been expanded slightly, with new tests and also with known ground truth for number of morphisms between specific graphs.

**details**
The test trouble with multiedges was due to my adding copies of existing edges using 3-tuples instead of 2-tuples. Usually we want to use 3-tuples for multigraphs. But if we need to add more edges, using a 3-tuple just adds the same edge multiple times, rather than creating new edges.  The fixed code is, e.g.:
```python
G.add_edges_from([e for i, e in enumerate(G.edges()) if i % 2 == 0])
```
And the silently broken version used `G.edges` instead of `G.edges()`.  Usually you want that, but not to create new edges.  In one specific graph I switched from this shot-gun approach to adding multiedges to adding a targeted multiedge. I should do that for more of the test graphs. Adding arbitrary multiedges quickly reduces symmetries and isomorphism counts. With targeted edges we can keep multiple isomorphisms even for MultiDiGraph cases.