### PR TITLE
ENH: Add Barber's bipartite modularity quality function

### DIFF
--- a/doc/reference/algorithms/bipartite.rst
+++ b/doc/reference/algorithms/bipartite.rst
@@ -149,3 +149,10 @@ Link Analysis
 
    birank
 
+Communities
+-----------
+.. automodule:: networkx.algorithms.bipartite.community
+.. autosummary::
+   :toctree: generated/
+
+   modularity

--- a/networkx/algorithms/bipartite/__init__.py
+++ b/networkx/algorithms/bipartite/__init__.py
@@ -76,6 +76,7 @@ For other bipartite graph generators see
 from networkx.algorithms.bipartite.basic import *
 from networkx.algorithms.bipartite.centrality import *
 from networkx.algorithms.bipartite.cluster import *
+from networkx.algorithms.bipartite.community import *
 from networkx.algorithms.bipartite.covering import *
 from networkx.algorithms.bipartite.edgelist import *
 from networkx.algorithms.bipartite.matching import *

--- a/networkx/algorithms/bipartite/community.py
+++ b/networkx/algorithms/bipartite/community.py
@@ -147,20 +147,15 @@ def modularity(G, communities, nodes, weight="weight", resolution=1):
 
     def community_contribution(community):
         comm = set(community)
-        comm_red = comm & red
-        comm_blue = comm & blue
 
-        # L_c: (weighted) internal edges. Iterate over red side only so
-        # each bipartite edge is visited exactly once.
-        L_c = sum(
-            wt
-            for u in comm_red
-            for _, v, wt in G.edges(u, data=weight, default=1)
-            if v in comm_blue
-        )
+        # L_c: (weighted) internal edges. In a bipartite graph edges only
+        # exist between the two node sets, so iterating over all edges
+        # with both endpoints in comm counts each bipartite edge exactly
+        # once.
+        L_c = sum(wt for _, v, wt in G.edges(comm, data=weight, default=1) if v in comm)
 
-        k_c = sum(degree[u] for u in comm_red)
-        d_c = sum(degree[u] for u in comm_blue)
+        k_c = sum(degree[u] for u in comm & red)
+        d_c = sum(degree[u] for u in comm & blue)
 
         return L_c / m - resolution * k_c * d_c * norm
 

--- a/networkx/algorithms/bipartite/community.py
+++ b/networkx/algorithms/bipartite/community.py
@@ -26,7 +26,7 @@ def modularity(G, communities, nodes, weight="weight", resolution=1):
               \delta(c_v, c_w)
 
     where $m$ is the (weighted) number of edges, $\tilde{A}$ is the
-    bipartite incidence matrix, $k_v$ is the (weighted) degree of red
+    bipartite adjacency matrix, $k_v$ is the (weighted) degree of red
     node $v$, $d_w$ is the (weighted) degree of blue node $w$, $\gamma$
     is the resolution parameter, and $\delta(c_v, c_w)$ is 1 if $v$ and
     $w$ are in the same community, else 0.
@@ -76,11 +76,12 @@ def modularity(G, communities, nodes, weight="weight", resolution=1):
         that edge is treated as having weight 1.
 
     resolution : float (default=1)
-        Resolution parameter $\gamma$. Values smaller than 1 favor
-        larger communities; values greater than 1 favor smaller
-        communities. Not part of Barber's original definition, but a
-        standard extension consistent with
-        :func:`networkx.community.modularity`.
+        Resolution parameter $\gamma$. With the default ``resolution=1``,
+        $Q_B$ reduces to Barber's original definition. Values smaller
+        than 1 favor larger communities; values greater than 1 favor
+        smaller communities. The resolution parameter is not part of
+        Barber's original definition, but a standard extension
+        consistent with :func:`networkx.community.modularity`.
 
     Returns
     -------
@@ -116,7 +117,7 @@ def modularity(G, communities, nodes, weight="weight", resolution=1):
 
     See Also
     --------
-    networkx.algorithms.community.quality.modularity
+    modularity
 
     References
     ----------
@@ -175,15 +176,14 @@ def _bipartite_modularity_merge_delta(
 ):
     r"""Change in bipartite modularity from merging two disjoint communities.
 
-    Computes ``Q_B(P') - Q_B(P)`` where P contains *community_a* and
-    *community_b* as separate communities and P' is obtained by replacing
+    Computes ``Q_B(P') - Q_B(P)`` where P contains `community_a` and
+    `community_b` as separate communities and P' is obtained by replacing
     them with their union ``community_a U community_b``.
 
     For bipartite modularity ``Q_B = sum_c [L_c/m - gamma k_c d_c / m^2]``,
     the merge delta has the closed form
 
-        merge_delta = E(A, B) / m
-                    - gamma * (k_A d_B + k_B d_A) / m^2
+        merge_delta = E(A, B) / m - gamma * (k_A d_B + k_B d_A) / m^2
 
     where ``E(A, B)`` is the sum of edge weights between A and B,
     ``k_C`` is the sum of the "red" degrees of nodes in C, and ``d_C``
@@ -200,7 +200,7 @@ def _bipartite_modularity_merge_delta(
     nonzero. This is the same pattern used for directed modularity
     (in-degree / out-degree tracked as separate attributes).
 
-    *community_a* and *community_b* must be disjoint and non-empty.
+    `community_a` and `community_b` must be disjoint and non-empty.
     Self-loops are tolerated: on the original graph they are absent by
     the bipartite convention, and on aggregated graphs they represent
     intra-community edges which are not part of ``E(A, B)`` and are

--- a/networkx/algorithms/bipartite/community.py
+++ b/networkx/algorithms/bipartite/community.py
@@ -162,142 +162,88 @@ def modularity(G, communities, nodes, weight="weight", resolution=1):
     return sum(community_contribution(c) for c in communities)
 
 
-def _bipartite_modularity_delta_partial_eval_remove(
-    G, node, community, resolution, weight="weight", *, nodes, m
+def _bipartite_modularity_merge_delta(
+    G,
+    community_a,
+    community_b,
+    resolution,
+    weight="weight",
+    *,
+    red_degree_attr="red_degree",
+    blue_degree_attr="blue_degree",
+    m,
 ):
-    r"""Change in bipartite modularity from removing *node* from *community*.
+    r"""Change in bipartite modularity from merging two disjoint communities.
 
-    One of a pair of partial-evaluation helpers following the pattern
-    established in PR #8507 for CPM (``_cpm_delta_partial_eval_remove``).
+    Computes ``Q_B(P') - Q_B(P)`` where P contains *community_a* and
+    *community_b* as separate communities and P' is obtained by replacing
+    them with their union ``community_a U community_b``.
 
-    Let P = [A, B, C, ...] be a partition with *node* in A, and let
-    P' = [A\{node}, B U {node}, C, ...] be the partition after moving
-    *node* from A into B. The overall quality change is:
+    For bipartite modularity ``Q_B = sum_c [L_c/m - gamma k_c d_c / m^2]``,
+    the merge delta has the closed form
 
-        q_delta = bipartite.modularity(G, P', nodes)
-                - bipartite.modularity(G, P, nodes)
+        merge_delta = E(A, B) / m
+                    - gamma * (k_A d_B + k_B d_A) / m^2
 
-    and can be decomposed as q_delta = q_rem + q_add where:
+    where ``E(A, B)`` is the sum of edge weights between A and B,
+    ``k_C`` is the sum of the "red" degrees of nodes in C, and ``d_C``
+    is the sum of the "blue" degrees of nodes in C.
 
-        q_rem = _bipartite_modularity_delta_partial_eval_remove(
-            G, node, A, resolution, weight, nodes=nodes, m=m)
-        q_add = _bipartite_modularity_delta_partial_eval_add(
-            G, node, B, resolution, weight, nodes=nodes, m=m)
+    **Attribute-based interface.** Rather than identifying each node
+    with a single bipartite side (which breaks once Louvain/Leiden has
+    aggregated communities into super-nodes that mix both colors), this
+    helper reads per-node ``red_degree_attr`` and ``blue_degree_attr``
+    attributes. On the original bipartite graph a red node has
+    ``red_degree = G.degree(v)`` and ``blue_degree = 0`` (and vice
+    versa). On an aggregated graph each super-node carries the sums
+    of both attributes over its constituent nodes; both may be
+    nonzero. This is the same pattern used for directed modularity
+    (in-degree / out-degree tracked as separate attributes).
 
-    This avoids recomputing Q_B over the whole partition on every candidate
-    move in a Louvain/Leiden-style optimization loop.
-
-    The composition property also holds:
-        q_rem == -q_add(G, node, A\{node}, ...)
-
-    Unlike the CPM helpers (which return unnormalized values since CPM has
-    no 1/m factor), these helpers return m-normalized values matching the
-    bipartite modularity definition Q_B = sum_c [L_c/m - gamma k_c d_c/m^2].
+    *community_a* and *community_b* must be disjoint and non-empty.
+    Self-loops are tolerated: on the original graph they are absent by
+    the bipartite convention, and on aggregated graphs they represent
+    intra-community edges which are not part of ``E(A, B)`` and are
+    correctly excluded by the ``v in community_b`` filter below.
 
     Parameters
     ----------
     G : NetworkX Graph
-    node : node
-        The node being removed from *community*.
-    community : set
-        The community that *node* currently belongs to (including *node*).
+        A graph whose nodes carry the red/blue degree attributes. May
+        be an original bipartite graph or an aggregated graph produced
+        by a multilevel optimizer.
+    community_a, community_b : set
+        Two disjoint communities to merge.
     resolution : float
         Resolution parameter gamma.
     weight : str or None
         Edge weight attribute.
-    nodes : set
-        Keyword-only. One bipartite node set ("red" nodes). Must be a set
-        or frozenset for efficient membership testing.
+    red_degree_attr : str
+        Keyword-only. Name of the node attribute holding the
+        "red-side" contribution to the node's degree.
+    blue_degree_attr : str
+        Keyword-only. Name of the node attribute holding the
+        "blue-side" contribution to the node's degree.
     m : float
-        Keyword-only. Total (weighted) edge count, computed as
-        ``sum(G.degree(v, weight=weight) for v in nodes)``.
+        Keyword-only. Total (weighted) edge count, a graph-level
+        invariant preserved across aggregation.
     """
-    node_is_red = node in nodes
+    red_nodes = G.nodes(data=red_degree_attr, default=0)
+    blue_nodes = G.nodes(data=blue_degree_attr, default=0)
 
-    # Opposite-side degree sum of the community. Since *node* contributes
-    # to its own side only, opp_deg_sum is the same whether we include or
-    # exclude *node* from the community.
-    if node_is_red:
-        opp_deg_sum = sum(
-            G.degree(v, weight=weight) for v in community if v not in nodes
-        )
-    else:
-        opp_deg_sum = sum(G.degree(v, weight=weight) for v in community if v in nodes)
+    k_a = sum(rd for v, rd in red_nodes if v in community_a)
+    d_a = sum(bd for v, bd in blue_nodes if v in community_a)
+    k_b = sum(rd for v, rd in red_nodes if v in community_b)
+    d_b = sum(bd for v, bd in blue_nodes if v in community_b)
 
-    deg_u = G.degree(node, weight=weight)
-
-    E_A = sum(
+    # E(A, B): edges with one endpoint in A and the other in B. Iterate
+    # edges incident to community_a and keep those landing in community_b.
+    # Self-loops (intra-community edges on aggregated super-nodes) are
+    # filtered out because they have both endpoints in community_a.
+    E_cross = sum(
         wt
-        for _, v, wt in G.edges(node, data=weight, default=1)
-        if v in community and v != node
+        for _, v, wt in G.edges(community_a, data=weight, default=1)
+        if v in community_b
     )
 
-    return resolution * deg_u * opp_deg_sum / m**2 - E_A / m
-
-
-def _bipartite_modularity_delta_partial_eval_add(
-    G, node, community, resolution, weight="weight", *, nodes, m
-):
-    r"""Change in bipartite modularity from inserting *node* into *community*.
-
-    One of a pair of partial-evaluation helpers following the pattern
-    established in PR #8507 for CPM (``_cpm_delta_partial_eval_add``).
-
-    Let P = [A, B, C, ...] be a partition with *node* in A, and let
-    P' = [A\{node}, B U {node}, C, ...] be the partition after moving
-    *node* from A into B. The overall quality change is:
-
-        q_delta = bipartite.modularity(G, P', nodes)
-                - bipartite.modularity(G, P, nodes)
-
-    and can be decomposed as q_delta = q_rem + q_add where:
-
-        q_rem = _bipartite_modularity_delta_partial_eval_remove(
-            G, node, A, resolution, weight, nodes=nodes, m=m)
-        q_add = _bipartite_modularity_delta_partial_eval_add(
-            G, node, B, resolution, weight, nodes=nodes, m=m)
-
-    This avoids recomputing Q_B over the whole partition on every candidate
-    move in a Louvain/Leiden-style optimization loop.
-
-    The composition property also holds:
-        q_rem == -q_add(G, node, A\{node}, ...)
-
-    Unlike the CPM helpers (which return unnormalized values since CPM has
-    no 1/m factor), these helpers return m-normalized values matching the
-    bipartite modularity definition Q_B = sum_c [L_c/m - gamma k_c d_c/m^2].
-
-    Parameters
-    ----------
-    G : NetworkX Graph
-    node : node
-        The node being inserted into *community*.
-    community : set
-        The target community (*node* is not yet a member).
-    resolution : float
-        Resolution parameter gamma.
-    weight : str or None
-        Edge weight attribute.
-    nodes : set
-        Keyword-only. One bipartite node set ("red" nodes). Must be a set
-        or frozenset for efficient membership testing.
-    m : float
-        Keyword-only. Total (weighted) edge count, computed as
-        ``sum(G.degree(v, weight=weight) for v in nodes)``.
-    """
-    node_is_red = node in nodes
-
-    if node_is_red:
-        opp_deg_sum = sum(
-            G.degree(v, weight=weight) for v in community if v not in nodes
-        )
-    else:
-        opp_deg_sum = sum(G.degree(v, weight=weight) for v in community if v in nodes)
-
-    deg_u = G.degree(node, weight=weight)
-
-    E_B = sum(
-        wt for _, v, wt in G.edges(node, data=weight, default=1) if v in community
-    )
-
-    return E_B / m - resolution * deg_u * opp_deg_sum / m**2
+    return E_cross / m - resolution * (k_a * d_b + k_b * d_a) / m**2

--- a/networkx/algorithms/bipartite/community.py
+++ b/networkx/algorithms/bipartite/community.py
@@ -1,0 +1,167 @@
+"""Community detection and quality functions for bipartite graphs."""
+
+import networkx as nx
+from networkx.algorithms.community.community_utils import is_partition
+from networkx.algorithms.community.quality import NotAPartition
+from networkx.utils.decorators import not_implemented_for
+
+__all__ = ["modularity"]
+
+
+@not_implemented_for("directed")
+@nx._dispatchable(name="bipartite_modularity", edge_attrs="weight")
+def modularity(G, communities, nodes, weight="weight", resolution=1):
+    r"""Returns Barber's bipartite modularity of the given partition.
+
+    Bipartite modularity [1]_ adapts Newman's modularity to bipartite
+    networks by replacing the configuration-model null model with one
+    that respects the bipartite structure: expected edges only occur
+    between the two node sets. For a bipartite graph with "red" nodes
+    (one set) and "blue" nodes (the other), it is defined as
+
+    .. math::
+
+        Q_B = \frac{1}{m} \sum_{v=1}^{r} \sum_{w=1}^{c}
+              \left( \tilde{A}_{vw} - \gamma\frac{k_v d_w}{m} \right)
+              \delta(c_v, c_w)
+
+    where $m$ is the (weighted) number of edges, $\tilde{A}$ is the
+    bipartite incidence matrix, $k_v$ is the (weighted) degree of red
+    node $v$, $d_w$ is the (weighted) degree of blue node $w$, $\gamma$
+    is the resolution parameter, and $\delta(c_v, c_w)$ is 1 if $v$ and
+    $w$ are in the same community, else 0.
+
+    Following Clauset, Newman and Moore [2]_, this can be rewritten as a
+    sum over communities:
+
+    .. math::
+
+        Q_B = \sum_{c=1}^{n}
+              \left[ \frac{L_c}{m} - \gamma\,\frac{k_c d_c}{m^2} \right]
+
+    where $L_c$ is the (weighted) number of intra-community edges for
+    community $c$, $k_c$ is the sum of degrees of the red nodes in $c$,
+    and $d_c$ is the sum of degrees of the blue nodes in $c$. This is
+    the form used in the implementation.
+
+    Note the structural analogy with the standard (unipartite) sum
+    formulation `L_c/m - gamma * (k_c / 2m)^2`: the null-model term is
+    a product of two degree sums, and in the undirected unipartite case
+    those two sums coincide so the product becomes a square. In the
+    bipartite case the sums differ (red vs. blue), so the null model
+    term remains a product of two distinct terms.
+
+    Communities in a bipartite modularity partition may contain nodes
+    from both bipartite sets; the bipartite structure enters only
+    through the null model.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+        An undirected bipartite graph.
+
+    communities : list or iterable of sets of nodes
+        These node sets must represent a partition of `G`'s nodes.
+        Communities may contain nodes from both bipartite sets.
+
+    nodes : container of nodes
+        A container with all nodes in **one** bipartite node set (the
+        "red" nodes). The other set is inferred as ``set(G) - set(nodes)``.
+        This follows the convention used throughout the bipartite
+        subpackage.
+
+    weight : string or None, optional (default="weight")
+        The edge attribute that holds the numerical value used as the
+        edge weight. If None or if an edge does not have the attribute,
+        that edge is treated as having weight 1.
+
+    resolution : float (default=1)
+        Resolution parameter $\gamma$. Values smaller than 1 favor
+        larger communities; values greater than 1 favor smaller
+        communities. Not part of Barber's original definition, but a
+        standard extension consistent with
+        :func:`networkx.community.modularity`.
+
+    Returns
+    -------
+    Q_B : float
+        The bipartite modularity of the partition.
+
+    Raises
+    ------
+    NotAPartition
+        If `communities` is not a valid partition of the nodes of `G`.
+
+    NetworkXNotImplemented
+        If `G` is directed. Barber's formulation is for undirected
+        bipartite graphs.
+
+    Examples
+    --------
+    Two disconnected :math:`K_{2,2}` components form a strong bipartite
+    community structure:
+
+    >>> from networkx.algorithms import bipartite
+    >>> G = nx.Graph([(0, 2), (1, 3)])
+    >>> red = {0, 1}
+    >>> bipartite.modularity(G, [{0, 2}, {1, 3}], red)
+    0.5
+
+    Notes
+    -----
+    The functions in the bipartite package do not check that `nodes` is
+    actually one side of a bipartition of `G`. It is the caller's
+    responsibility to provide a valid bipartite graph and a valid
+    bipartite node set.
+
+    See Also
+    --------
+    networkx.algorithms.community.quality.modularity
+
+    References
+    ----------
+    .. [1] Barber, M. J. (2007). "Modularity and community detection in
+       bipartite networks." Physical Review E, 76(6), 066102.
+       https://doi.org/10.1103/PhysRevE.76.066102
+    .. [2] Clauset, A., Newman, M. E. J., and Moore, C. (2004).
+       "Finding community structure in very large networks."
+       Physical Review E, 70(6), 066111.
+    """
+    if not isinstance(communities, list):
+        communities = list(communities)
+    if not is_partition(G, communities):
+        raise NotAPartition(G, communities)
+
+    red = set(nodes)
+    blue = set(G) - red
+
+    degree = dict(G.degree(weight=weight))
+    # Every edge has exactly one red and one blue endpoint, so the sum of
+    # red degrees equals the total (weighted) number of edges m.
+    m = sum(degree[v] for v in red)
+
+    if m == 0:
+        return 0.0
+
+    norm = 1 / m**2
+
+    def community_contribution(community):
+        comm = set(community)
+        comm_red = comm & red
+        comm_blue = comm & blue
+
+        # L_c: (weighted) internal edges. Iterate over red side only so
+        # each bipartite edge is visited exactly once.
+        L_c = sum(
+            wt
+            for u in comm_red
+            for _, v, wt in G.edges(u, data=weight, default=1)
+            if v in comm_blue
+        )
+
+        k_c = sum(degree[u] for u in comm_red)
+        d_c = sum(degree[u] for u in comm_blue)
+
+        return L_c / m - resolution * k_c * d_c * norm
+
+    return sum(community_contribution(c) for c in communities)

--- a/networkx/algorithms/bipartite/community.py
+++ b/networkx/algorithms/bipartite/community.py
@@ -160,3 +160,144 @@ def modularity(G, communities, nodes, weight="weight", resolution=1):
         return L_c / m - resolution * k_c * d_c * norm
 
     return sum(community_contribution(c) for c in communities)
+
+
+def _bipartite_modularity_delta_partial_eval_remove(
+    G, node, community, resolution, weight="weight", *, nodes, m
+):
+    r"""Change in bipartite modularity from removing *node* from *community*.
+
+    One of a pair of partial-evaluation helpers following the pattern
+    established in PR #8507 for CPM (``_cpm_delta_partial_eval_remove``).
+
+    Let P = [A, B, C, ...] be a partition with *node* in A, and let
+    P' = [A\{node}, B U {node}, C, ...] be the partition after moving
+    *node* from A into B. The overall quality change is:
+
+        q_delta = bipartite.modularity(G, P', nodes)
+                - bipartite.modularity(G, P, nodes)
+
+    and can be decomposed as q_delta = q_rem + q_add where:
+
+        q_rem = _bipartite_modularity_delta_partial_eval_remove(
+            G, node, A, resolution, weight, nodes=nodes, m=m)
+        q_add = _bipartite_modularity_delta_partial_eval_add(
+            G, node, B, resolution, weight, nodes=nodes, m=m)
+
+    This avoids recomputing Q_B over the whole partition on every candidate
+    move in a Louvain/Leiden-style optimization loop.
+
+    The composition property also holds:
+        q_rem == -q_add(G, node, A\{node}, ...)
+
+    Unlike the CPM helpers (which return unnormalized values since CPM has
+    no 1/m factor), these helpers return m-normalized values matching the
+    bipartite modularity definition Q_B = sum_c [L_c/m - gamma k_c d_c/m^2].
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+    node : node
+        The node being removed from *community*.
+    community : set
+        The community that *node* currently belongs to (including *node*).
+    resolution : float
+        Resolution parameter gamma.
+    weight : str or None
+        Edge weight attribute.
+    nodes : set
+        Keyword-only. One bipartite node set ("red" nodes). Must be a set
+        or frozenset for efficient membership testing.
+    m : float
+        Keyword-only. Total (weighted) edge count, computed as
+        ``sum(G.degree(v, weight=weight) for v in nodes)``.
+    """
+    node_is_red = node in nodes
+
+    # Opposite-side degree sum of the community. Since *node* contributes
+    # to its own side only, opp_deg_sum is the same whether we include or
+    # exclude *node* from the community.
+    if node_is_red:
+        opp_deg_sum = sum(
+            G.degree(v, weight=weight) for v in community if v not in nodes
+        )
+    else:
+        opp_deg_sum = sum(G.degree(v, weight=weight) for v in community if v in nodes)
+
+    deg_u = G.degree(node, weight=weight)
+
+    E_A = sum(
+        wt
+        for _, v, wt in G.edges(node, data=weight, default=1)
+        if v in community and v != node
+    )
+
+    return resolution * deg_u * opp_deg_sum / m**2 - E_A / m
+
+
+def _bipartite_modularity_delta_partial_eval_add(
+    G, node, community, resolution, weight="weight", *, nodes, m
+):
+    r"""Change in bipartite modularity from inserting *node* into *community*.
+
+    One of a pair of partial-evaluation helpers following the pattern
+    established in PR #8507 for CPM (``_cpm_delta_partial_eval_add``).
+
+    Let P = [A, B, C, ...] be a partition with *node* in A, and let
+    P' = [A\{node}, B U {node}, C, ...] be the partition after moving
+    *node* from A into B. The overall quality change is:
+
+        q_delta = bipartite.modularity(G, P', nodes)
+                - bipartite.modularity(G, P, nodes)
+
+    and can be decomposed as q_delta = q_rem + q_add where:
+
+        q_rem = _bipartite_modularity_delta_partial_eval_remove(
+            G, node, A, resolution, weight, nodes=nodes, m=m)
+        q_add = _bipartite_modularity_delta_partial_eval_add(
+            G, node, B, resolution, weight, nodes=nodes, m=m)
+
+    This avoids recomputing Q_B over the whole partition on every candidate
+    move in a Louvain/Leiden-style optimization loop.
+
+    The composition property also holds:
+        q_rem == -q_add(G, node, A\{node}, ...)
+
+    Unlike the CPM helpers (which return unnormalized values since CPM has
+    no 1/m factor), these helpers return m-normalized values matching the
+    bipartite modularity definition Q_B = sum_c [L_c/m - gamma k_c d_c/m^2].
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+    node : node
+        The node being inserted into *community*.
+    community : set
+        The target community (*node* is not yet a member).
+    resolution : float
+        Resolution parameter gamma.
+    weight : str or None
+        Edge weight attribute.
+    nodes : set
+        Keyword-only. One bipartite node set ("red" nodes). Must be a set
+        or frozenset for efficient membership testing.
+    m : float
+        Keyword-only. Total (weighted) edge count, computed as
+        ``sum(G.degree(v, weight=weight) for v in nodes)``.
+    """
+    node_is_red = node in nodes
+
+    if node_is_red:
+        opp_deg_sum = sum(
+            G.degree(v, weight=weight) for v in community if v not in nodes
+        )
+    else:
+        opp_deg_sum = sum(G.degree(v, weight=weight) for v in community if v in nodes)
+
+    deg_u = G.degree(node, weight=weight)
+
+    E_B = sum(
+        wt for _, v, wt in G.edges(node, data=weight, default=1) if v in community
+    )
+
+    return E_B / m - resolution * deg_u * opp_deg_sum / m**2

--- a/networkx/algorithms/bipartite/community.py
+++ b/networkx/algorithms/bipartite/community.py
@@ -228,13 +228,12 @@ def _bipartite_modularity_merge_delta(
         Keyword-only. Total (weighted) edge count, a graph-level
         invariant preserved across aggregation.
     """
-    red_nodes = G.nodes(data=red_degree_attr, default=0)
-    blue_nodes = G.nodes(data=blue_degree_attr, default=0)
-
-    k_a = sum(rd for v, rd in red_nodes if v in community_a)
-    d_a = sum(bd for v, bd in blue_nodes if v in community_a)
-    k_b = sum(rd for v, rd in red_nodes if v in community_b)
-    d_b = sum(bd for v, bd in blue_nodes if v in community_b)
+    # Iterate over community members rather than all of G.nodes
+    nodes = G.nodes
+    k_a = sum(nodes[v].get(red_degree_attr, 0) for v in community_a)
+    d_a = sum(nodes[v].get(blue_degree_attr, 0) for v in community_a)
+    k_b = sum(nodes[v].get(red_degree_attr, 0) for v in community_b)
+    d_b = sum(nodes[v].get(blue_degree_attr, 0) for v in community_b)
 
     # E(A, B): edges with one endpoint in A and the other in B. Iterate
     # edges incident to community_a and keep those landing in community_b.

--- a/networkx/algorithms/bipartite/community.py
+++ b/networkx/algorithms/bipartite/community.py
@@ -10,7 +10,7 @@ __all__ = ["modularity"]
 
 @not_implemented_for("directed")
 @nx._dispatchable(name="bipartite_modularity", edge_attrs="weight")
-def modularity(G, communities, nodes, weight="weight", resolution=1):
+def modularity(G, communities, nodes, *, weight="weight", resolution=1):
     r"""Returns Barber's bipartite modularity of the given partition.
 
     Bipartite modularity [1]_ adapts Newman's modularity to bipartite
@@ -102,10 +102,9 @@ def modularity(G, communities, nodes, weight="weight", resolution=1):
     Two disconnected :math:`K_{2,2}` components form a strong bipartite
     community structure:
 
-    >>> from networkx.algorithms import bipartite
     >>> G = nx.Graph([(0, 2), (1, 3)])
     >>> red = {0, 1}
-    >>> bipartite.modularity(G, [{0, 2}, {1, 3}], red)
+    >>> nx.bipartite.modularity(G, [{0, 2}, {1, 3}], red)
     0.5
 
     Notes

--- a/networkx/algorithms/bipartite/tests/test_community.py
+++ b/networkx/algorithms/bipartite/tests/test_community.py
@@ -1,9 +1,13 @@
-"""Tests for bipartite community quality functions."""
+"""Tests for bipartite community detection and quality functions."""
 
 import pytest
 
 import networkx as nx
 from networkx.algorithms import bipartite
+from networkx.algorithms.bipartite.community import (
+    _bipartite_modularity_delta_partial_eval_add,
+    _bipartite_modularity_delta_partial_eval_remove,
+)
 from networkx.algorithms.community.quality import NotAPartition
 
 
@@ -140,3 +144,143 @@ class TestBipartiteModularity:
         # iterable and convert internally.
         communities = [{0, 2}, {1, 3}]
         assert bipartite.modularity(G, communities, [0, 1]) == pytest.approx(0.0)
+
+
+def _q_delta_via_full_eval(G, u, A, B, rest, red, resolution=1, weight="weight"):
+    """Reference delta: compute Q_B on the before/after partitions."""
+    before = [A, B] + rest
+    after = [A - {u}, B | {u}] + rest
+    q_before = bipartite.modularity(
+        G, before, red, weight=weight, resolution=resolution
+    )
+    q_after = bipartite.modularity(G, after, red, weight=weight, resolution=resolution)
+    return q_after - q_before
+
+
+def _compute_m(G, red, weight="weight"):
+    """Compute total edge weight the same way bipartite.modularity does."""
+    return sum(G.degree(v, weight=weight) for v in red)
+
+
+class TestBipartiteModularityDelta:
+    def test_red_node_move_unweighted(self):
+        # Two disjoint K_{2,2} components. Move red node 0 from its
+        # community to the other.
+        G = nx.Graph()
+        G.add_edges_from([(0, 2), (0, 3), (1, 2), (1, 3)])
+        G.add_edges_from([(4, 6), (4, 7), (5, 6), (5, 7)])
+        red = {0, 1, 4, 5}
+        A = {0, 1, 2, 3}
+        B = {4, 5, 6, 7}
+        u = 0  # red node
+        m = _compute_m(G, red)
+
+        q_rem = _bipartite_modularity_delta_partial_eval_remove(
+            G, u, A, 1, nodes=red, m=m
+        )
+        q_add = _bipartite_modularity_delta_partial_eval_add(G, u, B, 1, nodes=red, m=m)
+        q_delta = _q_delta_via_full_eval(G, u, A, B, [], red)
+        assert q_rem + q_add == pytest.approx(q_delta)
+
+    def test_blue_node_move_unweighted(self):
+        # Same graph, move blue node 2.
+        G = nx.Graph()
+        G.add_edges_from([(0, 2), (0, 3), (1, 2), (1, 3)])
+        G.add_edges_from([(4, 6), (4, 7), (5, 6), (5, 7)])
+        red = {0, 1, 4, 5}
+        A = {0, 1, 2, 3}
+        B = {4, 5, 6, 7}
+        u = 2  # blue node
+        m = _compute_m(G, red)
+
+        q_rem = _bipartite_modularity_delta_partial_eval_remove(
+            G, u, A, 1, nodes=red, m=m
+        )
+        q_add = _bipartite_modularity_delta_partial_eval_add(G, u, B, 1, nodes=red, m=m)
+        q_delta = _q_delta_via_full_eval(G, u, A, B, [], red)
+        assert q_rem + q_add == pytest.approx(q_delta)
+
+    def test_weighted_edges(self):
+        G = nx.Graph()
+        G.add_edge(0, 2, weight=3)
+        G.add_edge(0, 3, weight=1)
+        G.add_edge(1, 2, weight=2)
+        G.add_edge(1, 3, weight=5)
+        red = {0, 1}
+        A = {0, 2}
+        B = {1, 3}
+        u = 0
+        m = _compute_m(G, red)
+
+        q_rem = _bipartite_modularity_delta_partial_eval_remove(
+            G, u, A, 1, nodes=red, m=m
+        )
+        q_add = _bipartite_modularity_delta_partial_eval_add(G, u, B, 1, nodes=red, m=m)
+        q_delta = _q_delta_via_full_eval(G, u, A, B, [], red)
+        assert q_rem + q_add == pytest.approx(q_delta)
+
+    def test_resolution_parameter(self):
+        G = nx.Graph()
+        G.add_edges_from([(0, 2), (0, 3), (1, 2), (1, 3)])
+        G.add_edges_from([(4, 6), (4, 7), (5, 6), (5, 7)])
+        red = {0, 1, 4, 5}
+        A = {0, 1, 2, 3}
+        B = {4, 5, 6, 7}
+        u = 0
+        m = _compute_m(G, red)
+
+        for gamma in (0.5, 1.0, 2.0):
+            q_rem = _bipartite_modularity_delta_partial_eval_remove(
+                G, u, A, gamma, nodes=red, m=m
+            )
+            q_add = _bipartite_modularity_delta_partial_eval_add(
+                G, u, B, gamma, nodes=red, m=m
+            )
+            q_delta = _q_delta_via_full_eval(G, u, A, B, [], red, resolution=gamma)
+            assert q_rem + q_add == pytest.approx(q_delta)
+
+    def test_composition_property(self):
+        # Verify that remove(u, A) == -add(u, A\{u}), i.e. the remove/add
+        # pair composes into the single quality_delta pattern used by #8509.
+        G = nx.Graph()
+        G.add_edges_from([(0, 2), (0, 3), (1, 2), (1, 3)])
+        G.add_edges_from([(4, 6), (4, 7), (5, 6), (5, 7)])
+        red = {0, 1, 4, 5}
+        A = {0, 1, 2, 3}
+        u = 0
+        m = _compute_m(G, red)
+
+        q_rem = _bipartite_modularity_delta_partial_eval_remove(
+            G, u, A, 1, nodes=red, m=m
+        )
+        q_add_neg = _bipartite_modularity_delta_partial_eval_add(
+            G, u, A - {u}, 1, nodes=red, m=m
+        )
+        assert q_rem == pytest.approx(-q_add_neg)
+
+    def test_random_graph_all_moves(self):
+        # Fuzz test: for every possible single-node move on a random
+        # bipartite graph, verify the delta invariant.
+        G = nx.bipartite.random_graph(6, 8, 0.5, seed=42)
+        red = {n for n, d in G.nodes(data=True) if d["bipartite"] == 0}
+        m = _compute_m(G, red)
+
+        # Start with a two-community partition.
+        comm_a = {n for n in G if n < 7}
+        comm_b = set(G) - comm_a
+        partition = [comm_a, comm_b]
+
+        for u in G:
+            if u in comm_a:
+                A, B, rest = comm_a, comm_b, []
+            else:
+                A, B, rest = comm_b, comm_a, []
+
+            q_rem = _bipartite_modularity_delta_partial_eval_remove(
+                G, u, A, 1, nodes=red, m=m
+            )
+            q_add = _bipartite_modularity_delta_partial_eval_add(
+                G, u, B, 1, nodes=red, m=m
+            )
+            q_delta = _q_delta_via_full_eval(G, u, A, B, rest, red)
+            assert q_rem + q_add == pytest.approx(q_delta)

--- a/networkx/algorithms/bipartite/tests/test_community.py
+++ b/networkx/algorithms/bipartite/tests/test_community.py
@@ -1,0 +1,142 @@
+"""Tests for bipartite community quality functions."""
+
+import pytest
+
+import networkx as nx
+from networkx.algorithms import bipartite
+from networkx.algorithms.community.quality import NotAPartition
+
+
+class TestBipartiteModularity:
+    def test_complete_bipartite_no_structure(self):
+        # K_{2,2} has no community structure: every red connects to
+        # every blue, so any split gives Q_B = 0.
+        G = nx.complete_bipartite_graph(2, 2)
+        red = {0, 1}
+        communities = [{0, 2}, {1, 3}]
+        assert bipartite.modularity(G, communities, red) == pytest.approx(0.0)
+
+    def test_two_disjoint_edges(self):
+        # Two disconnected edges form two perfect bipartite communities.
+        G = nx.Graph([(0, 2), (1, 3)])
+        red = {0, 1}
+        communities = [{0, 2}, {1, 3}]
+        # m = 2; each community: L_c=1, k_c=1, d_c=1
+        # contribution = 1/2 - 1*1/4 = 1/4; total = 1/2
+        assert bipartite.modularity(G, communities, red) == pytest.approx(0.5)
+
+    def test_single_community(self):
+        G = nx.complete_bipartite_graph(3, 4)
+        red = set(range(3))
+        communities = [set(G)]
+        assert bipartite.modularity(G, communities, red) == pytest.approx(0.0)
+
+    def test_singleton_communities(self):
+        G = nx.complete_bipartite_graph(3, 4)
+        red = set(range(3))
+        communities = [{n} for n in G]
+        assert bipartite.modularity(G, communities, red) == pytest.approx(0.0)
+
+    def test_weighted(self):
+        G = nx.Graph()
+        G.add_edge(0, 2, weight=3)
+        G.add_edge(1, 3, weight=1)
+        red = {0, 1}
+        communities = [{0, 2}, {1, 3}]
+        # m = 4
+        # {0,2}: L_c=3, k_c=3, d_c=3  -> 3/4 - 9/16 = 3/16
+        # {1,3}: L_c=1, k_c=1, d_c=1  -> 1/4 - 1/16 = 3/16
+        # total = 6/16 = 0.375
+        assert bipartite.modularity(G, communities, red) == pytest.approx(0.375)
+
+    def test_weight_none_ignores_attribute(self):
+        G = nx.Graph()
+        G.add_edge(0, 2, weight=3)
+        G.add_edge(1, 3, weight=1)
+        red = {0, 1}
+        communities = [{0, 2}, {1, 3}]
+        # With weight=None, both edges have weight 1. m = 2.
+        # Each community contributes 1/2 - 1/4 = 1/4 -> total 0.5
+        assert bipartite.modularity(G, communities, red, weight=None) == pytest.approx(
+            0.5
+        )
+
+    def test_resolution_scales_null_model(self):
+        G = nx.Graph([(0, 2), (1, 3)])
+        red = {0, 1}
+        communities = [{0, 2}, {1, 3}]
+        q1 = bipartite.modularity(G, communities, red, resolution=1)
+        q_low = bipartite.modularity(G, communities, red, resolution=0.5)
+        q_high = bipartite.modularity(G, communities, red, resolution=2)
+        assert q_low > q1 > q_high
+        # Explicit values (m=2): per-community L_c/m - res*k_c*d_c/m^2
+        # res=0.5: 2 * (1/2 - 0.5 * 1/4) = 0.75
+        # res=2.0: 2 * (1/2 - 2   * 1/4) = 0
+        assert q_low == pytest.approx(0.75)
+        assert q_high == pytest.approx(0.0)
+
+    def test_iterable_of_communities_is_accepted(self):
+        G = nx.Graph([(0, 2), (1, 3)])
+        red = {0, 1}
+        communities = iter([{0, 2}, {1, 3}])
+        assert bipartite.modularity(G, communities, red) == pytest.approx(0.5)
+
+    def test_empty_graph(self):
+        G = nx.Graph()
+        assert bipartite.modularity(G, [], set()) == pytest.approx(0.0)
+
+    def test_not_a_partition_raises(self):
+        G = nx.complete_bipartite_graph(2, 2)
+        red = {0, 1}
+        # Missing node 3
+        with pytest.raises(NotAPartition):
+            bipartite.modularity(G, [{0, 2}, {1}], red)
+        # Overlapping
+        with pytest.raises(NotAPartition):
+            bipartite.modularity(G, [{0, 1, 2}, {1, 3}], red)
+
+    def test_directed_not_implemented(self):
+        G = nx.DiGraph([(0, 2), (1, 3)])
+        with pytest.raises(nx.NetworkXNotImplemented):
+            bipartite.modularity(G, [{0, 2}, {1, 3}], {0, 1})
+
+    def test_communities_with_single_side_contribute_zero(self):
+        # A community containing only red (or only blue) nodes has L_c=0
+        # and one of k_c, d_c = 0, so its contribution is 0.
+        G = nx.complete_bipartite_graph(2, 2)
+        red = {0, 1}
+        communities = [{0, 1}, {2, 3}]
+        assert bipartite.modularity(G, communities, red) == pytest.approx(0.0)
+
+    def test_southern_women_trivial_partitions(self):
+        G = nx.davis_southern_women_graph()
+        women = {n for n, d in G.nodes(data=True) if d["bipartite"] == 0}
+        assert bipartite.modularity(G, [set(G)], women) == pytest.approx(0.0)
+        assert bipartite.modularity(G, [{n} for n in G], women) == pytest.approx(0.0)
+
+    def test_disjoint_bipartite_components_positive(self):
+        # Two disjoint K_{2,2} components; grouping each component as a
+        # community gives strong bipartite modularity.
+        G = nx.Graph()
+        G.add_edges_from([(0, 2), (0, 3), (1, 2), (1, 3)])
+        G.add_edges_from([(4, 6), (4, 7), (5, 6), (5, 7)])
+        red = {0, 1, 4, 5}
+        communities = [{0, 1, 2, 3}, {4, 5, 6, 7}]
+        q = bipartite.modularity(G, communities, red)
+        assert q > 0
+        # Hand calc: m = 8. For each component L_c=4, k_c=4, d_c=4.
+        # contribution = 4/8 - 16/64 = 0.5 - 0.25 = 0.25; total = 0.5
+        assert q == pytest.approx(0.5)
+
+    def test_random_bipartite_trivial_partitions(self):
+        G = nx.bipartite.random_graph(6, 8, 0.5, seed=42)
+        red = {n for n, d in G.nodes(data=True) if d["bipartite"] == 0}
+        assert bipartite.modularity(G, [set(G)], red) == pytest.approx(0.0)
+        assert bipartite.modularity(G, [{n} for n in G], red) == pytest.approx(0.0)
+
+    def test_nodes_as_iterable(self):
+        G = nx.complete_bipartite_graph(2, 2)
+        # Pass nodes as list rather than set; function should accept any
+        # iterable and convert internally.
+        communities = [{0, 2}, {1, 3}]
+        assert bipartite.modularity(G, communities, [0, 1]) == pytest.approx(0.0)

--- a/networkx/algorithms/bipartite/tests/test_community.py
+++ b/networkx/algorithms/bipartite/tests/test_community.py
@@ -144,6 +144,20 @@ class TestBipartiteModularity:
         communities = [{0, 2}, {1, 3}]
         assert bipartite.modularity(G, communities, [0, 1]) == pytest.approx(0.0)
 
+    def test_multigraph(self):
+        # MultiGraph with parallel edges: each parallel edge is counted
+        # separately in both the degree sums and L_c. Two parallel (0, 2)
+        # edges plus one (1, 3). Degrees: deg(0)=2, deg(1)=1, deg(2)=2,
+        # deg(3)=1. m = 3.
+        #   {0, 2}: L=2, k=2, d=2 -> 2/3 - 4/9 = 2/9
+        #   {1, 3}: L=1, k=1, d=1 -> 1/3 - 1/9 = 2/9
+        # Total Q = 4/9.
+        G = nx.MultiGraph()
+        G.add_edges_from([(0, 2), (0, 2), (1, 3)])
+        red = {0, 1}
+        communities = [{0, 2}, {1, 3}]
+        assert bipartite.modularity(G, communities, red) == pytest.approx(4 / 9)
+
 
 def _compute_m(G, red, weight="weight"):
     """Compute total edge weight the same way bipartite.modularity does."""
@@ -273,6 +287,27 @@ class TestBipartiteModularityMergeDelta:
             q_merge = _bipartite_modularity_merge_delta(G, A, B, 1, m=m)
             q_delta = _q_merge_delta_via_full_eval(G, A, B, rest, red)
             assert q_merge == pytest.approx(q_delta)
+
+    def test_multigraph(self):
+        # Parallel edges must be reflected in both the red/blue degree
+        # attributes and in E(A, B). Edges: (0, 2) x 2, (1, 2), (1, 3).
+        # Degrees: deg(0)=2, deg(1)=2, deg(2)=3, deg(3)=1. m = 4.
+        # Merging A={0, 3} with B={1, 2}:
+        #   k_A = 2, d_A = 1, k_B = 2, d_B = 3
+        #   E(A, B) = 2 (parallel 0-2) + 1 (1-3) = 3
+        # merge_delta = 3/4 - (2*3 + 2*1)/16 = 3/4 - 1/2 = 1/4.
+        G = nx.MultiGraph()
+        G.add_edges_from([(0, 2), (0, 2), (1, 2), (1, 3)])
+        red = {0, 1}
+        _set_bipartite_degree_attrs(G, red)
+        m = _compute_m(G, red)
+
+        A = {0, 3}
+        B = {1, 2}
+        q_merge = _bipartite_modularity_merge_delta(G, A, B, 1, m=m)
+        q_delta = _q_merge_delta_via_full_eval(G, A, B, [], red)
+        assert q_merge == pytest.approx(q_delta)
+        assert q_merge == pytest.approx(0.25)
 
     def test_aggregated_supernode_graph(self):
         # Construct an aggregated graph where each super-node carries the

--- a/networkx/algorithms/bipartite/tests/test_community.py
+++ b/networkx/algorithms/bipartite/tests/test_community.py
@@ -5,8 +5,7 @@ import pytest
 import networkx as nx
 from networkx.algorithms import bipartite
 from networkx.algorithms.bipartite.community import (
-    _bipartite_modularity_delta_partial_eval_add,
-    _bipartite_modularity_delta_partial_eval_remove,
+    _bipartite_modularity_merge_delta,
 )
 from networkx.algorithms.community.quality import NotAPartition
 
@@ -146,10 +145,31 @@ class TestBipartiteModularity:
         assert bipartite.modularity(G, communities, [0, 1]) == pytest.approx(0.0)
 
 
-def _q_delta_via_full_eval(G, u, A, B, rest, red, resolution=1, weight="weight"):
-    """Reference delta: compute Q_B on the before/after partitions."""
-    before = [A, B] + rest
-    after = [A - {u}, B | {u}] + rest
+def _compute_m(G, red, weight="weight"):
+    """Compute total edge weight the same way bipartite.modularity does."""
+    return sum(G.degree(v, weight=weight) for v in red)
+
+
+def _set_bipartite_degree_attrs(G, red, weight="weight"):
+    """Set red_degree / blue_degree attributes on a leaf bipartite graph.
+
+    Red nodes get red_degree = deg(v), blue_degree = 0.
+    Blue nodes get red_degree = 0, blue_degree = deg(v).
+    """
+    for v in G:
+        deg = G.degree(v, weight=weight)
+        if v in red:
+            G.nodes[v]["red_degree"] = deg
+            G.nodes[v]["blue_degree"] = 0
+        else:
+            G.nodes[v]["red_degree"] = 0
+            G.nodes[v]["blue_degree"] = deg
+
+
+def _q_merge_delta_via_full_eval(G, C_a, C_b, rest, red, resolution=1, weight="weight"):
+    """Reference merge delta: compute Q_B before/after merging C_a and C_b."""
+    before = [C_a, C_b] + rest
+    after = [C_a | C_b] + rest
     q_before = bipartite.modularity(
         G, before, red, weight=weight, resolution=resolution
     )
@@ -157,130 +177,147 @@ def _q_delta_via_full_eval(G, u, A, B, rest, red, resolution=1, weight="weight")
     return q_after - q_before
 
 
-def _compute_m(G, red, weight="weight"):
-    """Compute total edge weight the same way bipartite.modularity does."""
-    return sum(G.degree(v, weight=weight) for v in red)
-
-
-class TestBipartiteModularityDelta:
-    def test_red_node_move_unweighted(self):
-        # Two disjoint K_{2,2} components. Move red node 0 from its
-        # community to the other.
+class TestBipartiteModularityMergeDelta:
+    def test_singleton_move_red(self):
+        # Moving red node 0 from A to B on two disjoint K_{2,2}.
         G = nx.Graph()
         G.add_edges_from([(0, 2), (0, 3), (1, 2), (1, 3)])
         G.add_edges_from([(4, 6), (4, 7), (5, 6), (5, 7)])
         red = {0, 1, 4, 5}
-        A = {0, 1, 2, 3}
-        B = {4, 5, 6, 7}
-        u = 0  # red node
+        _set_bipartite_degree_attrs(G, red)
         m = _compute_m(G, red)
+        u = 0
+        B = {4, 5, 6, 7}
+        q_merge = _bipartite_modularity_merge_delta(G, {u}, B, 1, m=m)
+        q_delta = _q_merge_delta_via_full_eval(G, {u}, B, [{1, 2, 3}], red)
+        assert q_merge == pytest.approx(q_delta)
 
-        q_rem = _bipartite_modularity_delta_partial_eval_remove(
-            G, u, A, 1, nodes=red, m=m
-        )
-        q_add = _bipartite_modularity_delta_partial_eval_add(G, u, B, 1, nodes=red, m=m)
-        q_delta = _q_delta_via_full_eval(G, u, A, B, [], red)
-        assert q_rem + q_add == pytest.approx(q_delta)
-
-    def test_blue_node_move_unweighted(self):
-        # Same graph, move blue node 2.
+    def test_singleton_move_blue(self):
         G = nx.Graph()
         G.add_edges_from([(0, 2), (0, 3), (1, 2), (1, 3)])
         G.add_edges_from([(4, 6), (4, 7), (5, 6), (5, 7)])
         red = {0, 1, 4, 5}
+        _set_bipartite_degree_attrs(G, red)
+        m = _compute_m(G, red)
+        u = 2  # blue
+        B = {4, 5, 6, 7}
+        q_merge = _bipartite_modularity_merge_delta(G, {u}, B, 1, m=m)
+        q_delta = _q_merge_delta_via_full_eval(G, {u}, B, [{0, 1, 3}], red)
+        assert q_merge == pytest.approx(q_delta)
+
+    def test_two_k22_merge(self):
+        # Two disjoint K_{2,2}. Merging the two components drops Q_B from
+        # 0.5 to 0 (merged partition is a single community covering the
+        # whole graph).
+        G = nx.Graph()
+        G.add_edges_from([(0, 2), (0, 3), (1, 2), (1, 3)])
+        G.add_edges_from([(4, 6), (4, 7), (5, 6), (5, 7)])
+        red = {0, 1, 4, 5}
+        _set_bipartite_degree_attrs(G, red)
+        m = _compute_m(G, red)
         A = {0, 1, 2, 3}
         B = {4, 5, 6, 7}
-        u = 2  # blue node
-        m = _compute_m(G, red)
 
-        q_rem = _bipartite_modularity_delta_partial_eval_remove(
-            G, u, A, 1, nodes=red, m=m
-        )
-        q_add = _bipartite_modularity_delta_partial_eval_add(G, u, B, 1, nodes=red, m=m)
-        q_delta = _q_delta_via_full_eval(G, u, A, B, [], red)
-        assert q_rem + q_add == pytest.approx(q_delta)
+        q_merge = _bipartite_modularity_merge_delta(G, A, B, 1, m=m)
+        q_delta = _q_merge_delta_via_full_eval(G, A, B, [], red)
+        assert q_merge == pytest.approx(q_delta)
+        assert q_merge == pytest.approx(-0.5)
 
-    def test_weighted_edges(self):
+    def test_weighted_merge(self):
         G = nx.Graph()
         G.add_edge(0, 2, weight=3)
         G.add_edge(0, 3, weight=1)
         G.add_edge(1, 2, weight=2)
         G.add_edge(1, 3, weight=5)
         red = {0, 1}
+        _set_bipartite_degree_attrs(G, red)
+        m = _compute_m(G, red)
         A = {0, 2}
         B = {1, 3}
-        u = 0
-        m = _compute_m(G, red)
 
-        q_rem = _bipartite_modularity_delta_partial_eval_remove(
-            G, u, A, 1, nodes=red, m=m
-        )
-        q_add = _bipartite_modularity_delta_partial_eval_add(G, u, B, 1, nodes=red, m=m)
-        q_delta = _q_delta_via_full_eval(G, u, A, B, [], red)
-        assert q_rem + q_add == pytest.approx(q_delta)
+        q_merge = _bipartite_modularity_merge_delta(G, A, B, 1, m=m)
+        q_delta = _q_merge_delta_via_full_eval(G, A, B, [], red)
+        assert q_merge == pytest.approx(q_delta)
 
     def test_resolution_parameter(self):
         G = nx.Graph()
         G.add_edges_from([(0, 2), (0, 3), (1, 2), (1, 3)])
         G.add_edges_from([(4, 6), (4, 7), (5, 6), (5, 7)])
         red = {0, 1, 4, 5}
+        _set_bipartite_degree_attrs(G, red)
+        m = _compute_m(G, red)
         A = {0, 1, 2, 3}
         B = {4, 5, 6, 7}
-        u = 0
-        m = _compute_m(G, red)
 
         for gamma in (0.5, 1.0, 2.0):
-            q_rem = _bipartite_modularity_delta_partial_eval_remove(
-                G, u, A, gamma, nodes=red, m=m
-            )
-            q_add = _bipartite_modularity_delta_partial_eval_add(
-                G, u, B, gamma, nodes=red, m=m
-            )
-            q_delta = _q_delta_via_full_eval(G, u, A, B, [], red, resolution=gamma)
-            assert q_rem + q_add == pytest.approx(q_delta)
+            q_merge = _bipartite_modularity_merge_delta(G, A, B, gamma, m=m)
+            q_delta = _q_merge_delta_via_full_eval(G, A, B, [], red, resolution=gamma)
+            assert q_merge == pytest.approx(q_delta)
 
-    def test_composition_property(self):
-        # Verify that remove(u, A) == -add(u, A\{u}), i.e. the remove/add
-        # pair composes into the single quality_delta pattern used by #8509.
+    def test_random_graph_all_pairs(self):
+        # Fuzz test: every ordered pair of three communities on a random
+        # bipartite graph, verified against the full quality function.
+        G = nx.bipartite.random_graph(6, 8, 0.5, seed=42)
+        red = {n for n, d in G.nodes(data=True) if d["bipartite"] == 0}
+        _set_bipartite_degree_attrs(G, red)
+        m = _compute_m(G, red)
+
+        all_nodes = sorted(G)
+        third = len(all_nodes) // 3
+        C1 = set(all_nodes[:third])
+        C2 = set(all_nodes[third : 2 * third])
+        C3 = set(all_nodes[2 * third :])
+
+        pairs = [(C1, C2, [C3]), (C1, C3, [C2]), (C2, C3, [C1])]
+        for A, B, rest in pairs:
+            q_merge = _bipartite_modularity_merge_delta(G, A, B, 1, m=m)
+            q_delta = _q_merge_delta_via_full_eval(G, A, B, rest, red)
+            assert q_merge == pytest.approx(q_delta)
+
+    def test_aggregated_supernode_graph(self):
+        # Construct an aggregated graph where each super-node carries the
+        # red/blue degree sums of its constituent community, and self-loops
+        # encode intra-community edge weights. Verify merge_delta on the
+        # aggregate equals merge_delta on the original for the same merge
+        # operation.
+        #
+        # Original: two disjoint K_{2,2} on nodes {0,1,2,3} and {4,5,6,7},
+        # with one extra cross-edge (1, 6) to give the merge a nonzero
+        # E(A, B).
         G = nx.Graph()
         G.add_edges_from([(0, 2), (0, 3), (1, 2), (1, 3)])
         G.add_edges_from([(4, 6), (4, 7), (5, 6), (5, 7)])
+        G.add_edge(1, 6)  # cross edge so E(A, B) != 0
         red = {0, 1, 4, 5}
+        _set_bipartite_degree_attrs(G, red)
+        m = _compute_m(G, red)
+
         A = {0, 1, 2, 3}
-        u = 0
-        m = _compute_m(G, red)
+        B = {4, 5, 6, 7}
+        q_merge_leaf = _bipartite_modularity_merge_delta(G, A, B, 1, m=m)
 
-        q_rem = _bipartite_modularity_delta_partial_eval_remove(
-            G, u, A, 1, nodes=red, m=m
+        # Aggregated graph: community A -> super-node "a", B -> "b".
+        # k_a = sum of red degrees in A, etc. Self-loop weight on "a" is
+        # the intra-A edge weight total (L_A); likewise for "b". Edge
+        # ("a", "b") has weight E(A, B).
+        k_A = sum(G.nodes[v]["red_degree"] for v in A)
+        d_A = sum(G.nodes[v]["blue_degree"] for v in A)
+        k_B = sum(G.nodes[v]["red_degree"] for v in B)
+        d_B = sum(G.nodes[v]["blue_degree"] for v in B)
+        L_A = sum(1 for u, v in G.edges() if u in A and v in A)
+        L_B = sum(1 for u, v in G.edges() if u in B and v in B)
+        E_AB = sum(
+            1 for u, v in G.edges() if (u in A and v in B) or (u in B and v in A)
         )
-        q_add_neg = _bipartite_modularity_delta_partial_eval_add(
-            G, u, A - {u}, 1, nodes=red, m=m
-        )
-        assert q_rem == pytest.approx(-q_add_neg)
 
-    def test_random_graph_all_moves(self):
-        # Fuzz test: for every possible single-node move on a random
-        # bipartite graph, verify the delta invariant.
-        G = nx.bipartite.random_graph(6, 8, 0.5, seed=42)
-        red = {n for n, d in G.nodes(data=True) if d["bipartite"] == 0}
-        m = _compute_m(G, red)
+        H = nx.Graph()
+        H.add_node("a", red_degree=k_A, blue_degree=d_A)
+        H.add_node("b", red_degree=k_B, blue_degree=d_B)
+        H.add_edge("a", "a", weight=L_A)
+        H.add_edge("b", "b", weight=L_B)
+        H.add_edge("a", "b", weight=E_AB)
 
-        # Start with a two-community partition.
-        comm_a = {n for n in G if n < 7}
-        comm_b = set(G) - comm_a
-        partition = [comm_a, comm_b]
+        # m is preserved across aggregation.
+        q_merge_agg = _bipartite_modularity_merge_delta(H, {"a"}, {"b"}, 1, m=m)
 
-        for u in G:
-            if u in comm_a:
-                A, B, rest = comm_a, comm_b, []
-            else:
-                A, B, rest = comm_b, comm_a, []
-
-            q_rem = _bipartite_modularity_delta_partial_eval_remove(
-                G, u, A, 1, nodes=red, m=m
-            )
-            q_add = _bipartite_modularity_delta_partial_eval_add(
-                G, u, B, 1, nodes=red, m=m
-            )
-            q_delta = _q_delta_via_full_eval(G, u, A, B, rest, red)
-            assert q_rem + q_add == pytest.approx(q_delta)
+        assert q_merge_leaf == pytest.approx(q_merge_agg)


### PR DESCRIPTION
Add `bipartite.modularity` implementing Barber's Q_B (2007) as a quality function for bipartite community partitions. The implementation uses the community-sum form

    Q_B = sum_c [ L_c/m - gamma * k_c * d_c / m^2 ]

where k_c and d_c are the degree sums of the red and blue nodes in community c. This mirrors the per-community form used by `nx.community.modularity` but with a bipartite null model: the product of two distinct degree sums rather than the square of a single one.

References:
- Barber, M. J. (2007). Modularity and community detection in bipartite networks. Phys. Rev. E 76, 066102.

For context and roadmap see the discussion at #8610

AI disclaimer: I used claude to format and proof read (with minor edits, specially the math) the docstrings.