### PR TITLE
DOC: clarify remaining readwrite generator docstrings

### DIFF
--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -41,24 +41,24 @@ from networkx.utils import open_file
 
 
 def generate_edgelist(G, delimiter=" ", data=True):
-    """Generate a single line of the graph G in edge list format.
+    """Generate lines representing edges in edge list format.
 
     Parameters
     ----------
     G : NetworkX graph
 
-    delimiter : string, optional
-       Separator for node labels
+    delimiter : str, default=" "
+        Separator for node labels.
 
     data : bool or list of keys
        If False generate no edge data.  If True use a dictionary
        representation of edge data.  If a list of keys use a list of data
        values corresponding to the keys.
 
-    Returns
-    -------
-    lines : string
-        Lines of data in adjlist format.
+    Yields
+    ------
+    str
+        A line of data in edge list format for an edge in `G`.
 
     Examples
     --------
@@ -103,7 +103,7 @@ def generate_edgelist(G, delimiter=" ", data=True):
 
     See Also
     --------
-    write_adjlist, read_adjlist
+    write_edgelist, read_edgelist
     """
     if data is True:
         for u, v, d in G.edges(data=True):

--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -41,14 +41,14 @@ from networkx.utils import open_file
 
 
 def generate_edgelist(G, delimiter=" ", data=True):
-    """Generate lines representing edges in edge list format.
+    """Generate lines representing edges of `G` in edge list format.
 
     Parameters
     ----------
     G : NetworkX graph
 
     delimiter : str, default=" "
-        Separator for node labels.
+       Separator for node labels.
 
     data : bool or list of keys
        If False generate no edge data.  If True use a dictionary

--- a/networkx/readwrite/edgelist.py
+++ b/networkx/readwrite/edgelist.py
@@ -47,7 +47,7 @@ def generate_edgelist(G, delimiter=" ", data=True):
     ----------
     G : NetworkX graph
 
-    delimiter : str, default=" "
+    delimiter : str, optional (default=" ")
        Separator for node labels.
 
     data : bool or list of keys

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -119,11 +119,15 @@ def generate_gexf(G, encoding="utf-8", prettyprint=True, version="1.2draft"):
     Version of GEFX File Format (see http://gexf.net/schema.html)
     Supported values: "1.1draft", "1.2draft"
 
+    Yields
+    ------
+    str
+        Lines representing the graph in GEXF format
+
     Raises
     ------
     ValueError
         If an attribute has mixed typed values across nodes or edges.
-
 
     Examples
     --------

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -639,9 +639,9 @@ def generate_gml(G, stringizer=None):
         strings. If it cannot convert a value into a string, it should raise a
         `ValueError` to indicate that. Default value: None.
 
-    Returns
-    -------
-    lines: generator of strings
+    Yields
+    ------
+    str
         Lines of GML data. Newlines are not appended.
 
     Raises

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -37,19 +37,20 @@ from networkx.utils import open_file
 
 
 def generate_multiline_adjlist(G, delimiter=" "):
-    """Generate a single line of the graph G in multiline adjacency list format.
+    """Generate lines representing a graph in multiline adjacency list format.
 
     Parameters
     ----------
     G : NetworkX graph
 
-    delimiter : string, optional
-       Separator for node labels
+    delimiter : str, default=" "
+        Separator for node labels.
 
-    Returns
-    -------
-    lines : string
-        Lines of data in multiline adjlist format.
+    Yields
+    ------
+    str
+        A line of data in multiline adjacency list format for a node or one of
+        its neighbors in `G`.
 
     Examples
     --------

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -37,14 +37,14 @@ from networkx.utils import open_file
 
 
 def generate_multiline_adjlist(G, delimiter=" "):
-    """Generate lines representing a graph in multiline adjacency list format.
+    """Generate lines representing the graph `G` in multiline adjacency list format.
 
     Parameters
     ----------
     G : NetworkX graph
 
     delimiter : str, default=" "
-        Separator for node labels.
+       Separator for node labels.
 
     Yields
     ------

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -43,7 +43,7 @@ def generate_multiline_adjlist(G, delimiter=" "):
     ----------
     G : NetworkX graph
 
-    delimiter : str, default=" "
+    delimiter : str, optional (default=" ")
        Separator for node labels.
 
     Yields


### PR DESCRIPTION
Closes #5807

## Summary
- replace the remaining stale `Returns` sections with `Yields` in `generate_edgelist` and `generate_multiline_adjlist`
- update the `generate_edgelist` `See Also` entry to point to the edge-list helpers instead of the adjacency-list helpers

## Validation
- `python -Werror -c 'import networkx'`
- `python -m pytest networkx/readwrite/tests/test_adjlist.py networkx/readwrite/tests/test_edgelist.py --doctest-modules networkx/readwrite/edgelist.py networkx/readwrite/multiline_adjlist.py`

## Disclosure
- I used AI tools for drafting assistance, then manually reviewed, edited, and validated the final change locally.