### PR TITLE
Add HITS algorithm benchmark to benchmark suite

### DIFF
--- a/benchmarks/benchmarks/benchmark_hits.py
+++ b/benchmarks/benchmarks/benchmark_hits.py
@@ -1,17 +1,17 @@
 """Benchmarks for a certain set of algorithms"""
 
-import random
-
 import networkx as nx
+
+seed = 0xDEADC0DE
 
 
 class HitsAlgorithm:
     timeout = 120
     _graphs = [
-        nx.barabasi_albert_graph(1000, m=3),
-        nx.barabasi_albert_graph(10_000, m=3),
-        nx.gnp_random_graph(5000, 0.001),
-        nx.scale_free_graph(10_000),
+        nx.barabasi_albert_graph(1000, m=3, seed=seed),
+        nx.barabasi_albert_graph(10_000, m=3, seed=seed),
+        nx.gnp_random_graph(5000, 0.001, seed=seed),
+        nx.scale_free_graph(10_000, seed=seed),
         nx.grid_2d_graph(30, 30),
     ]
     params = [

--- a/benchmarks/benchmarks/benchmark_hits.py
+++ b/benchmarks/benchmarks/benchmark_hits.py
@@ -1,0 +1,31 @@
+"""Benchmarks for a certain set of algorithms"""
+
+import random
+
+import networkx as nx
+
+
+class HitsAlgorithm:
+    timeout = 120
+    _graphs = [
+        nx.barabasi_albert_graph(1000, m=3),
+        nx.barabasi_albert_graph(10_000, m=3),
+        nx.gnp_random_graph(5000, 0.001),
+        nx.scale_free_graph(10_000),
+        nx.grid_2d_graph(30, 30),
+    ]
+    params = [
+        "BA(1000, m=3)",
+        "BA(10000, m=3)",
+        "gnp(5000, 0.001)",
+        "scale_free(10000)",
+        "grid(30, 30)",
+    ]
+
+    param_names = ["graph"]
+
+    def setup(self, graph):
+        self.graphs_dict = dict(zip(self.params, self._graphs))
+
+    def time_hits(self, graph):
+        _, _ = nx.hits(self.graphs_dict[graph])

--- a/benchmarks/benchmarks/benchmark_hits.py
+++ b/benchmarks/benchmarks/benchmark_hits.py
@@ -1,11 +1,11 @@
-"""Benchmarks for a certain set of algorithms"""
+"""Benchmarks for HITS link analysis."""
 
 import networkx as nx
 
 seed = 0xDEADC0DE
 
 
-class HitsAlgorithm:
+class HitsAlgorithmBenchmarks:
     timeout = 120
     _graphs = [
         nx.barabasi_albert_graph(1000, m=3, seed=seed),


### PR DESCRIPTION
See #8620 for motivation.

Unfortunately the old implementation of HITS was removed so long ago (nx version 2.6(!)) reliably building old/new NetworkX for comparison no longer seems to be possible, at least with a Python version that's still supported. You can probably do so if you go all the way back to Python 3.9, but Python itself has changed so much since them (esp. with faster CPython) that it's not really a meaningful comparison.

One thing you *can* do in principle is check different scipy versions by adding e.g. `"1.16", "1.17"` to the scipy versions in the asv conf. I did so and ran on `main` to test the different ARPACK implementations, but didn't see a significant difference.

Anyways - not necessarily useful for #8620 given the support window issues, but potentially useful for folks hacking on hits moving forward!