### PR TITLE
MAINT: remove unused imports and dead helpers

### DIFF
--- a/networkx/algorithms/bipartite/cluster.py
+++ b/networkx/algorithms/bipartite/cluster.py
@@ -1,7 +1,5 @@
 """Functions for computing clustering of pairs"""
 
-import itertools
-
 import networkx as nx
 
 __all__ = [

--- a/networkx/algorithms/centrality/current_flow_betweenness_subset.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness_subset.py
@@ -91,8 +91,6 @@ def current_flow_betweenness_centrality_subset(
     .. [2] A measure of betweenness centrality based on random walks,
        M. E. J. Newman, Social Networks 27, 39-54 (2005).
     """
-    import numpy as np
-
     from networkx.utils import reverse_cuthill_mckee_ordering
 
     if not nx.is_connected(G):
@@ -201,8 +199,6 @@ def edge_current_flow_betweenness_centrality_subset(
     .. [2] A measure of betweenness centrality based on random walks,
        M. E. J. Newman, Social Networks 27, 39-54 (2005).
     """
-    import numpy as np
-
     if not nx.is_connected(G):
         raise nx.NetworkXError("Graph not connected.")
     N = G.number_of_nodes()

--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -1,7 +1,7 @@
 """Algorithms to characterize the number of triangles in a graph."""
 
 from collections import Counter
-from itertools import chain, combinations
+from itertools import chain
 
 import networkx as nx
 from networkx.utils import not_implemented_for

--- a/networkx/algorithms/community/bipartitions.py
+++ b/networkx/algorithms/community/bipartitions.py
@@ -2,7 +2,6 @@
 
 import random
 from copy import deepcopy
-from itertools import count
 
 import networkx as nx
 

--- a/networkx/algorithms/community/modularity_max.py
+++ b/networkx/algorithms/community/modularity_max.py
@@ -1,8 +1,6 @@
 """Functions for detecting communities based on modularity."""
 
-import random
 from collections import defaultdict
-from copy import deepcopy
 
 import networkx as nx
 from networkx.algorithms.community.quality import modularity

--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -3,8 +3,6 @@
 import networkx as nx
 from networkx.utils.decorators import not_implemented_for
 
-from ...utils import arbitrary_element
-
 __all__ = [
     "number_connected_components",
     "connected_components",

--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -10,9 +10,7 @@ import networkx as nx
 # Define the default maximum flow function to use in all flow based
 # connectivity algorithms.
 from networkx.algorithms.flow import (
-    boykov_kolmogorov,
     build_residual_network,
-    dinitz,
     edmonds_karp,
     preflow_push,
     shortest_augmenting_path,

--- a/networkx/algorithms/d_separation.py
+++ b/networkx/algorithms/d_separation.py
@@ -217,7 +217,7 @@ from collections import deque
 from itertools import chain
 
 import networkx as nx
-from networkx.utils import UnionFind, not_implemented_for
+from networkx.utils import not_implemented_for
 
 __all__ = [
     "is_d_separator",

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -11,7 +11,7 @@ from itertools import combinations, product
 from math import gcd
 
 import networkx as nx
-from networkx.utils import arbitrary_element, not_implemented_for, pairwise
+from networkx.utils import not_implemented_for, pairwise
 
 __all__ = [
     "descendants",

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -124,7 +124,6 @@ __all__ = ["ISMAGS"]
 
 import itertools
 from collections import Counter, defaultdict
-from functools import reduce, wraps
 
 import networkx as nx
 

--- a/networkx/algorithms/matching.py
+++ b/networkx/algorithms/matching.py
@@ -1,6 +1,6 @@
 """Functions for computing and verifying matchings in a graph."""
 
-from itertools import combinations, repeat
+from itertools import repeat
 
 import networkx as nx
 from networkx.utils import not_implemented_for

--- a/networkx/algorithms/triads.py
+++ b/networkx/algorithms/triads.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from itertools import combinations, permutations
 
 import networkx as nx
-from networkx.utils import not_implemented_for, py_random_state
+from networkx.utils import not_implemented_for
 
 __all__ = [
     "triadic_census",

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -1611,7 +1611,6 @@ class FancyArrowFactory:
     ):
         import matplotlib as mpl
         import matplotlib.patches  # call as mpl.patches
-        import matplotlib.pyplot as plt
         import numpy as np
 
         if isinstance(connectionstyle, str):

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -1,7 +1,6 @@
 """Unit tests for matplotlib drawing functions."""
 
 import itertools
-import os
 import warnings
 
 import pytest

--- a/networkx/readwrite/json_graph/node_link.py
+++ b/networkx/readwrite/json_graph/node_link.py
@@ -1,4 +1,3 @@
-import warnings
 from itertools import count
 
 import networkx as nx

--- a/networkx/readwrite/json_graph/tree.py
+++ b/networkx/readwrite/json_graph/tree.py
@@ -1,5 +1,3 @@
-from itertools import chain
-
 import networkx as nx
 
 __all__ = ["tree_data", "tree_graph"]

--- a/networkx/utils/decorators.py
+++ b/networkx/utils/decorators.py
@@ -2,7 +2,6 @@ import bz2
 import collections
 import gzip
 import inspect
-import itertools
 import re
 from collections import defaultdict
 from os.path import splitext


### PR DESCRIPTION
## Summary

This removes a small set of imports that were left behind by earlier refactors and deprecation expirations. The changes are limited to unused bindings; no tests are removed.

The removals are intentionally conservative. I kept imports that still serve as optional dependency checks, re-export conveniences, pytest skip globals, or namespace assertions. I'm making these changes in one big PR to make it easier to skip in `git blame`.

<details>
<summary> (Human-verified) AI-assisted `blame` to explain these changes </summary>

| Removed | Became unnecessary in |
|---|---|
| `itertools` in `bipartite/cluster.py` | 7c0a99877 on 2025-04-13, when `_four_cycles` stopped using `itertools.combinations`. |
| local `numpy as np` in both current-flow subset functions | 28f3e9f61 on 2024-03-01, when `np.abs(row[i] - row[j])` became `abs(row.item(i) - row.item(j))`. |
| `combinations` in `algorithms/cluster.py` | 7c0a99877 on 2025-04-13, when `square_clustering` stopped iterating over neighbor pairs with `combinations`. |
| `count` in `community/bipartitions.py` | Introduced unused in 3dacd1bdc on 2025-12-04. |
| `random`, `deepcopy` in `community/modularity_max.py` | Introduced unused in 3dacd1bdc on 2025-12-04 while adding/moving bipartition code. |
| `arbitrary_element` in `components/connected.py` | 7eba5a38b on 2025-09-29, when `is_connected` switched to `next(connected_components(G))`. |
| `boykov_kolmogorov`, `dinitz` in `connectivity.py` | 4bc8ba917 on 2024-04-09, when explicit flow-function cases were replaced by generic cutoff logic. |
| `UnionFind` in `d_separation.py` | a97c162a9 on 2023-12-22, when the old UnionFind-based algorithm was replaced. |
| `arbitrary_element` in `dag.py` | 7c35210a9 on 2026-01-17, when the call became `nx.utils.arbitrary_element(G)`. |
| `reduce`, `wraps` in `isomorphism/ismags.py` | 3a7f729bf on 2025-10-13; `intersect` and wrapper-maker uses were removed/refactored, imports left behind. |
| `combinations` in `matching.py` | 28b3014d6 on 2022-02-18, when pairwise matching validation was replaced with set-based node tracking. |
| `py_random_state` in `triads.py` | 9ffe0addc on 2025-02-05, when deprecated `random_triad` was removed. |
| `matplotlib.pyplot as plt` inside `FancyArrowFactory.__init__` | Introduced unused in 1fa2414f4 on 2024-02-06. |
| `os` in `drawing/tests/test_pylab.py` | 39928cf79 on 2025-09-13, when tests switched from `os.unlink("test.ps")` to `tmp_path`. |
| `warnings` in `json_graph/node_link.py` | cd59f059f on 2025-09-26, when the `link` deprecation warnings were removed. |
| `chain` in `json_graph/tree.py` | b467fdd82 on 2023-05-02, when dict construction switched to unpacking. |
| `itertools` in `utils/decorators.py` | Introduced unused in 89a54703f on 2021-06-21. |

</details>

--- 

AI-assisted-by: OpenAI Codex.

AI was used to identify these unused imports throughout the code base, and to handle (local and remote) version control (including generating the hidden `blame` table) as well as targeted testing before pushing to the remote. It also polished a first human-written draft of the PR description, which I've since condensed.
