### PR TITLE
MAINT: Handle insufficient degree Pearson samples

### DIFF
--- a/networkx/algorithms/assortativity/correlation.py
+++ b/networkx/algorithms/assortativity/correlation.py
@@ -145,6 +145,10 @@ def degree_pearson_correlation_coefficient(G, x="out", y="in", weight=None, node
     -----
     This calls scipy.stats.pearsonr.
 
+    Returns ``nan`` if the graph has fewer than two ``(degree, degree)``
+    pairs, since the Pearson correlation coefficient is undefined in
+    that case.
+
     References
     ----------
     .. [1] M. E. J. Newman, Mixing patterns in networks
@@ -154,7 +158,9 @@ def degree_pearson_correlation_coefficient(G, x="out", y="in", weight=None, node
     """
     import scipy as sp
 
-    xy = node_degree_xy(G, x=x, y=y, nodes=nodes, weight=weight)
+    xy = list(node_degree_xy(G, x=x, y=y, nodes=nodes, weight=weight))
+    if len(xy) < 2:
+        return float("nan")
     x, y = zip(*xy)
     return float(sp.stats.pearsonr(x, y)[0])
 

--- a/networkx/algorithms/assortativity/tests/test_correlation.py
+++ b/networkx/algorithms/assortativity/tests/test_correlation.py
@@ -6,7 +6,7 @@ from networkx.algorithms.assortativity.correlation import attribute_ac
 from .base_test import BaseTestAttributeMixing, BaseTestDegreeMixing
 
 np = pytest.importorskip("numpy")
-pytest.importorskip("scipy")
+sp = pytest.importorskip("scipy")
 
 
 class TestDegreeMixingCorrelation(BaseTestDegreeMixing):
@@ -60,6 +60,24 @@ class TestDegreeMixingCorrelation(BaseTestDegreeMixing):
     def test_degree_assortativity_double_star(self):
         r = nx.degree_assortativity_coefficient(self.DS)
         np.testing.assert_almost_equal(r, -0.9339, decimal=4)
+
+    @pytest.mark.parametrize(
+        "G",
+        [
+            nx.empty_graph(2),
+            nx.DiGraph([(1, 2)]),
+            nx.Graph([(1, 1)]),
+        ],
+    )
+    def test_degree_pearson_assortativity_insufficient_samples(self, G):
+        r = nx.degree_pearson_correlation_coefficient(G)
+        assert np.isnan(r)
+
+    def test_degree_pearson_assortativity_selfloop_only_graph(self):
+        G = nx.Graph([(1, 1), (2, 2), (3, 3)])
+        with pytest.warns(sp.stats.ConstantInputWarning):
+            r = nx.degree_pearson_correlation_coefficient(G)
+        assert np.isnan(r)
 
 
 class TestAttributeMixingCorrelation(BaseTestAttributeMixing):


### PR DESCRIPTION
## Summary

This updates `degree_pearson_correlation_coefficient` to return `nan` when `node_degree_xy` produces fewer than two `(degree, degree)` pairs.

That covers both the edgeless graph case from #6913 and the related one-sample Pearson cases (e.g. one-edge directed graph or a graph with a single self-loop) mentioned in #7392.

Returning NaN matches the surrounding assortativity API: the coefficient is undefined for these inputs, and `degree_assortativity_coefficient` already returns `nan` for the analogous cases.

Closes #6913.

Supersedes #8395 (only handled the zero-pair case) and #7392 (stale, unaddressed review comments).

---

Assisted-by: OpenAI Codex.

AI tools were used to interact with GitHub (including polishing a drafted PR description) and local version control, as well as for making the actual code changes. I manually decided on the "correct" behavior (detecting fewer than two pairs, and returning NaN instead of raising) and communicated this to the model during prompting.
