### PR TITLE
Add description and keywords support to GEXF reader/writer

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -87,6 +87,9 @@ def write_gexf(G, path, encoding="utf-8", prettyprint=True, version="1.2draft"):
     This implementation does not support mixed graphs (directed and undirected
     edges together).
 
+    This implementation supports writing a single graph per GEXF file.
+    GEXF documents containing multiple graphs are not supported.
+
     The node id attribute is set to be the string of the node label.
     If you want to specify an id use set it as node data, e.g.
     node['a']['id']=1 to set the id of node 'a' to 1.
@@ -142,6 +145,9 @@ def generate_gexf(G, encoding="utf-8", prettyprint=True, version="1.2draft"):
     This implementation does not support mixed graphs (directed and undirected
     edges together).
 
+    This implementation supports writing a single graph per GEXF file.
+    GEXF documents containing multiple graphs are not supported.
+
     The node id attribute is set to be the string of the node label.
     If you want to specify an id use set it as node data, e.g.
     node['a']['id']=1 to set the id of node 'a' to 1.
@@ -187,6 +193,9 @@ def read_gexf(path, node_type=None, relabel=False, version="1.2draft"):
     -----
     This implementation does not support mixed graphs (directed and undirected
     edges together).
+
+    This implementation supports reading a single graph per GEXF file.
+    GEXF documents containing multiple graphs are not supported.
 
     References
     ----------

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -328,11 +328,11 @@ class GEXFWriter(GEXF):
 
         # Make meta element a non-graph element
         # Also add lastmodifieddate as attribute, not tag
-        meta_element = Element("meta")
+        self.meta_element = Element("meta")
         subelement_text = f"NetworkX {nx.__version__}"
-        SubElement(meta_element, "creator").text = subelement_text
-        meta_element.set("lastmodifieddate", time.strftime("%Y-%m-%d"))
-        self.xml.append(meta_element)
+        SubElement(self.meta_element, "creator").text = subelement_text
+        self.meta_element.set("lastmodifieddate", time.strftime("%Y-%m-%d"))
+        self.xml.append(self.meta_element)
 
         register_namespace("viz", self.NS_VIZ)
 
@@ -369,6 +369,14 @@ class GEXFWriter(GEXF):
             mode = "dynamic"
         else:
             mode = "static"
+        # set graph description in meta element
+        description = G.graph.get("description")
+        if description is not None:
+            SubElement(self.meta_element, "description").text = str(description)
+        # set graph keywords in meta element
+        keywords = G.graph.get("keywords")
+        if keywords is not None:
+            SubElement(self.meta_element, "keywords").text = str(keywords)
         # Add a graph element to the XML
         if G.is_directed():
             default = "directed"
@@ -741,24 +749,35 @@ class GEXFReader(GEXF):
 
     def __call__(self, stream):
         self.xml = ElementTree(file=stream)
+        meta = self.xml.find(f"{{{self.NS_GEXF}}}meta")
         g = self.xml.find(f"{{{self.NS_GEXF}}}graph")
         if g is not None:
-            return self.make_graph(g)
+            return self.make_graph(g, meta_xml=meta)
         # try all the versions
         for version in self.versions:
             self.set_version(version)
+            meta = self.xml.find(f"{{{self.NS_GEXF}}}meta")
             g = self.xml.find(f"{{{self.NS_GEXF}}}graph")
             if g is not None:
-                return self.make_graph(g)
+                return self.make_graph(g, meta_xml=meta)
         raise nx.NetworkXError("No <graph> element in GEXF file.")
 
-    def make_graph(self, graph_xml):
+    def make_graph(self, graph_xml, meta_xml=None):
         # start with empty DiGraph or MultiDiGraph
         edgedefault = graph_xml.get("defaultedgetype", None)
         if edgedefault == "directed":
             G = nx.MultiDiGraph()
         else:
             G = nx.MultiGraph()
+
+        # add description and keywords from meta element
+        if meta_xml is not None:
+            description = meta_xml.find(f"{{{self.NS_GEXF}}}description")
+            if description is not None:
+                G.graph["description"] = description.text
+            keywords = meta_xml.find(f"{{{self.NS_GEXF}}}keywords")
+            if keywords is not None:
+                G.graph["keywords"] = keywords.text
 
         # graph attributes
         graph_name = graph_xml.get("name", "")

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -142,6 +142,7 @@ org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/\
 """
         cls.attribute_graph = nx.DiGraph()
         cls.attribute_graph.graph["node_default"] = {"frog": True}
+        cls.attribute_graph.graph["description"] = "A Web network"
         cls.attribute_graph.add_node(
             "0", label="Gephi", url="https://gephi.org", indegree=1, frog=False
         )
@@ -219,6 +220,7 @@ org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/\
         G = self.attribute_graph
         H = nx.read_gexf(self.attribute_fh)
         assert sorted(G.nodes(True)) == sorted(H.nodes(data=True))
+        assert H.graph.get("description") == "A Web network"
         ge = sorted(G.edges(data=True))
         he = sorted(H.edges(data=True))
         for a, b in zip(ge, he):
@@ -664,3 +666,19 @@ gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
         assert G.nodes[1].get("baz") == H.nodes[1].get("baz")
         assert isinstance(H.nodes[2].get("baz"), float)
         assert G.nodes[2].get("baz") == H.nodes[2].get("baz")
+
+    def test_meta_description_keywords_round_trip(self):
+        G = nx.DiGraph()
+        G.add_node(0, label="Node0")
+        G.add_edge(0, 1)
+        G.graph["description"] = "Test description"
+        G.graph["keywords"] = "test, network, graph"
+        fh = io.BytesIO()
+        nx.write_gexf(G, fh)
+
+        fh.seek(0)
+        H = nx.read_gexf(fh, node_type=int)
+        assert H.graph.get("description") == "Test description"
+        assert H.graph.get("keywords") == "test, network, graph"
+        assert sorted(G.nodes()) == sorted(H.nodes())
+        assert sorted(G.edges()) == sorted(H.edges())


### PR DESCRIPTION
Adds support for reading and writing `description` and `keywords` in GEXF metadata.

Also clarifies that NetworkX only supports a single graph per GEXF file.

Fixes #8624 