### PR TITLE
BENCH: Add triangles benchmarks

### DIFF
--- a/benchmarks/benchmarks/benchmark_triangles.py
+++ b/benchmarks/benchmarks/benchmark_triangles.py
@@ -1,0 +1,45 @@
+import networkx as nx
+from benchmarks.utils import fetch_drug_interaction_network
+
+GRAPH_SPECS = [
+    ("barabasi_albert_graph", (10_000, 3), ()),
+    ("powerlaw_cluster_graph", (5_000, 3, 0.1), ()),
+    ("powerlaw_cluster_graph", (5_000, 5, 0.3), ()),
+    ("random_geometric_graph", (3_000, 0.025), ()),
+    ("gaussian_random_partition_graph", (3_000, 40, 10, 0.1, 0.001), ()),
+    ("connected_watts_strogatz_graph", (5_000, 10, 0.05), (("tries", 100),)),
+    ("gnp_random_graph", (1_000, 0.01), ()),
+    ("gnp_random_graph", (1_000, 0.1), ()),
+    ("complete_graph", (300,), ()),
+    ("drug_interaction_network", (), ()),
+]
+
+
+def build_graph(name, args, kwargs_items, seed):
+    if name == "drug_interaction_network":
+        return fetch_drug_interaction_network()
+
+    graph_func = getattr(nx, name)
+    kwargs = dict(kwargs_items)
+    if name != "complete_graph":
+        kwargs["seed"] = seed
+    return graph_func(*args, **kwargs)
+
+
+class Triangles:
+    timeout = 120
+    seed = 42
+    params = (GRAPH_SPECS,)
+    param_names = ["graph"]
+
+    def setup_cache(self):
+        return {
+            graph_spec: build_graph(*graph_spec, seed=self.seed)
+            for graph_spec in GRAPH_SPECS
+        }
+
+    def setup(self, graphs, graph_spec):
+        self.G = graphs[graph_spec]
+
+    def time_triangles(self, graphs, graph_spec):
+        _ = nx.triangles(self.G)


### PR DESCRIPTION
Add a benchmark suite for `triangles` to measure progress on #5246.

<details>
<summary>Example benchmark run comparing main to a follow-up change</summary>

```
| Change   | Before [068905f7] <codex/triangles-benchmarks>   | After [128667d3] <codex/triangles-skip-empty-updates>   |   Ratio | Benchmark (Parameter)                                                                                                 |
|----------|--------------------------------------------------|---------------------------------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------|
| -        | 30.0±0.6ms                                       | 24.8±0.4ms                                              |    0.83 | benchmark_triangles.Triangles.time_triangles(('connected_watts_strogatz_graph', (5000, 10, 0.05), (('tries', 100),))) |
| -        | 10.4±0.05ms                                      | 7.93±0.1ms                                              |    0.76 | benchmark_triangles.Triangles.time_triangles(('random_geometric_graph', (3000, 0.025), ()))                           |
| -        | 28.1±0.7ms                                       | 14.9±0.5ms                                              |    0.53 | benchmark_triangles.Triangles.time_triangles(('powerlaw_cluster_graph', (5000, 5, 0.3), ()))                          |
| -        | 16.8±0.8ms                                       | 6.67±0.2ms                                              |    0.4  | benchmark_triangles.Triangles.time_triangles(('powerlaw_cluster_graph', (5000, 3, 0.1), ()))                          |
| -        | 10.5±0.1ms                                       | 3.99±0.04ms                                             |    0.38 | benchmark_triangles.Triangles.time_triangles(('gaussian_random_partition_graph', (3000, 40, 10, 0.1, 0.001), ()))     |
| -        | 31.9±0.3ms                                       | 11.6±0.4ms                                              |    0.36 | benchmark_triangles.Triangles.time_triangles(('barabasi_albert_graph', (10000, 3), ()))                               |
| -        | 4.98±0.1ms                                       | 1.74±0.03ms                                             |    0.35 | benchmark_triangles.Triangles.time_triangles(('gnp_random_graph', (1000, 0.01), ()))                                  |

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.

```
</details>

---

Assisted-by: OpenAI Codex.

AI tooling was used to
 - Handle version control and to write the first implementation of the benchmark suite.
 - Iterate faster (do/undo changes to use virtual environments instead of conda with `asv`).
 - Identify the [`setup_cache` optimization](/Users/gillespeiffer/Documents/projects/project-euler/src/p0918.py) to avoid rebuilding graphs.
