### PR TITLE
MAINT: use merge-based implementation for `tournament.hamiltonian_path`

### DIFF
--- a/benchmarks/benchmarks/benchmark_algorithms.py
+++ b/benchmarks/benchmarks/benchmark_algorithms.py
@@ -2,6 +2,8 @@
 
 import random
 
+from asv_runner.benchmarks.mark import skip_for_params
+
 import networkx as nx
 from benchmarks.utils import (
     benchmark_name_from_func_call,
@@ -152,7 +154,7 @@ def _make_tournament_benchmark_graphs(seed):
     return graphs
 
 
-class ReachabilityBenchmark:
+class TournamentBenchmark:
     timeout = 120
     _seed = 42
     param_names = ["graph"]
@@ -165,6 +167,10 @@ class ReachabilityBenchmark:
         self.nodes = sorted(self.G)
         rng = random.Random(self._seed)
         self.source, self.target = rng.sample(self.nodes, 2)
+
+    @skip_for_params([("Tournament (1000, seed=42)",)])
+    def time_hamiltonian_path(self, graph):
+        _ = nx.tournament.hamiltonian_path(self.G)
 
     def time_is_reachable(self, graph):
         _ = nx.tournament.is_reachable(self.G, self.source, self.target)

--- a/networkx/algorithms/tests/test_tournament.py
+++ b/networkx/algorithms/tests/test_tournament.py
@@ -7,7 +7,6 @@ import pytest
 from networkx import DiGraph
 from networkx.algorithms.tournament import (
     hamiltonian_path,
-    index_satisfying,
     is_reachable,
     is_strongly_connected,
     is_tournament,
@@ -15,16 +14,6 @@ from networkx.algorithms.tournament import (
     score_sequence,
     tournament_matrix,
 )
-
-
-def test_condition_not_satisfied():
-    iter_in = [0]
-    assert index_satisfying(iter_in, lambda x: x > 0) == 1
-
-
-def test_empty_iterable():
-    with pytest.raises(ValueError):
-        index_satisfying([], lambda x: x > 0)
 
 
 def test_is_tournament():

--- a/networkx/algorithms/tournament.py
+++ b/networkx/algorithms/tournament.py
@@ -21,10 +21,10 @@ To access the functions in this module, you must access them through the
 
 """
 
-from itertools import combinations
+from itertools import batched, combinations
 
 import networkx as nx
-from networkx.utils import arbitrary_element, not_implemented_for, py_random_state
+from networkx.utils import not_implemented_for, py_random_state
 
 __all__ = [
     "hamiltonian_path",
@@ -37,31 +37,22 @@ __all__ = [
 ]
 
 
-def index_satisfying(iterable, condition):
-    """Returns the index of the first element in `iterable` that
-    satisfies the given condition.
-
-    If no such element is found (that is, when the iterable is
-    exhausted), this returns the length of the iterable (that is, one
-    greater than the last index of the iterable).
-
-    `iterable` must not be empty. If `iterable` is empty, this
-    function raises :exc:`ValueError`.
-
-    """
-    # Pre-condition: iterable must not be empty.
-    for i, x in enumerate(iterable):
-        if condition(x):
-            return i
-    # If we reach the end of the iterable without finding an element
-    # that satisfies the condition, return the length of the iterable,
-    # which is one greater than the index of its last element. If the
-    # iterable was empty, `i` will not be defined, so we raise an
-    # exception.
-    try:
-        return i + 1
-    except NameError as err:
-        raise ValueError("iterable must be non-empty") from err
+def _merge_paths(adj, left, right):
+    """Merge two Hamiltonian paths into one Hamiltonian path."""
+    path = []
+    i = j = 0
+    while i < len(left) and j < len(right):
+        u = left[i]
+        v = right[j]
+        if v in adj[u]:
+            path.append(u)
+            i += 1
+        else:
+            path.append(v)
+            j += 1
+    path.extend(left[i:])
+    path.extend(right[j:])
+    return path
 
 
 @not_implemented_for("undirected")
@@ -133,22 +124,19 @@ def hamiltonian_path(G):
 
     Notes
     -----
-    This is a recursive implementation with an asymptotic running time
-    of $O(n^2)$, ignoring multiplicative polylogarithmic factors, where
-    $n$ is the number of nodes in the graph.
+    This implementation is based on mergesort and runs in $O(n \\log n)$ time,
+    where $n$ is the number of nodes in the graph.
+    It repeatedly merges Hamiltonian paths of subtournaments.
 
     """
-    if len(G) == 0:
-        return []
-    if len(G) == 1:
-        return [arbitrary_element(G)]
-    v = arbitrary_element(G)
-    hampath = hamiltonian_path(G.subgraph(set(G) - {v}))
-    # Get the index of the first node in the path that does *not* have
-    # an edge to `v`, then insert `v` before that node.
-    index = index_satisfying(hampath, lambda u: v not in G[u])
-    hampath.insert(index, v)
-    return hampath
+    adj = G._adj
+    paths = [[v] for v in G]
+    while len(paths) > 1:
+        paths = [
+            _merge_paths(adj, *group) if len(group) == 2 else group[0]
+            for group in batched(paths, 2)
+        ]
+    return paths[0] if paths else []
 
 
 @py_random_state(1)


### PR DESCRIPTION
This changes the implementation of the `hamiltonian_path` function for tournament graphs to use another algorithm based on merging of Hamiltonian paths instead. A reference for that algorithm can be found [here (algorithm 1 from section 3)](https://imada.sdu.dk/u/jbj/DM19/turnering.pdf).
It also adds a (limited) benchmark for the function.

<details>
<summary>Some notes on benchmarking</summary>

The old implementation is really slow _and_ recursive, to the point where it's not even fun to compare ourselves to. A faster version of that uses an insertion-sort style algorithm, which is still quadratic, but pretty fast (faster than the $n \log n$ implementation for random tournaments). Something like this:
```python
def hamiltonian_path_quadratic(G):
    adj = G._adj
    path = []

    for v in G:
        for i, u in enumerate(path):
            if u not in adj[v]:
                path.insert(i, v)
                break
        else:
            path.append(v)

    return path
```

I chose to upload the merge-based one as while it's slightly slower on the average case, it's _much_ faster on the worst case (when the insertion order means we have to scan through the entire path). Some numbers:

```
random tournaments
 nodes    merge branch  fast quadratic  current recursive   ratio q/m
---------------------------------------------------------------------------
    10        0.018 ms        0.003 ms           0.320 ms        0.18
   100        0.161 ms        0.033 ms           8.668 ms        0.20
  1000        1.802 ms        0.424 ms     RecursionError        0.24
  2000        5.449 ms        1.286 ms     RecursionError        0.24
  4000       17.742 ms        5.832 ms     RecursionError        0.33

worst-case tournaments
 nodes    merge branch  fast quadratic  current recursive   ratio q/m
---------------------------------------------------------------------------
    10        0.022 ms        0.006 ms           0.385 ms        0.27
   100        0.156 ms        0.356 ms           8.284 ms        2.29
  1000        1.596 ms       58.606 ms     RecursionError       36.72
  2000        4.809 ms      268.537 ms     RecursionError       55.85
  4000       13.765 ms     1692.887 ms     RecursionError      122.99
```



</details>

---


_This PR was written with AI assistance._
While I verified the algorithm manually and guided the model through its implementation, this inefficiency (and the implementation of the solution) were identified through the use of an LLM. I wrote the PR description manually.
