### PR TITLE
MAINT: Improve community quality edge counts

### DIFF
--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -101,15 +101,16 @@ def inter_community_edges(G, partition):
     in different blocks of the partition.
 
     """
+    if not G.is_multigraph():
+        return G.size() - intra_community_edges(G, partition)
+
     node_community = _node_community_map(partition)
     inter_edges = (
         (u, v) for u, v in G.edges() if node_community[u] != node_community[v]
     )
-    if G.is_multigraph():
-        if G.is_directed():
-            return len(set(inter_edges))
-        return len({frozenset(edge) for edge in inter_edges})
-    return sum(1 for _ in inter_edges)
+    if G.is_directed():
+        return len(set(inter_edges))
+    return len({frozenset(edge) for edge in inter_edges})
 
 
 @nx._dispatchable

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -101,16 +101,11 @@ def inter_community_edges(G, partition):
     in different blocks of the partition.
 
     """
-    if not G.is_multigraph():
-        return G.size() - intra_community_edges(G, partition)
-
     node_community = _node_community_map(partition)
-    inter_edges = (
-        (u, v) for u, v in G.edges() if node_community[u] != node_community[v]
+    count = sum(
+        1 for u in G._adj for v in G._adj[u] if node_community[u] != node_community[v]
     )
-    if G.is_directed():
-        return len(set(inter_edges))
-    return len({frozenset(edge) for edge in inter_edges})
+    return count if G.is_directed() else count // 2
 
 
 @nx._dispatchable

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -57,6 +57,14 @@ def _require_partition(G, partition):
 require_partition = argmap(_require_partition, (0, 1))
 
 
+def _node_community_map(partition):
+    return {
+        node: community_id
+        for community_id, community in enumerate(partition)
+        for node in community
+    }
+
+
 @nx._dispatchable
 def intra_community_edges(G, partition):
     """Returns the number of intra-community edges for a partition of `G`.
@@ -72,7 +80,8 @@ def intra_community_edges(G, partition):
     in the same block of the partition.
 
     """
-    return sum(G.subgraph(block).size() for block in partition)
+    node_community = _node_community_map(partition)
+    return sum(1 for u, v in G.edges() if node_community[u] == node_community[v])
 
 
 @nx._dispatchable
@@ -91,20 +100,16 @@ def inter_community_edges(G, partition):
     The *inter-community edges* are those edges joining a pair of nodes
     in different blocks of the partition.
 
-    Implementation note: this function creates an intermediate graph
-    that may require the same amount of memory as that of `G`.
-
     """
-    # Alternate implementation that does not require constructing a new
-    # graph object (but does require constructing an affiliation
-    # dictionary):
-    #
-    #     aff = dict(chain.from_iterable(((v, block) for v in block)
-    #                                    for block in partition))
-    #     return sum(1 for u, v in G.edges() if aff[u] != aff[v])
-    #
-    MG = nx.MultiDiGraph if G.is_directed() else nx.MultiGraph
-    return nx.quotient_graph(G, partition, create_using=MG).size()
+    node_community = _node_community_map(partition)
+    inter_edges = (
+        (u, v) for u, v in G.edges() if node_community[u] != node_community[v]
+    )
+    if G.is_multigraph():
+        if G.is_directed():
+            return len(set(inter_edges))
+        return len({frozenset(edge) for edge in inter_edges})
+    return sum(1 for _ in inter_edges)
 
 
 @nx._dispatchable
@@ -124,19 +129,7 @@ def inter_community_non_edges(G, partition):
     those non-edges on a pair of nodes in different blocks of the
     partition.
 
-    Implementation note: this function creates two intermediate graphs,
-    which may require up to twice the amount of memory as required to
-    store `G`.
-
     """
-    # Alternate implementation that does not require constructing two
-    # new graph objects (but does require constructing an affiliation
-    # dictionary):
-    #
-    #     aff = dict(chain.from_iterable(((v, block) for v in block)
-    #                                    for block in partition))
-    #     return sum(1 for u, v in nx.non_edges(G) if aff[u] != aff[v])
-    #
     return inter_community_edges(nx.complement(G), partition)
 
 

--- a/networkx/algorithms/community/tests/test_quality.py
+++ b/networkx/algorithms/community/tests/test_quality.py
@@ -318,3 +318,11 @@ def test_inter_community_edges_with_digraphs():
     G = nx.cycle_graph(4, create_using=nx.DiGraph())
     partition = [{0, 1}, {2, 3}]
     assert inter_community_edges(G, partition) == 2
+
+
+def test_inter_community_edges_with_multigraphs():
+    G = nx.MultiGraph()
+    G.add_nodes_from(range(4))
+    G.add_edges_from([(0, 1), (0, 2), (0, 2), (1, 2)])
+    partition = [{0, 1}, {2, 3}]
+    assert inter_community_edges(G, partition) == 2


### PR DESCRIPTION
This updates the older community-quality helpers to count directly from the partition labels instead of building subgraphs or quotient graphs.

This was already mentioned in #3350, which asked why the faster affiliation-dictionary approach was left as a comment rather than used. The same idea also lets the stale implementation notes be removed.

<details>
<summary>Benchmarks and validation</summary>

The benchmark uses random graphs with 2,000 nodes split into 20 interleaved communities. Simple graphs have 10,000 edges; multigraphs duplicate half of those edges and have 15,000 edges. Timings are medians of three runs for the old inter-community implementation and seven runs for the other cases. Peak temporary Python allocations are measured with `tracemalloc` after graph construction, so the input graph itself is excluded.

Every benchmark case asserts that the old and new implementations return the same result.

| Graph | Helper | Old time | New time | Old peak allocation | New peak allocation |
|---|---|---:|---:|---:|---:|
| `Graph` | intra | 10.202 ms | 2.834 ms | 0.181 MiB | 0.183 MiB |
| `Graph` | inter | 1,694.334 ms | 2.648 ms | 1.397 MiB | 0.108 MiB |
| `DiGraph` | intra | 10.882 ms | 1.629 ms | 0.190 MiB | 0.108 MiB |
| `DiGraph` | inter | 3,029.565 ms | 2.080 ms | 1.416 MiB | 0.108 MiB |
| `MultiGraph` | intra | 19.462 ms | 9.639 ms | 0.183 MiB | 0.180 MiB |
| `MultiGraph` | inter | 1,791.458 ms | 2.733 ms | 2.849 MiB | 0.108 MiB |
| `MultiDiGraph` | intra | 14.837 ms | 4.729 ms | 0.192 MiB | 0.108 MiB |
| `MultiDiGraph` | inter | 3,302.104 ms | 1.544 ms | 2.868 MiB | 0.108 MiB |

The focused test module also passes:

```text
$ python -m pytest networkx/algorithms/community/tests/test_quality.py -q
...........                                                              [100%]
11 passed in 0.41s
```

Benchmark code:

```python
import gc
import statistics
import time
import tracemalloc

import networkx as nx
from networkx.algorithms.community.quality import (
    inter_community_edges,
    intra_community_edges,
)


def old_intra_community_edges(G, partition):
    return sum(G.subgraph(block).size() for block in partition)


def old_inter_community_edges(G, partition):
    graph_type = nx.MultiDiGraph if G.is_directed() else nx.MultiGraph
    return nx.quotient_graph(G, partition, create_using=graph_type).size()


def measure(func, G, partition, repeat):
    times = []
    result = None
    for _ in range(repeat):
        start = time.perf_counter()
        result = func(G, partition)
        times.append(time.perf_counter() - start)

    # Measure temporary allocations made by the algorithm, excluding the graph.
    gc.collect()
    tracemalloc.start()
    memory_result = func(G, partition)
    _, peak = tracemalloc.get_traced_memory()
    tracemalloc.stop()
    assert result == memory_result
    return result, statistics.median(times), peak


def make_graph(graph_type):
    node_count = 2_000
    directed = graph_type in {nx.DiGraph, nx.MultiDiGraph}
    base = nx.gnm_random_graph(node_count, 10_000, seed=42, directed=directed)
    G = graph_type(base)
    if G.is_multigraph():
        G.add_edges_from(list(base.edges)[::2])
    partition = [set(range(start, node_count, 20)) for start in range(20)]
    return G, partition


implementations = [
    ("intra", old_intra_community_edges, intra_community_edges),
    ("inter", old_inter_community_edges, inter_community_edges),
]

for graph_type in [nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph]:
    G, partition = make_graph(graph_type)
    print(
        f"\n{graph_type.__name__}: {G.number_of_nodes()} nodes, "
        f"{G.number_of_edges()} edges"
    )
    for name, old_func, new_func in implementations:
        repeat = 3 if name == "inter" else 7
        old_result, old_time, old_peak = measure(old_func, G, partition, repeat)
        new_result, new_time, new_peak = measure(new_func, G, partition, 7)
        assert old_result == new_result
        print(
            f"{name:5} old {old_time * 1e3:9.3f} ms {old_peak / 2**20:7.3f} MiB"
            f" | new {new_time * 1e3:9.3f} ms {new_peak / 2**20:7.3f} MiB"
        )
```

</details>

---

_This PR was written with AI assistance._
AI was used to generate the benchmark and implementation, as well as for digging into archives to find the speed-up opportunity.
