### PR TITLE
MAINT: Avoid subgraph views in `is_forest`

### DIFF
--- a/networkx/algorithms/tree/recognition.py
+++ b/networkx/algorithms/tree/recognition.py
@@ -208,11 +208,11 @@ def is_forest(G):
         raise nx.NetworkXPointlessConcept("G has no nodes.")
 
     if G.is_directed():
-        components = (G.subgraph(c) for c in nx.weakly_connected_components(G))
+        components = nx.weakly_connected_components(G)
     else:
-        components = (G.subgraph(c) for c in nx.connected_components(G))
+        components = nx.connected_components(G)
 
-    return all(len(c) - 1 == c.number_of_edges() for c in components)
+    return all(len(c) - 1 == sum(1 for _ in G.edges(c)) for c in components)
 
 
 @nx._dispatchable


### PR DESCRIPTION
Avoid subgraphs in `is_forest` while maintaining the early stopping criterion of lazily generated components.

Alternatively, a global condition is faster for most graphs:
```python
if G.is_directed():
    n_components = nx.number_weakly_connected_components(G)
else:
    n_components = nx.number_connected_components(G)

return G.number_of_edges() == len(G) - n_components
```
This would work because by definition, a connected component $c$ of size $n$ has at least $m=n-1$ edges, with equality indicating the component is a tree.

Timing all three options gives the following results ("hybrid" is the version from this PR):
```text
case                           nodes    edges    old_ms global_ms hybrid_ms
first component cyclic         10000     9001     0.094     5.363     0.039
last component cyclic          10000     9001    76.799     4.957    13.799
connected cycle                10000    10000    35.010     6.725    15.287
dense connected                 4000    79727    65.101     2.701    24.104
forest many components         10000     9000    72.798     8.404    16.691
directed forest                10000     9999    43.382     4.856    15.379
```

---
_This PR was created with AI assistance._
Codex was used to identify the unnecessary use of subgraph views, as well as to create and run some simple benchmarks.