### PR TITLE
MAINT: Avoid subgraph views in `strategy_connected_sequential`

### DIFF
--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -197,7 +197,7 @@ def strategy_connected_sequential(G, colors, traversal="bfs"):
         # Yield the source node, then all the nodes in the specified
         # traversal order.
         yield source
-        for _, end in traverse(G.subgraph(component), source):
+        for _, end in traverse(G, source):
             yield end
 
 


### PR DESCRIPTION
Avoid subgraph views in `strategy_connected_sequential`. Since we are starting from a node in a connected component, there is no need to add a subgraph view.

```text
Connected sequential coloring traversal timings
median over repeats; old uses G.subgraph(component), new traverses G directly

graph                  traversal   nodes   edges          old        new  speedup
path 1k                bfs          1000     999     3.202 ms   0.752 ms     4.26
path 1k                dfs          1000     999     3.070 ms   0.737 ms     4.16
path 10k               bfs         10000    9999    33.647 ms   8.237 ms     4.08
path 10k               dfs         10000    9999    32.260 ms   8.273 ms     3.90
cycle 10k              bfs         10000   10000    32.215 ms   7.795 ms     4.13
cycle 10k              dfs         10000   10000    32.520 ms   8.208 ms     3.96
balanced tree 16k      bfs         16383   16382    53.314 ms  10.756 ms     4.96
balanced tree 16k      dfs         16383   16382    51.623 ms  12.548 ms     4.11
gnp sparse 5k          bfs          5000    4963    47.007 ms  13.895 ms     3.38
gnp sparse 5k          dfs          5000    4963    45.845 ms  11.299 ms     4.06
gnp sparse 10k         bfs         10000   10023    97.045 ms  30.025 ms     3.23
gnp sparse 10k         dfs         10000   10023    87.286 ms  24.236 ms     3.60
many paths 1k x 10     bfs         10000    9000    74.244 ms  21.926 ms     3.39
many paths 1k x 10     dfs         10000    9000    66.758 ms  16.870 ms     3.96
many cycles 1k x 10    bfs         10000   10000    82.964 ms  23.250 ms     3.57
many cycles 1k x 10    dfs         10000   10000    73.283 ms  19.011 ms     3.85
many stars 1k x 10     bfs         10000    9000    86.962 ms  18.590 ms     4.68
many stars 1k x 10     dfs         10000    9000    66.143 ms  16.686 ms     3.96
empty 10k              bfs         10000       0   353.345 ms 117.127 ms     3.02
empty 10k              dfs         10000       0   308.984 ms  68.950 ms     4.48
```

---
_This PR was created with AI assistance._
Codex was used to find unnecessary uses of subgraph views, as well as to write and run some simple benchmarks.