### PR TITLE
MAINT: Replace simple lambdas with callables

### DIFF
--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -35,6 +35,7 @@ http://en.wikipedia.org/wiki/Travelling_salesman_problem
 """
 
 import math
+from operator import itemgetter
 
 import networkx as nx
 from networkx.algorithms.tree.mst import random_spanning_tree
@@ -627,7 +628,7 @@ def held_karp_ascent(G, weight="weight"):
             # Delete the edge (N, v) so that we cannot pick it.
             edge_data = G[N][n]
             G.remove_edge(N, n)
-            min_weight = min(G.in_edges(n, data=weight), key=lambda x: x[2])[2]
+            min_weight = min(G.in_edges(n, data=weight), key=itemgetter(2))[2]
             min_edges = [
                 (u, v, d) for u, v, d in G.in_edges(n, data=weight) if d == min_weight
             ]

--- a/networkx/algorithms/approximation/treewidth.py
+++ b/networkx/algorithms/approximation/treewidth.py
@@ -60,7 +60,7 @@ def treewidth_min_degree(G):
           2-tuple with treewidth and the corresponding decomposed tree.
     """
     deg_heuristic = MinDegreeHeuristic(G)
-    return treewidth_decomp(G, lambda graph: deg_heuristic.best_node(graph))
+    return treewidth_decomp(G, deg_heuristic.best_node)
 
 
 @not_implemented_for("directed")

--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -490,7 +490,7 @@ def _greedy_coloring_with_interchange(G, nodes):
         neighbors = graph[node].iter_neighbors()
         col_used = {graph[adj_node.node_id].color for adj_node in neighbors}
         col_used.discard(-1)
-        k1 = next(itertools.dropwhile(lambda x: x in col_used, itertools.count()))
+        k1 = next(itertools.dropwhile(col_used.__contains__, itertools.count()))
 
         # k1 is now the lowest available color
         if k1 > k:

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -9,6 +9,7 @@ import heapq
 from collections import deque
 from itertools import combinations, product
 from math import gcd
+from operator import itemgetter
 
 import networkx as nx
 from networkx.utils import arbitrary_element, not_implemented_for, pairwise
@@ -1104,7 +1105,7 @@ def dag_longest_path(G, weight="weight", default_weight=1, topo_order=None):
 
         # Use the best predecessor if there is one and its distance is
         # non-negative, otherwise terminate.
-        maxu = max(us, key=lambda x: x[0]) if us else (0, v)
+        maxu = max(us, key=itemgetter(0)) if us else (0, v)
         dist[v] = maxu if maxu[0] >= 0 else (0, v)
 
     u = None

--- a/networkx/algorithms/dominating.py
+++ b/networkx/algorithms/dominating.py
@@ -2,6 +2,7 @@
 
 from heapq import heappop, heappush
 from itertools import chain, count
+from operator import itemgetter
 
 import networkx as nx
 
@@ -202,7 +203,7 @@ def connected_dominating_set(G):
     unseen_degree = dict(G.degree)
 
     # Find node with highest degree and update its neighbors
-    (max_deg_node, max_deg) = max(unseen_degree.items(), key=lambda x: x[1])
+    (max_deg_node, max_deg) = max(unseen_degree.items(), key=itemgetter(1))
     for nbr in G_succ[max_deg_node]:
         unseen_degree[nbr] -= 1
 

--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -7,6 +7,7 @@ For now, only Weisfeiler-Lehman hashing is implemented.
 import warnings
 from collections import Counter, defaultdict
 from hashlib import blake2b
+from operator import itemgetter
 
 import networkx as nx
 
@@ -220,7 +221,7 @@ def weisfeiler_lehman_graph_hash(
         node_labels = weisfeiler_lehman_step(G, node_labels, edge_attr=edge_attr)
         counter = Counter(node_labels.values())
         # sort the counter, extend total counts
-        subgraph_hash_counts.extend(sorted(counter.items(), key=lambda x: x[0]))
+        subgraph_hash_counts.extend(sorted(counter.items(), key=itemgetter(0)))
 
     # hash the final counter
     return _hash_label(str(tuple(subgraph_hash_counts)), digest_size)

--- a/networkx/algorithms/node_classification.py
+++ b/networkx/algorithms/node_classification.py
@@ -23,6 +23,8 @@ Semi-supervised learning using gaussian fields and harmonic functions.
 In ICML (Vol. 3, pp. 912-919).
 """
 
+from operator import itemgetter
+
 import networkx as nx
 
 __all__ = ["harmonic_function", "local_and_global_consistency"]
@@ -214,6 +216,6 @@ def _get_label_info(G, label_name):
             labels.append([i, label_to_id[label]])
     labels = np.array(labels)
     label_dict = np.array(
-        [label for label, _ in sorted(label_to_id.items(), key=lambda x: x[1])]
+        [label for label, _ in sorted(label_to_id.items(), key=itemgetter(1))]
     )
     return (labels, label_dict)

--- a/networkx/algorithms/similarity.py
+++ b/networkx/algorithms/similarity.py
@@ -17,6 +17,7 @@ import math
 import time
 from dataclasses import dataclass
 from itertools import product
+from operator import itemgetter
 
 import networkx as nx
 from networkx.utils import np_random_state
@@ -1957,7 +1958,7 @@ def panther_vector_similarity(
 
     # Ensure we return exactly k results (sorted by similarity)
     if len(top_k_with_val) > k:
-        sorted_items = sorted(top_k_with_val.items(), key=lambda x: x[1], reverse=True)
+        sorted_items = sorted(top_k_with_val.items(), key=itemgetter(1), reverse=True)
         top_k_with_val = dict(sorted_items[:k])
 
     return top_k_with_val

--- a/networkx/algorithms/simple_paths.py
+++ b/networkx/algorithms/simple_paths.py
@@ -385,11 +385,7 @@ def _all_simple_edge_paths(G, source, targets, cutoff):
     # We bootstrap the search by adding a dummy iterator to the stack that only yields
     # a dummy edge to source (so that the trivial path has a chance of being included).
 
-    get_edges = (
-        (lambda node: G.edges(node, keys=True))
-        if G.is_multigraph()
-        else (lambda node: G.edges(node))
-    )
+    get_edges = (lambda n: G.edges(n, keys=True)) if G.is_multigraph() else G.edges
 
     # The current_path is a dictionary that maps nodes in the path to the edge that was
     # used to enter that node (instead of a list of edges) because we want both a fast


### PR DESCRIPTION
Replaces some lambda functions with faster or simpler equivalents. On average, replacing a lambda function with an equivalent C-implemented stdlib function is nearly twice as fast.

---

_This PR was made with AI assistance._
Codex was used to find these unnecessary lambda functions and benchmark them.