### PR TITLE
ENH: Add Shen's overlapping modularity quality function

### DIFF
--- a/doc/reference/algorithms/community.rst
+++ b/doc/reference/algorithms/community.rst
@@ -101,6 +101,7 @@ Measuring partitions
    :toctree: generated/
 
    modularity
+   overlapping_modularity
    constant_potts_model
    partition_quality
 
@@ -119,3 +120,4 @@ Validating partitions
    :toctree: generated/
 
    is_partition
+   is_cover

--- a/networkx/algorithms/community/community_utils.py
+++ b/networkx/algorithms/community/community_utils.py
@@ -2,7 +2,7 @@
 
 import networkx as nx
 
-__all__ = ["is_partition"]
+__all__ = ["is_cover", "is_partition"]
 
 
 @nx._dispatchable
@@ -28,3 +28,37 @@ def is_partition(G, communities):
     nodes = {n for c in communities for n in c if n in G}
 
     return len(G) == len(nodes) == sum(len(c) for c in communities)
+
+
+@nx._dispatchable
+def is_cover(G, communities):
+    """Returns *True* if `communities` is a cover of the nodes of `G`.
+
+    A *cover* of a graph is a collection of sets of nodes such that every
+    node in the graph belongs to at least one set. Unlike a partition,
+    sets in a cover may overlap.
+
+    Parameters
+    ----------
+    G : NetworkX graph.
+
+    communities : list or iterable of sets of nodes
+        If not a list, the iterable is converted internally to a list.
+        If it is an iterator it is exhausted. Nodes appearing in
+        `communities` but not in `G` are ignored, mirroring the
+        behavior of :func:`is_partition`.
+
+    See Also
+    --------
+    is_partition
+
+    References
+    ----------
+    .. [1] Lancichinetti, A., Fortunato, S., & Kertesz, J. (2009).
+       "Detecting the overlapping and hierarchical community structure
+       in complex networks." New J. Phys. 11, 033015.
+    """
+    if not isinstance(communities, list):
+        communities = list(communities)
+    nodes = {n for c in communities for n in c if n in G}
+    return len(nodes) == len(G)

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -3,6 +3,7 @@ communities).
 
 """
 
+from collections import defaultdict
 from itertools import combinations
 
 import networkx as nx
@@ -261,7 +262,7 @@ def modularity(G, communities, weight="weight", resolution=1):
 
 @not_implemented_for("directed")
 @nx._dispatchable(edge_attrs="weight")
-def overlapping_modularity(G, communities, weight="weight", resolution=1):
+def overlapping_modularity(G, communities, *, weight="weight", resolution=1):
     r"""Returns Shen et al.'s extended modularity for an overlapping cover.
 
     Standard modularity assumes each node belongs to exactly one
@@ -306,17 +307,20 @@ def overlapping_modularity(G, communities, weight="weight", resolution=1):
 
     communities : iterable of sets of nodes
         A cover of `G`'s nodes: every node must appear in at least one
-        set, but sets may overlap. Accepts the output of
-        :func:`~networkx.algorithms.community.kclique.k_clique_communities`
-        directly.
+        set, but sets may overlap. Accepts the output of any NetworkX
+        overlapping community-detection algorithm such as
+        :func:`~networkx.algorithms.community.kclique.k_clique_communities`.
 
     weight : string or None, optional (default="weight")
         Edge attribute holding the numerical edge weight. If None, or if
         an edge does not have the attribute, that edge has weight 1.
 
     resolution : float, optional (default=1)
-        Resolution parameter $\gamma$. Values smaller than 1 favor larger
-        communities; values greater than 1 favor smaller communities.
+        Resolution parameter $\gamma$. As in standard modularity, values
+        smaller than 1 favor larger communities and values greater than
+        1 favor smaller communities. The degree of overlap in the cover
+        is independent of $\gamma$, since $\gamma$ rescales only the
+        null-model term.
 
     Returns
     -------
@@ -374,11 +378,11 @@ def overlapping_modularity(G, communities, weight="weight", resolution=1):
         raise nx.NetworkXError("`communities` is not a valid cover of the nodes of G")
 
     # Membership count O_v for each node
-    membership = {}
+    membership = defaultdict(int)
     for community in communities:
         for node in community:
             if node in G:
-                membership[node] = membership.get(node, 0) + 1
+                membership[node] += 1
 
     degree = dict(G.degree(weight=weight))
     deg_sum = sum(degree.values())  # equals 2m for undirected

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -6,10 +6,15 @@ communities).
 from itertools import combinations
 
 import networkx as nx
-from networkx.algorithms.community.community_utils import is_partition
-from networkx.utils.decorators import argmap
+from networkx.algorithms.community.community_utils import is_cover, is_partition
+from networkx.utils.decorators import argmap, not_implemented_for
 
-__all__ = ["constant_potts_model", "modularity", "partition_quality"]
+__all__ = [
+    "constant_potts_model",
+    "modularity",
+    "overlapping_modularity",
+    "partition_quality",
+]
 
 
 class NotAPartition(nx.NetworkXError):
@@ -252,6 +257,154 @@ def modularity(G, communities, weight="weight", resolution=1):
         return L_c / m - resolution * out_degree_sum * in_degree_sum * norm
 
     return sum(map(community_contribution, communities))
+
+
+@not_implemented_for("directed")
+@nx._dispatchable(edge_attrs="weight")
+def overlapping_modularity(G, communities, weight="weight", resolution=1):
+    r"""Returns Shen et al.'s extended modularity for an overlapping cover.
+
+    Standard modularity assumes each node belongs to exactly one
+    community. Shen et al. [1]_ extend modularity to overlapping
+    communities by discounting each node's contribution by the number of
+    communities it belongs to:
+
+    .. math::
+        EQ = \frac{1}{2m} \sum_{i} \sum_{v \in C_i, w \in C_i}
+             \frac{1}{O_v O_w}\!\left[ A_{vw} - \gamma\,\frac{k_v k_w}{2m}\right]
+
+    where the outer sum runs over communities $C_i$ in the cover, $A_{vw}$
+    is the (weighted) adjacency, $k_v$ is the (weighted) degree of $v$,
+    $O_v$ is the number of communities to which $v$ belongs, $m$ is the
+    total (weighted) edge count, and $\gamma$ is the resolution parameter.
+
+    The factor $1 / (O_v O_w)$ discounts contributions from nodes that
+    belong to many communities: a node in 3 communities contributes 1/3
+    of its modularity share to each.
+
+    The resolution parameter $\gamma$ is not part of the original Shen
+    definition; it is added for consistency with
+    :func:`~networkx.algorithms.community.quality.modularity`. Setting
+    $\gamma = 1$ recovers Shen's EQ exactly.
+
+    Implementation uses the equivalent community-sum form
+
+    .. math::
+        EQ = \sum_{i}\!\left[\frac{\tilde{L}_{C_i}}{m}
+             - \gamma\!\left(\frac{\tilde{k}_{C_i}}{2m}\right)^{\!2}\right]
+
+    where $\tilde{L}_{C_i} = \sum_{(v,w) \in L_{C_i}} 1/(O_v O_w)$ is the
+    overlap-discounted intra-community edge count and
+    $\tilde{k}_{C_i} = \sum_{v \in C_i} k_v / O_v$ is the
+    overlap-discounted degree sum. When the cover is actually a partition
+    ($O_v = 1$ for all $v$), $EQ$ reduces to the standard modularity $Q$.
+
+    Parameters
+    ----------
+    G : NetworkX Graph
+        An undirected graph.
+
+    communities : iterable of sets of nodes
+        A cover of `G`'s nodes: every node must appear in at least one
+        set, but sets may overlap. Accepts the output of
+        :func:`~networkx.algorithms.community.kclique.k_clique_communities`
+        directly.
+
+    weight : string or None, optional (default="weight")
+        Edge attribute holding the numerical edge weight. If None, or if
+        an edge does not have the attribute, that edge has weight 1.
+
+    resolution : float, optional (default=1)
+        Resolution parameter $\gamma$. Values smaller than 1 favor larger
+        communities; values greater than 1 favor smaller communities.
+
+    Returns
+    -------
+    EQ : float
+        The extended modularity of the cover.
+
+    Raises
+    ------
+    NetworkXError
+        If `communities` is not a valid cover of the nodes of `G` (some
+        node in `G` does not belong to any community).
+
+    NetworkXNotImplemented
+        If `G` is directed. Shen's formulation is for undirected graphs.
+
+    Examples
+    --------
+    On a partition, EQ equals standard modularity (up to floating-point
+    summation order):
+
+    >>> G = nx.barbell_graph(3, 0)
+    >>> partition = [{0, 1, 2}, {3, 4, 5}]
+    >>> Q = nx.community.modularity(G, partition)
+    >>> EQ = nx.community.overlapping_modularity(G, partition)
+    >>> abs(Q - EQ) < 1e-12
+    True
+
+    Evaluate an overlapping cover produced by ``k_clique_communities``.
+    Two K_5 cliques sharing nodes 3 and 4 yield a 2-community cover:
+
+    >>> G = nx.complete_graph(5)
+    >>> G.add_edges_from(nx.complete_graph(range(3, 8)).edges())
+    >>> cover = list(nx.community.k_clique_communities(G, 4))
+    >>> round(nx.community.overlapping_modularity(G, cover), 3)
+    0.158
+
+    See Also
+    --------
+    modularity
+    is_cover
+
+    References
+    ----------
+    .. [1] Shen, H., Cheng, X., Cai, K., & Hu, M. B. (2009). "Detect
+       overlapping and hierarchical community structure in networks."
+       Physica A, 388(8), 1706-1712.
+       https://doi.org/10.1016/j.physa.2008.12.021
+    .. [2] Lancichinetti, A., Fortunato, S., & Kertesz, J. (2009).
+       "Detecting the overlapping and hierarchical community structure
+       in complex networks." New J. Phys. 11, 033015. (Cover definition.)
+    """
+    if not isinstance(communities, list):
+        communities = list(communities)
+    if not is_cover(G, communities):
+        raise nx.NetworkXError("`communities` is not a valid cover of the nodes of G")
+
+    # Membership count O_v for each node
+    membership = {}
+    for community in communities:
+        for node in community:
+            if node in G:
+                membership[node] = membership.get(node, 0) + 1
+
+    degree = dict(G.degree(weight=weight))
+    deg_sum = sum(degree.values())  # equals 2m for undirected
+
+    if deg_sum == 0:
+        return 0.0
+
+    def community_contribution(community):
+        comm = set(community)
+
+        # Tilde-L: overlap-discounted intra-community edge weight.
+        # Each edge (u, v) with both endpoints in comm contributes
+        # w_uv / (O_u * O_v) exactly once.
+        L_c_tilde = sum(
+            wt / (membership[u] * membership[v])
+            for u, v, wt in G.edges(comm, data=weight, default=1)
+            if v in comm
+        )
+
+        # Tilde-k: overlap-discounted degree sum.
+        k_c_tilde = sum(degree[u] / membership[u] for u in comm)
+
+        # Per-community contribution: 2*L_tilde/(2m) - gamma*(k_tilde/(2m))^2.
+        return 2 * L_c_tilde / deg_sum - resolution * (k_c_tilde / deg_sum) ** 2
+
+    return sum(community_contribution(c) for c in communities)
 
 
 def _cpm_delta_partial_eval_remove(

--- a/networkx/algorithms/community/tests/test_quality.py
+++ b/networkx/algorithms/community/tests/test_quality.py
@@ -10,6 +10,7 @@ from networkx import barbell_graph
 from networkx.algorithms.community import (
     constant_potts_model,
     modularity,
+    overlapping_modularity,
     partition_quality,
 )
 from networkx.algorithms.community.quality import (
@@ -304,6 +305,142 @@ def test_modularity_resolution():
     result = modularity(G, C, resolution=gamma)
     # This C is maximal for gamma=0.3:  modularity = 0.805990
     assert result == pytest.approx((23 / 24) - gamma * (1170 / (48**2)))
+
+
+class TestOverlappingModularity:
+    """Tests for :func:`overlapping_modularity` (Shen et al.'s EQ)."""
+
+    def test_equivalence_with_modularity_on_partition(self):
+        # When the cover is actually a partition, EQ must equal Q.
+        G = nx.barbell_graph(3, 0)
+        partition = [{0, 1, 2}, {3, 4, 5}]
+        assert overlapping_modularity(G, partition) == pytest.approx(
+            modularity(G, partition)
+        )
+
+    def test_equivalence_on_karate_club(self):
+        G = nx.karate_club_graph()
+        partition = list(nx.community.label_propagation_communities(G))
+        assert overlapping_modularity(G, partition) == pytest.approx(
+            modularity(G, partition)
+        )
+
+    def test_triangle_two_overlapping_communities(self):
+        # Triangle (0,1,2), cover [{0,1}, {1,2}]. Hand-calculated EQ = -1/6.
+        G = nx.cycle_graph(3)
+        cover = [{0, 1}, {1, 2}]
+        assert overlapping_modularity(G, cover) == pytest.approx(-1 / 6)
+
+    def test_triangle_all_pairs_cover(self):
+        # Triangle, cover [{0,1}, {1,2}, {0,2}]. Hand-calculated EQ = -1/12.
+        G = nx.cycle_graph(3)
+        cover = [{0, 1}, {1, 2}, {0, 2}]
+        assert overlapping_modularity(G, cover) == pytest.approx(-1 / 12)
+
+    def test_single_community_is_zero(self):
+        # Shen page 4: EQ = 0 when all nodes are in a single community.
+        G = nx.karate_club_graph()
+        assert overlapping_modularity(G, [set(G)]) == pytest.approx(0.0)
+
+    def test_resolution_monotonicity(self):
+        # For a fixed cover, higher resolution -> lower EQ
+        # (the null-model term grows with gamma).
+        G = nx.barbell_graph(3, 0)
+        cover = [{0, 1, 2}, {3, 4, 5}]
+        eq_low = overlapping_modularity(G, cover, resolution=0.5)
+        eq_one = overlapping_modularity(G, cover, resolution=1)
+        eq_high = overlapping_modularity(G, cover, resolution=2)
+        assert eq_low > eq_one > eq_high
+
+    def test_kclique_communities_integration(self):
+        # Output of k_clique_communities should feed directly to
+        # overlapping_modularity without raising.
+        G = nx.complete_graph(5)
+        H = nx.relabel_nodes(nx.complete_graph(5), {i: i + 3 for i in range(5)})
+        G.add_edges_from(H.edges())
+        cover = list(nx.community.k_clique_communities(G, 4))
+        # All nodes should be covered (each appears in some maximal clique
+        # community), so this should not raise.
+        eq = overlapping_modularity(G, cover)
+        assert isinstance(eq, float)
+
+    def test_invalid_cover_raises(self):
+        G = nx.path_graph(4)
+        with pytest.raises(nx.NetworkXError):
+            overlapping_modularity(G, [{0, 1}])  # nodes 2, 3 uncovered
+
+    def test_directed_not_implemented(self):
+        G = nx.DiGraph([(0, 1), (1, 2)])
+        with pytest.raises(nx.NetworkXNotImplemented):
+            overlapping_modularity(G, [{0, 1, 2}])
+
+    def test_empty_graph(self):
+        assert overlapping_modularity(nx.Graph(), []) == 0.0
+
+    def test_weighted_reduces_to_unweighted_when_uniform(self):
+        # When all edge weights are 1, the weighted result matches the
+        # unweighted-default result.
+        G = nx.cycle_graph(4)
+        for u, v in G.edges():
+            G[u][v]["weight"] = 1.0
+        cover = [{0, 1, 2}, {2, 3, 0}]
+        assert overlapping_modularity(G, cover) == pytest.approx(
+            overlapping_modularity(G, cover, weight=None)
+        )
+
+    def test_weight_none_ignores_edge_weights(self):
+        # weight=None must treat the graph as unweighted regardless of
+        # actual edge weights.
+        G = nx.cycle_graph(4)
+        for u, v in G.edges():
+            G[u][v]["weight"] = 99.0
+        Gp = nx.cycle_graph(4)  # no weights
+        cover = [{0, 1, 2}, {2, 3, 0}]
+        assert overlapping_modularity(G, cover, weight=None) == pytest.approx(
+            overlapping_modularity(Gp, cover, weight=None)
+        )
+
+    def test_resolution_partition_matches_modularity(self):
+        # On a partition input, EQ(gamma) must equal Q(gamma) for any gamma.
+        G = nx.barbell_graph(3, 0)
+        partition = [{0, 1, 2}, {3, 4, 5}]
+        for gamma in (0.3, 1.0, 2.5):
+            assert overlapping_modularity(
+                G, partition, resolution=gamma
+            ) == pytest.approx(modularity(G, partition, resolution=gamma))
+
+    def test_weighted_triangle_hand_calc(self):
+        # Triangle with non-uniform edge weights:
+        #   (0,1)=2, (1,2)=3, (0,2)=1
+        # Weighted degrees: k_0=3, k_1=5, k_2=4; 2m=12.
+        # Cover [{0,1}, {1,2}]; O_0=1, O_1=2, O_2=1.
+        # Community {0,1}: L_tilde=2/(1*2)=1, k_tilde=3+5/2=5.5
+        #   contribution = 2*1/12 - (5.5/12)**2 = -25/576
+        # Community {1,2}: L_tilde=3/(2*1)=1.5, k_tilde=5/2+4=6.5
+        #   contribution = 2*1.5/12 - (6.5/12)**2 = -25/576
+        # EQ = -50/576 = -25/288.
+        G = nx.Graph()
+        G.add_weighted_edges_from([(0, 1, 2), (1, 2, 3), (0, 2, 1)])
+        cover = [{0, 1}, {1, 2}]
+        assert overlapping_modularity(G, cover) == pytest.approx(-25 / 288)
+
+    def test_multigraph(self):
+        # Round-tripping a simple graph through MultiGraph gives the same
+        # EQ; adding a parallel edge then changes the value, confirming
+        # parallel edges contribute to both the null-model and the
+        # overlap-discounted edge sums.
+        G = nx.barbell_graph(3, 0)
+        H = nx.MultiGraph(G)
+        cover = [{0, 1, 2, 3}, {2, 3, 4, 5}]  # bridge nodes 2, 3 overlap
+
+        assert overlapping_modularity(H, cover) == pytest.approx(
+            overlapping_modularity(G, cover)
+        )
+
+        H.add_edge(0, 1)  # parallel edge in H, no equivalent in G
+        assert overlapping_modularity(H, cover) != pytest.approx(
+            overlapping_modularity(G, cover)
+        )
 
 
 def test_inter_community_edges_with_digraphs():

--- a/networkx/algorithms/community/tests/test_utils.py
+++ b/networkx/algorithms/community/tests/test_utils.py
@@ -24,3 +24,47 @@ def test_not_disjoint():
 def test_not_node():
     G = nx.empty_graph(3)
     assert not nx.community.is_partition(G, [{0, 1}, {3}])
+
+
+def test_is_cover_partition():
+    G = nx.path_graph(4)
+    assert nx.community.is_cover(G, [{0, 1}, {2, 3}])
+
+
+def test_is_cover_overlapping():
+    G = nx.path_graph(4)
+    assert nx.community.is_cover(G, [{0, 1, 2}, {2, 3}])
+
+
+def test_is_cover_node_in_many_communities():
+    G = nx.path_graph(4)
+    assert nx.community.is_cover(G, [{0, 1, 2, 3}, {1, 2}, {2, 3}])
+
+
+def test_is_cover_iterable_inputs():
+    G = nx.path_graph(4)
+    # Tuple of frozensets (e.g. output of k_clique_communities)
+    assert nx.community.is_cover(G, (frozenset({0, 1}), frozenset({2, 3})))
+    # Iterator (gets exhausted internally)
+    assert nx.community.is_cover(G, iter([{0, 1, 2}, {2, 3}]))
+
+
+def test_is_cover_missing_node():
+    G = nx.path_graph(4)
+    assert not nx.community.is_cover(G, [{0, 1, 2}])
+
+
+def test_is_cover_empty_communities_nonempty_graph():
+    G = nx.path_graph(4)
+    assert not nx.community.is_cover(G, [])
+
+
+def test_is_cover_empty_graph_empty_communities():
+    assert nx.community.is_cover(nx.Graph(), [])
+
+
+def test_is_cover_extraneous_nodes_ignored():
+    # Nodes appearing in communities that are not in G are ignored,
+    # mirroring is_partition's behavior.
+    G = nx.path_graph(4)
+    assert nx.community.is_cover(G, [{0, 1, 2, 3}, {99}])


### PR DESCRIPTION
Add `nx.community.overlapping_modularity` implementing Shen et al.'s extended modularity EQ (2009) as a quality function for overlapping community covers. The implementation uses the community-sum form

    EQ = sum_i [ L_tilde_C / m - gamma * (k_tilde_C / 2m)^2 ]

where L_tilde_C is the overlap-discounted intra-community edge count (each edge weighted by 1/(O_v * O_w) with O_v the number of communities containing v) and k_tilde_C is the overlap-discounted degree sum. This mirrors the community-sum form used by `nx.community.modularity` with overlap-discounted quantities replacing the raw counterparts. When the cover is just a partition (O_v = 1 for all v), EQ reduces to Q exactly.

Also add `nx.community.is_cover`, the cover-equivalent of `is_partition`: a cover requires every node in G to belong to at least one community, but allows overlap. Used internally to validate input to overlapping_modularity, exposed publicly for users (e.g. to sanity-check the output of `k_clique_communities` before scoring).

The resolution parameter gamma is not in Shen's original definition; it is added for consistency with `modularity(resolution=...)`. With gamma=1 the formula is exactly Shen's EQ.

Tests cover equivalence with standard modularity on partition inputs, hand-calculated EQ values for a triangle under several covers, weighted hand-calculation, k_clique_communities integration, resolution parameter monotonicity, and the usual edge cases (directed not implemented, empty graph, weight=None, invalid cover).
