### PR TITLE
Optimize VF2 GMState frontier update by removing full core scan

### DIFF
--- a/networkx/algorithms/isomorphism/isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/isomorphvf2.py
@@ -1096,25 +1096,17 @@ class GMState:
 
             # Now we add every other node...
 
-            # Updates for T_1^{inout}
-            new_nodes = set()
-            for node in GM.core_1:
-                new_nodes.update(
-                    [neighbor for neighbor in GM.G1[node] if neighbor not in GM.core_1]
-                )
-            for node in new_nodes:
-                if node not in GM.inout_1:
-                    GM.inout_1[node] = self.depth
+            # Incrementally update T_1^{inout} using the newly added node G1_node.
+            # Only neighbors of G1_node can newly enter the frontier.
+            for neighbor in GM.G1[G1_node]:
+                if neighbor not in GM.core_1 and neighbor not in GM.inout_1:
+                    GM.inout_1[neighbor] = self.depth
 
-            # Updates for T_2^{inout}
-            new_nodes = set()
-            for node in GM.core_2:
-                new_nodes.update(
-                    [neighbor for neighbor in GM.G2[node] if neighbor not in GM.core_2]
-                )
-            for node in new_nodes:
-                if node not in GM.inout_2:
-                    GM.inout_2[node] = self.depth
+            # Incrementally updates T_2^{inout} using the newly added node G2_node.
+            # Only neighbors of G2_node can newly enter the frontier.
+            for neighbor in GM.G2[G2_node]:
+                if neighbor not in GM.core_2 and neighbor not in GM.inout_2:
+                    GM.inout_2[neighbor] = self.depth
 
     def restore(self):
         """Deletes the GMState object and restores the class variables."""
@@ -1189,61 +1181,29 @@ class DiGMState:
 
             # Now we add every other node...
 
-            # Updates for T_1^{in}
-            new_nodes = set()
-            for node in GM.core_1:
-                new_nodes.update(
-                    [
-                        predecessor
-                        for predecessor in GM.G1.predecessors(node)
-                        if predecessor not in GM.core_1
-                    ]
-                )
-            for node in new_nodes:
-                if node not in GM.in_1:
-                    GM.in_1[node] = self.depth
+            # Incrementally update T_1^{in} using the newly added node G1_node.
+            # Only predecessors of G1_node can newly enter the frontier.
+            for predecessor in GM.G1.predecessors(G1_node):
+                if predecessor not in GM.core_1 and predecessor not in GM.in_1:
+                    GM.in_1[predecessor] = self.depth
 
-            # Updates for T_2^{in}
-            new_nodes = set()
-            for node in GM.core_2:
-                new_nodes.update(
-                    [
-                        predecessor
-                        for predecessor in GM.G2.predecessors(node)
-                        if predecessor not in GM.core_2
-                    ]
-                )
-            for node in new_nodes:
-                if node not in GM.in_2:
-                    GM.in_2[node] = self.depth
+            # Incrementally update T_2^{in} using the newly added node G2_node.
+            # Only predecessors of G2_node can newly enter the frontier.
+            for predecessor in GM.G2.predecessors(G2_node):
+                if predecessor not in GM.core_2 and predecessor not in GM.in_2:
+                    GM.in_2[predecessor] = self.depth
 
-            # Updates for T_1^{out}
-            new_nodes = set()
-            for node in GM.core_1:
-                new_nodes.update(
-                    [
-                        successor
-                        for successor in GM.G1.successors(node)
-                        if successor not in GM.core_1
-                    ]
-                )
-            for node in new_nodes:
-                if node not in GM.out_1:
-                    GM.out_1[node] = self.depth
+            # Incrementally update T_1^{out} using the newly added node G1_node.
+            # Only successors of G1_node can newly enter the frontier.
+            for successor in GM.G1.successors(G1_node):
+                if successor not in GM.core_1 and successor not in GM.out_1:
+                    GM.out_1[successor] = self.depth
 
-            # Updates for T_2^{out}
-            new_nodes = set()
-            for node in GM.core_2:
-                new_nodes.update(
-                    [
-                        successor
-                        for successor in GM.G2.successors(node)
-                        if successor not in GM.core_2
-                    ]
-                )
-            for node in new_nodes:
-                if node not in GM.out_2:
-                    GM.out_2[node] = self.depth
+            # Incrementally update T_2^{out} using the newly added node G2_node.
+            # Only successors of G2_node can newly enter the frontier.
+            for successor in GM.G2.successors(G2_node):
+                if successor not in GM.core_2 and successor not in GM.out_2:
+                    GM.out_2[successor] = self.depth
 
     def restore(self):
         """Deletes the DiGMState object and restores the class variables."""


### PR DESCRIPTION
In the current implementation of  **VF2 graph isomorphism algorithm** , frontier sets `(inout_1/inout_2/in_1/in_2/out_1/out_2)`are updated by iterating over all nodes in `core_1` and `core_2` at each recursion step.This introduces unnecessary overhead as the size of core grows during the search.

However, only neighbors of the most recently matched node(`G1_node` and `G2_node`) can introduce new frontier nodes. Therefore, scanning the entire core set is redundant.

## Change

Replace full core-based frontier construction:

```python
for node in core_1:
    for neighbor in G1[node]:
        if neighbor not in core_1 and neighbor not in inout_1:
            inout_1[neighbor] = depth
```
with incremental neighbor-based update:

```python
for neighbor in G1[G1_node]:
    if neighbor not in core_1 and neighbor not in inout_1:
        inout_1[neighbor] = depth
```

The same change is applied symmetrically for:

* GM.core_2
* directed variant (predecessors / successors)

## Performance

A simple benchmark on synthetic graphs shows a consistent speedup above 50%:

### benchmark
```python
import time
import random
import networkx as nx
from networkx.algorithms import isomorphism as iso


# ----------------------------
# Graph generators
# ----------------------------

def make_graph(n, p=0.05, directed=False, seed=42):
    rng = random.Random(seed)

    if directed:
        G = nx.DiGraph()
    else:
        G = nx.Graph()

    G.add_nodes_from(range(n))

    for i in range(n):
        for j in range(i + 1, n):
            if rng.random() < p:
                if directed:
                    # add random direction
                    if rng.random() < 0.5:
                        G.add_edge(i, j)
                    else:
                        G.add_edge(j, i)
                else:
                    G.add_edge(i, j)

    return G


def make_hard_graph(n):
    # symmetric regular-like graph (worst case VF2 behavior)
    G = nx.random_regular_graph(3, n, seed=42)
    return G


# ----------------------------
# Benchmark runner
# ----------------------------

def run_vf2(G, H):
    if G.is_directed():
        gm = iso.DiGraphMatcher(G, H)
    else:
        gm = iso.GraphMatcher(G, H)
    return gm.is_isomorphic()


def time_run(G, H, repeat=3):
    start = time.perf_counter()
    for _ in range(repeat):
        run_vf2(G, H)
    return (time.perf_counter() - start) / repeat


# ----------------------------
# Main benchmark
# ----------------------------

def benchmark():
    sizes = [100, 200, 300, 400]
    densities = [0.01, 0.03, 0.05, 0.10, 0.50]

    print("\nVF2 Timing Benchmark (undirected)\n")
    print("size | density | avg_time (seconds)")
    print("-------------------------------------")

    for n in sizes:
        for p in densities:
            G = make_graph(n, p, directed=False)
            H = nx.relabel_nodes(G, {i: i for i in G.nodes})

            t = time_run(G, H)
            print(f"{n:4} | {p:7.2f} | {t:.6f}")

    print("\nVF2 Timing Benchmark (directed)\n")
    print("size | density | avg_time (seconds)")
    print("-------------------------------------")

    for n in sizes:
        for p in densities:
            G = make_graph(n, p, directed=True)
            H = nx.relabel_nodes(G, {i: i for i in G.nodes})

            t = time_run(G, H)
            print(f"{n:4} | {p:7.2f} | {t:.6f}")

    print("\nVF2 Hard Case Benchmark (undirected)\n")
    print("size | avg_time (seconds)")
    print("--------------------------")

    for n in [100,200]:
        G = make_hard_graph(n)
        H = nx.relabel_nodes(G, {i: i for i in G.nodes})

        t = time_run(G, H)
        print(f"{n:4} | {t:.6f}")


if __name__ == "__main__":
    benchmark()
```

### Result
Branch **main**
```
VF2 Timing Benchmark (undirected)

size | density | avg_time (seconds)
-------------------------------------
 100 |    0.01 | 0.013043
 100 |    0.03 | 0.018268
 100 |    0.05 | 0.022888
 100 |    0.10 | 0.031593
 100 |    0.50 | 0.064261
 200 |    0.01 | 0.067794
 200 |    0.03 | 0.102321
 200 |    0.05 | 0.113543
 200 |    0.10 | 0.169737
 200 |    0.50 | 0.602332
 300 |    0.01 | 0.365967
 300 |    0.03 | 0.371505
 300 |    0.05 | 0.449170
 300 |    0.10 | 0.603862
 300 |    0.50 | 1.854204
 400 |    0.01 | 0.520071
 400 |    0.03 | 0.727768
 400 |    0.05 | 0.805949
 400 |    0.10 | 0.906752
 400 |    0.50 | 3.438262

VF2 Timing Benchmark (directed)

size | density | avg_time (seconds)
-------------------------------------
 100 |    0.01 | 0.021348
 100 |    0.03 | 0.027065
 100 |    0.05 | 0.031793
 100 |    0.10 | 0.040897
 100 |    0.50 | 0.093718
 200 |    0.01 | 0.083128
 200 |    0.03 | 0.127871
 200 |    0.05 | 0.168167
 200 |    0.10 | 0.202045
 200 |    0.50 | 0.623477
 300 |    0.01 | 0.233290
 300 |    0.03 | 0.381877
 300 |    0.05 | 0.379902
 300 |    0.10 | 0.448194
 300 |    0.50 | 1.410317
 400 |    0.01 | 0.324678
 400 |    0.03 | 0.542874
 400 |    0.05 | 0.706315
 400 |    0.10 | 1.399364
 400 |    0.50 | 4.500142

VF2 Hard Case Benchmark (undirected)

size | avg_time (seconds)
--------------------------
 100 | 0.213842
 200 | 2.244042
```

New implementation
```
VF2 Timing Benchmark (undirected)

size | density | avg_time (seconds)
-------------------------------------
 100 |    0.01 | 0.003869
 100 |    0.03 | 0.006884
 100 |    0.05 | 0.008357
 100 |    0.10 | 0.011098
 100 |    0.50 | 0.019732
 200 |    0.01 | 0.014283
 200 |    0.03 | 0.039230
 200 |    0.05 | 0.047955
 200 |    0.10 | 0.050258
 200 |    0.50 | 0.075264
 300 |    0.01 | 0.070826
 300 |    0.03 | 0.113649
 300 |    0.05 | 0.119264
 300 |    0.10 | 0.171238
 300 |    0.50 | 0.223750
 400 |    0.01 | 0.188986
 400 |    0.03 | 0.241292
 400 |    0.05 | 0.248461
 400 |    0.10 | 0.292100
 400 |    0.50 | 0.415978

VF2 Timing Benchmark (directed)

size | density | avg_time (seconds)
-------------------------------------
 100 |    0.01 | 0.005885
 100 |    0.03 | 0.006984
 100 |    0.05 | 0.010324
 100 |    0.10 | 0.014783
 100 |    0.50 | 0.029626
 200 |    0.01 | 0.018922
 200 |    0.03 | 0.036037
 200 |    0.05 | 0.056546
 200 |    0.10 | 0.062110
 200 |    0.50 | 0.112506
 300 |    0.01 | 0.044456
 300 |    0.03 | 0.126051
 300 |    0.05 | 0.139400
 300 |    0.10 | 0.164768
 300 |    0.50 | 0.276526
 400 |    0.01 | 0.097947
 400 |    0.03 | 0.236631
 400 |    0.05 | 0.252701
 400 |    0.10 | 0.290739
 400 |    0.50 | 0.524869

VF2 Hard Case Benchmark (undirected)

size | avg_time (seconds)
--------------------------
 100 | 0.094428
 200 | 1.593947
```
