### PR TITLE
fix: replace bare except with except Exception in convert.py

### DIFF
--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -110,7 +110,7 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
     if isinstance(data, list | tuple | nx.reportviews.EdgeViewABC | Iterator):
         try:
             return from_edgelist(data, create_using=create_using)
-        except:
+        except Exception:
             pass
 
     # pygraphviz  agraph


### PR DESCRIPTION
Replaced bare `except:` with `except Exception:` in `networkx/convert.py`.

Bare `except:` catches all exceptions including `KeyboardInterrupt` and `SystemExit`, which can make programs difficult to interrupt and hide real errors. Using `except Exception:` is the recommended practice as it catches all user-facing exceptions while still allowing system-exiting ones to propagate.

This follows PEP 8 recommendation: https://peps.python.org/pep-0008/#programming-recommendations