### PR TITLE
DOC: Add conference information to visualization in football example

### DIFF
--- a/examples/graph/plot_football.py
+++ b/examples/graph/plot_football.py
@@ -33,22 +33,43 @@ with zipfile.ZipFile(Path.cwd() / "football.zip") as zf:  # zipfile object
 gml = gml.split("\n")[1:]
 G = nx.parse_gml(gml)  # parse gml data
 
-# Extract the conference to color the nodes
-conf = [c for _, c in G.nodes(data="value")]
-
 print(txt)
 # print degree for each team - number of games
 for n, d in G.degree():
     print(f"{n:20} {d:2}")
 
-options = {
-    "node_color": conf,
-    "node_size": 50,
-    "linewidths": 0,
-    "width": 0.1,
-    "cmap": plt.cm.tab20,  # Categorical colormap with 20 categories
-}
+# Extract conference data from the text
+conf_data = txt.split("\n\n")[1].split("\n")
+
+# Color nodes by primary color of conference champions (from Wikipedia)
+# fmt: off
+champ_clrs = [
+    "#782F40", "#F47321", "#00274C", "#841617", "#FDB913", "#AE9142", "#00B140",
+    "#1E4D2B", "#4b2e83", "#0021A5", "#343636", "#B1B3B3"
+]
+# fmt: on
+conf_mapping = {}
+for line, clr in zip(conf_data, champ_clrs):
+    conf_key, conf_name = line.split("=")
+    conf_mapping[int(conf_key)] = {"name": conf_name.strip(), "color": clr}
 
 pos = nx.spring_layout(G, seed=1969)  # Seed for reproducible layout
-nx.draw(G, pos, **options)
+fig, ax = plt.subplots(figsize=(10, 6))
+
+# Draw nodes for each conference separately to populate handles for a legend
+opts = {"node_size": 50, "linewidths": 0}
+for conf, data in conf_mapping.items():
+    nodes = [n for n, c in G.nodes(data="value") if c == conf]
+    label = data["name"]
+    color = data["color"]
+    nx.draw_networkx_nodes(
+        G, pos=pos, ax=ax, nodelist=nodes, label=label, node_color=color, **opts
+    )
+ax.legend(loc=8, ncols=6, bbox_to_anchor=(0.5, -0.15))
+
+# Draw edges
+nx.draw_networkx_edges(G, pos=pos, ax=ax, width=0.1)
+
+ax.set_axis_off()
+fig.tight_layout()
 plt.show()

--- a/examples/graph/plot_football.py
+++ b/examples/graph/plot_football.py
@@ -33,12 +33,21 @@ with zipfile.ZipFile(Path.cwd() / "football.zip") as zf:  # zipfile object
 gml = gml.split("\n")[1:]
 G = nx.parse_gml(gml)  # parse gml data
 
+# Extract the conference to color the nodes
+conf = [c for _, c in G.nodes(data="value")]
+
 print(txt)
 # print degree for each team - number of games
 for n, d in G.degree():
     print(f"{n:20} {d:2}")
 
-options = {"node_color": "black", "node_size": 50, "linewidths": 0, "width": 0.1}
+options = {
+    "node_color": conf,
+    "node_size": 50,
+    "linewidths": 0,
+    "width": 0.1,
+    "cmap": plt.cm.tab20,  # Categorical colormap with 20 categories
+}
 
 pos = nx.spring_layout(G, seed=1969)  # Seed for reproducible layout
 nx.draw(G, pos, **options)


### PR DESCRIPTION
A proposal to add information about the communities to the `plot_football` example.

In this case, the communities reflect the conferences of which the individual teams are members. It turns out that force-directed layouts (unsurprisingly) do a decent job at capturing this conference structure!

There are two commits here - the first (db32130) represents a simpler version of the example where the conference data (already part of the graph) is extracted, then these values are used directly with a categorical color map to highlight community structure. This works fine and is nice and short.

The second commit is a more full-fledged example that incorporates even more information - primarily it demonstrates how to use `draw_networkx_nodes` with the `label` kwarg to generate meaningful legends for the plot. As a college football enjoyer, I couldn't resist the temptation to inject even more football into the example by coloring the nodes by the primary colors of conference champions for the year the data was collected.

Either way - I think highlighting the community structure in the visualization is an improvement, so that's what I propose. I'd be happy to go with either the simpler or more detailed option!