### PR TITLE
ENH: leiden test and doc_string improvements

### DIFF
--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -19,47 +19,56 @@ __all__ = ["leiden_communities", "leiden_partitions"]
 @nx._dispatchable(edge_attrs="weight")
 def leiden_communities(
     G,
+    *,
     weight="weight",
     resolution=1.0,
     max_level=None,
     seed=None,
-    quality_function="cpm",
+    metric="cpm",
     theta=0.01,
 ):
-    r"""Return the best set of communities of `G` using Leiden Community Detection
-    algorithm [1]_.
+    r"""Return best node communities of `G`.
 
-    Leiden Community Detection is an algorithm to extract the community structure
-    of a network based on modularity optimization. It is an improvement upon the
-    Louvain Community Detection algorithm. See :any:`louvain_communities`.
+    This function uses the Leiden Community Detection algorithm [1]_ to estimate
+    the community structure based on metric optimization. The metric can be
+    modularity or Constant Potts Model (CPM). Leiden ensures that the communities
+    are well connected whereas Louvain does not. See :any:`louvain_communities`.
 
-    Unlike the Louvain algorithm, it guarantees that communities are well connected in addition
-    to being faster and uncovering better partitions. [1]_
+    The algorithm works in 3 phases. On the first phase, starting with a partition
+    of all singleton nodes, and a randomly shuffled queue of all nodes, each node
+    in the queue is considered in order and moved to the current community which
+    most increases the metric value. The node can stay in its current community.
+    If it moves, all neighbors of the moved node which are not currently in the
+    queue are added to the end of the queue to be considered for moving in turn.
+    The first phase continues until the queue is empty, resulting in a node
+    partition $P$.
 
-    The algorithm works in 3 phases. On the first phase, it adds the nodes to a queue randomly
-    and assigns every node to be in its own community. For each node it tries to find the
-    maximum positive modularity gain by moving each node to all of its neighbor communities.
-    If a node is moved from its community, it adds to the rear of the queue all neighbors of
-    the node that do not belong to the node’s new community and that are not in the queue.
+    The second phase refines $P$ to obtain $P_{refined}$. Each community in $P$
+    is considered on its own and split into subcommunities using a method closely
+    resembling the first phase. Starting from a subpartition of singleton nodes,
+    and a randomly ordered queue, subcommunities are merged only if both are
+    sufficiently well connected. This is determined randomly using a distribution
+    based on edge weights and controlled by the parameter `theta`. The merging
+    results in a splitting or refinement of the communities in $P$ such that
+    each set in $P_{refined}$ is a subset of one community in $P$. Thus each
+    community in $P$ also represents a community of subcommunities from $P_{refined}$.
 
-    The first phase continues until the queue is empty.
+    The third phase involves creating an aggregate network of community connections.
+    The communities in $P_{refined}$ act as nodes in the new network. Edges exist
+    between communities that have underlying nodes connected to nodes in the other
+    community. The weight of each such edge is the sum of the original graph edge
+    weights for edges between nodes in the two partitions. An initial partition of
+    the new network is provided via $P$ by joining the subcommunities of each
+    community in $P$ into an aggregated community of the new network. Each
+    subcommunity from $P_{refined}$ is a subset of one community in $P$ and thus
+    belongs to one community in the new network.
 
-    The second phase consists in refining the partition $P$ obtained from the first phase. It starts
-    with a singleton partition $P_{refined}$. Then it merges nodes locally in $P_{refined}$ within
-    each community of the partition $P$. Nodes are merged with a community in $P_{refined}$ only if
-    both are sufficiently well connected to their community in $P$. This means that after the
-    refinement phase is concluded, communities in $P$ sometimes will have been split into multiple
-    communities.
-
-    The third phase consists of aggregating the network by building a new network whose nodes are
-    now the communities found in the second phase. However, the non-refined partition is used to create
-    an initial partition for the aggregate network.
-
-    Once this phase is complete it is possible to reapply the first and second phases creating bigger
-    communities with increased modularity.
-
-    The above three phases are executed until no modularity gain is achieved or `max_level` number
-    of iterations have been performed.
+    The result of the 3 phases is a new network (level of aggregation) which encodes
+    a new partition of the original network. We can reapply the 3 phases
+    to create bigger aggregations with increased metric value. At each level
+    the network is smaller with fewer nodes and edges, so convergence is guaranteed.
+    The three phases are repeatedly applied until no modularity
+    gain is achieved or `max_level` applications have been performed.
 
     Parameters
     ----------
@@ -67,41 +76,53 @@ def leiden_communities(
     weight : string or None, optional (default="weight")
         The name of an edge attribute that holds the numerical value
         used as a weight. If None then each edge has weight 1.
+    metric : str (default="cpm")
+        The name of the partition quality metric that the algorithm optimises.
+        Allowed names are "cpm" and "modularity".
     resolution : float, optional (default=1)
-        If resolution is less than 1, the algorithm favors larger communities.
-        Greater than 1 favors smaller communities
+        Resolution should be a positive number indicating the coarseness of
+        the communities produced. With a lower resolution, larger communities
+        are produced. To see the smaller sub-communities, use a higher resolution.
     max_level : int or None, optional (default=None)
         The maximum number of levels (steps of the algorithm) to compute.
-        Must be a positive integer or None. If None, then there is no max
-        level and the threshold parameter determines the stopping condition.
+        Must be a positive integer or None indicating the process is reapplied
+        until no increase in metric is obtained.
     seed : integer, random_state, or None (default)
         Indicator of random number generation state.
         See :ref:`Randomness<randomness>`.
-    quality_function : str (default="cpm")
-        The algorithm optimises for a measure of quality. By default
-        the constant_potts_model is used, but this can be changed (e.g.
-        modularity)
     theta : float (default=0.01)
-        Parameter that determines the degree of randomness in the
+        Parameter that determines the degree of randomness in the second phase
         _refine_partition step of the algorithm,
 
     Returns
     -------
     list
-        A list of disjoint sets (partition of `G`). Each set represents one community.
+        A partition of `G` as a list of disjoint sets of nodes. Each set represents
+        one community of nodes and each node of `G` appears in exactly one set.
 
     Examples
     --------
 
+    >>> G = nx.barbell_graph(3, 4)
+    >>> cpm_comm = nx.community.leiden_communities(G, resolution=0.5, seed=62537129)
+    >>> len(cpm_comm)
+    3
+    >>> sorted(sorted(c) for c in cpm_comm, key=len)
+    [{0, 1, 2}, {3, 4, 5, 6}, {7, 8, 9}]
+
     Notes
     -----
     The order in which the nodes are considered can affect the final output.
-    In the algorithm the ordering happens using a random shuffle.
+    In the algorithm the ordering happens using a random shuffle controlled by
+    `seed` which also controls the randomness involved in selecting communities
+    to merge during the refining (2nd) stage.
 
     References
     ----------
-    .. [1] Traag, V.A., Waltman, L. & van Eck, N.J. From Louvain to Leiden: guaranteeing
-       well-connected communities. Sci Rep 9, 5233 (2019). https://doi.org/10.1038/s41598-019-41695-z
+    .. [1] Traag, V.A., Waltman, L. & van Eck, N.J.
+       From Louvain to Leiden: guaranteeing well-connected communities.
+       Sci Rep 9, 5233 (2019).
+       https://doi.org/10.1038/s41598-019-41695-z
 
     See Also
     --------
@@ -109,7 +130,7 @@ def leiden_communities(
     :any:`louvain_communities`
     """
 
-    partitions = leiden_partitions(G, weight, resolution, seed, quality_function, theta)
+    partitions = leiden_partitions(G, weight, resolution, seed, metric, theta)
 
     if max_level is not None:
         if max_level <= 0:
@@ -123,13 +144,14 @@ def leiden_communities(
 @nx._dispatchable(edge_attrs="weight")
 def leiden_partitions(
     G,
+    *,
     weight="weight",
+    metric="cpm",
     resolution=1.0,
     seed=None,
-    quality_function="cpm",
     theta=0.01,
 ):
-    """Yield partitions for each level of Leiden Community Detection (backend required)
+    """Yield partitions at each level of Leiden Community Detection
 
     Leiden Community Detection is an algorithm to extract the community
     structure of a network based on modularity optimization.
@@ -137,9 +159,8 @@ def leiden_partitions(
     The partitions across levels (steps of the algorithm) form a dendrogram
     of communities. A dendrogram is a diagram representing a tree and each
     level represents a partition of the G graph. The top level contains the
-    smallest communities and as you traverse to the bottom of the tree the
-    communities get bigger and the overall modularity increases making
-    the partition better.
+    smallest communities and as you traverse the tree the communities get
+    bigger and the overall partition quality metric increases.
 
     Each level is generated by executing the three phases of the Leiden Community
     Detection algorithm. See :any:`leiden_communities`.
@@ -150,24 +171,33 @@ def leiden_partitions(
     weight : string or None, optional (default="weight")
         The name of an edge attribute that holds the numerical value
         used as a weight. If None then each edge has weight 1.
+    metric : str (default="cpm")
+        The name of the partition quality metric that the algorithm optimises.
+        Allowed names are "cpm" and "modularity".
     resolution : float, optional (default=1)
-        If resolution is less than 1, the algorithm favors larger communities.
-        Greater than 1 favors smaller communities.
+        Resolution should be a positive number indicating the coarseness of
+        the communities produced. With a lower resolution, larger communities
+        are produced. To see the smaller sub-communities, use a higher resolution.
     seed : integer, random_state, or None (default)
         Indicator of random number generation state.
         See :ref:`Randomness<randomness>`.
+    theta : float (default=0.01)
+        Parameter that determines the degree of randomness in the second phase
+        _refine_partition step of the algorithm,
 
     Yields
     ------
-    list
-        A list of disjoint sets (partition of `G`). Each set represents one community.
-        All communities together contain all the nodes in `G`. The yielded partitions
-        increase modularity with each iteration.
+    list of sets of nodes
+        A partition of `G` as a list of disjoint sets of nodes. Each set represents
+        one community of nodes and each node of `G` appears in exactly one set.
+        The quality metric of the yielded partitions increases with each iteration.
 
     References
     ----------
-    .. [1] Traag, V.A., Waltman, L. & van Eck, N.J. From Louvain to Leiden: guaranteeing
-       well-connected communities. Sci Rep 9, 5233 (2019). https://doi.org/10.1038/s41598-019-41695-z
+    .. [1] Traag, V.A., Waltman, L. & van Eck, N.J.
+       From Louvain to Leiden: guaranteeing well-connected communities.
+       Sci Rep 9, 5233 (2019).
+       https://doi.org/10.1038/s41598-019-41695-z
 
     See Also
     --------
@@ -203,10 +233,10 @@ def leiden_partitions(
 
     # The following setup stage depends on the choice of quality
     # function. In particular, this stage must set three things:
-    # 1) set the function quality_function
+    # 1) set the function metric
     # 2) set the corresponding quality_delta function
     # 3) set the specific attributes required to compute the
-    #    quality_function and quality_delta
+    #    metric and quality_delta
 
     # the quality_delta function computes the partial quality delta contributed by
     # adding nodes_to_add to community.
@@ -215,12 +245,12 @@ def leiden_partitions(
     # to compute the overall quality delta from moving node u from A to B we have
     # q_delta = quality_delta({u}, B) - quality_delta({u}, A-{u})
 
-    if quality_function == "cpm":
+    if metric == "cpm":
         # Setup for constant potts model
         node_attributes = ["node_weight"]
         nx.set_node_attributes(graph, 1, name="node_weight")
 
-        quality_function = functools.partial(
+        metric = functools.partial(
             constant_potts_model,
             resolution=resolution,
             node_weight="node_weight",
@@ -259,7 +289,7 @@ def leiden_partitions(
                 )
                 return E - gamma * comm_size * nodes_size
 
-    elif quality_function == "modularity":
+    elif metric == "modularity":
         # Setup for (unipartite) modularity
 
         # the modualrity function throws an zero division error
@@ -274,7 +304,7 @@ def leiden_partitions(
             except ZeroDivisionError:
                 return float("inf")
 
-        quality_function = guarded_modularity
+        metric = guarded_modularity
         if is_directed:
             # Setup for directed modularity
             node_attributes = ["in_degree", "out_degree"]
@@ -334,13 +364,13 @@ def leiden_partitions(
                 )
                 return E_D - gamma * nodes_size * comm_size
 
-    elif quality_function == "barber_modularity":
+    elif metric == "barber_modularity":
         # Setup for undirected bipartite barber modularity (not yet fully implemented)
 
         if is_directed:
             raise nx.NetworkXError("barber_modularity not implemented for DiGraph")
 
-        # quality_function should be defined inline rather than
+        # metric should be defined inline rather than
         # importing nx.bipartite.community.modularity as the
         # function within this algorithm needs to accept the
         # aggregated graphs which are not bipartite and therefore
@@ -349,7 +379,7 @@ def leiden_partitions(
         def barber_modularity():
             return
 
-        quality_function = barber_modularity
+        metric = barber_modularity
 
         node_attributes = ["red_degree", "blue_degree"]
 
@@ -396,10 +426,10 @@ def leiden_partitions(
 
         raise nx.NetworkXError("barber_modularity not implemented for leiden")
     else:
-        raise nx.NetworkXError(f"{quality_function} not implemented for DiGraph")
+        raise nx.NetworkXError(f"{metric} not implemented for DiGraph")
 
     # The setup phase has ended, the main algorithm now begins.
-    Q = quality_function(graph, partition)
+    Q = metric(graph, partition)
 
     improvement_made = True
 
@@ -419,7 +449,7 @@ def leiden_partitions(
         P_refined_flat = [comm for P_ref in P_refined for comm in P_ref]
 
         # Stop when overall change in quality is close to zero.
-        Q_new = quality_function(graph, P_refined_flat)
+        Q_new = metric(graph, P_refined_flat)
         improvement_made = (Q_new - Q) > 0.0000001
         Q = Q_new
 
@@ -606,12 +636,12 @@ def _merge_node_subset(
         # one is selected at random, and u is added to that
         # community
         if candidate_comm:
-            # the probability distribution that the new community it drawn
+            # the probability distribution that the new community is drawn
             # from is defined in terms of the quality delta associated
             # with the move to each community.
 
             # If moving u to community C results in a quality delta QC,
-            # the relative frequency withi which C will be chosen is
+            # the relative frequency with which C will be chosen is
             # proportional to
             #
             #       math.exp(QC/theta)
@@ -638,7 +668,7 @@ def _create_aggregate_graph(G, refined_communities_list, node_attributes):
     Generate a new graph based on the partitions of a given graph
 
     node_attributes is a list of attributes that are required for the
-    given choice of quality function. When aggregating a community (set
+    given choice of quality metric. When aggregating a community (set
     of nodes) into a new node of the aggregated graph, the value for
     each attribute is the sum of the constituent nodes.
     """
@@ -701,18 +731,3 @@ def _convert_multigraph(G, weight, is_directed):
         else:
             H.add_edge(u, v, weight=wt)
     return H
-
-
-def _is_valid_refinement(p, ref_p):
-    """
-    helper function useful during debugging, checking whether
-    a refined partition ref_p is a true refinement of a partition p
-    """
-    val = True
-    for c1 in ref_p:
-        for c2 in p:
-            if c1.issubset(c2):
-                break
-        else:
-            val = False
-    return val

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -104,11 +104,19 @@ def leiden_communities(
     --------
 
     >>> G = nx.barbell_graph(3, 4)
-    >>> cpm_comm = nx.community.leiden_communities(G, resolution=0.5, seed=62537129)
+    >>> cpm_comm = nx.community.leiden_communities(G, resolution=0.2, seed=62537129)
     >>> len(cpm_comm)
     3
-    >>> sorted(sorted(c) for c in cpm_comm, key=len)
-    [{0, 1, 2}, {3, 4, 5, 6}, {7, 8, 9}]
+    >>> sorted(sorted(c) for c in cpm_comm)
+    [[0, 1, 2], [3, 4, 5, 6], [7, 8, 9]]
+
+    Higher resolution produces smaller sub-communities:
+
+    >>> cpm_comm = nx.community.leiden_communities(G, resolution=0.4, seed=62537129)
+    >>> len(cpm_comm)
+    4
+    >>> sorted(sorted(c) for c in cpm_comm)
+    [[0, 1, 2], [3, 4], [5, 6], [7, 8, 9]]
 
     Notes
     -----

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -78,7 +78,8 @@ def leiden_communities(
         used as a weight. If None then each edge has weight 1.
     metric : str (default="cpm")
         The name of the partition quality metric that the algorithm optimises.
-        Allowed names are "cpm" and "modularity".
+        Allowed names are "cpm" and "modularity" for constant potts model and
+        modularity respectively.
     resolution : float, optional (default=1)
         Resolution should be a positive number indicating the coarseness of
         the communities produced. With a lower resolution, larger communities

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -130,7 +130,9 @@ def leiden_communities(
     :any:`louvain_communities`
     """
 
-    partitions = leiden_partitions(G, weight, resolution, seed, metric, theta)
+    partitions = leiden_partitions(
+        G, weight=weight, resolution=resolution, seed=seed, metric=metric, theta=theta
+    )
 
     if max_level is not None:
         if max_level <= 0:

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -33,6 +33,8 @@ def leiden_communities(
     the community structure based on metric optimization. The metric can be
     modularity or Constant Potts Model (CPM). Leiden ensures that the communities
     are well connected whereas Louvain does not. See :any:`louvain_communities`.
+    The functions which comppute those two metrics are :any:`modularity` and
+    :any:`constant_potts_model`
 
     The algorithm works in 3 phases. On the first phase, starting with a partition
     of all singleton nodes, and a randomly shuffled queue of all nodes, each node
@@ -79,7 +81,8 @@ def leiden_communities(
     metric : str (default="cpm")
         The name of the partition quality metric that the algorithm optimises.
         Allowed names are "cpm" and "modularity" for constant potts model and
-        modularity respectively.
+        modularity respectively. See functions :any:`modularity` and
+        :any:`constant_potts_model` for more info.
     resolution : float, optional (default=1)
         Resolution should be a positive number indicating the coarseness of
         the communities produced. With a lower resolution, larger communities
@@ -137,6 +140,8 @@ def leiden_communities(
     --------
     leiden_partitions
     :any:`louvain_communities`
+    :any:`modularity`
+    :any:`constant_potts_model`
     """
 
     partitions = leiden_partitions(

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -33,7 +33,7 @@ def leiden_communities(
     the community structure based on metric optimization. The metric can be
     modularity or Constant Potts Model (CPM). Leiden ensures that the communities
     are well connected whereas Louvain does not. See :any:`louvain_communities`.
-    The functions which comppute those two metrics are :any:`modularity` and
+    The functions which compute those two metrics are :any:`modularity` and
     :any:`constant_potts_model`
 
     The algorithm works in 3 phases. On the first phase, starting with a partition
@@ -69,8 +69,8 @@ def leiden_communities(
     a new partition of the original network. We can reapply the 3 phases
     to create bigger aggregations with increased metric value. At each level
     the network is smaller with fewer nodes and edges, so convergence is guaranteed.
-    The three phases are repeatedly applied until no modularity
-    gain is achieved or `max_level` applications have been performed.
+    The three phases are repeatedly applied until no gain is achieved or
+    `max_level` applications have been performed.
 
     Parameters
     ----------
@@ -442,7 +442,9 @@ def leiden_partitions(
 
         raise nx.NetworkXError("barber_modularity not implemented for leiden")
     else:
-        raise nx.NetworkXError(f"{metric} not implemented for DiGraph")
+        raise nx.NetworkXError(
+            f'leiden only supports metrics "cpm" and "modularity". Got: {metric}'
+        )
 
     # The setup phase has ended, the main algorithm now begins.
     Q = metric(graph, partition)

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -502,7 +502,7 @@ def partition_quality(G, partition):
     ----------
     .. [1] Santo Fortunato.
            "Community Detection in Graphs".
-           *Physical Reports*, Volume 486, Issue 3--5 pp. 75--174
+           *Physics Reports*, Volume 486, Feb 2010, Issue 3--5 pp. 75--174
            <https://arxiv.org/abs/0906.0612>
     """
 

--- a/networkx/algorithms/community/tests/test_leiden.py
+++ b/networkx/algorithms/community/tests/test_leiden.py
@@ -1,43 +1,51 @@
 import pytest
 
 import networkx as nx
+
+comm = nx.community
 from networkx.algorithms.community import leiden_communities, leiden_partitions
 from networkx.algorithms.community.quality import constant_potts_model, modularity
 
 
-def test_modularity_increase():
+def _equivalent_partitions(P1, P2):
+    return {frozenset(C) for C in P1} == {frozenset(C) for C in P2}
 
-    # by default leiden_communities uses constant_potts_model as the quality
-    # function being optimised, not modularity.
 
-    # The equivalent test test_cpm_increase is implemented below using constant_potts_model
-    # and another test using modularity as the explicit quality function
-    # test_modularity_increase_qf_parameter is also implemented below
-
-    G = nx.LFR_benchmark_graph(
+@pytest.fixture(params=[nx.Graph, nx.MultiGraph])
+def G(request):
+    LFR_graph = nx.LFR_benchmark_graph(
         250, 3, 1.5, 0.009, average_degree=5, min_community=20, seed=10
     )
-    partition = [{u} for u in G.nodes()]
-    q_mod = nx.community.modularity(G, partition)
-    partition = nx.community.leiden_communities(
-        G, quality_function="modularity", resolution=0.2
-    )
+    G = request.param(LFR_graph)
+    G.add_edges_from(LFR_graph.edges())  # duplicate edges if multigraph
+    return G
 
-    assert nx.community.modularity(G, partition) > q_mod
+@pytest.fixture
+def singletons(G):
+    return [{node} for node in G]
+
+def _metrics():
+    yield from ["cpm", "modularity"]
+
+def _quality():
+    def cpm(G, P):
+        return comm.constant_potts_model(G, P, resolution=0.2)
+
+    def qmod(G, P):
+        return comm.modularity(G, P, resolution=0.2)
+
+    for gamma in [0.2, 0.5, 0.9]:
+        yield from [("cpm", cpm, gamma), ("modularity", qmod, gamma)]
 
 
-def test_valid_partition():
-    G = nx.LFR_benchmark_graph(
-        250, 3, 1.5, 0.009, average_degree=5, min_community=20, seed=10
-    )
-    partition = nx.community.leiden_communities(G, resolution=0.1, seed=10)
-
-    assert nx.community.is_partition(G, partition)
+def test_valid_partition(G):
+    partition = comm.leiden_communities(G, resolution=0.1, seed=10)
+    assert comm.is_partition(G, partition)
 
 
-def test_partition_iterator():
+def test_partitions_yields_copy():
     G = nx.path_graph(15)
-    parts_iter = nx.community.leiden_partitions(G, resolution=0.2, seed=42)
+    parts_iter = comm.leiden_partitions(G, resolution=0.2, seed=42)
     first_part = next(parts_iter)
     first_copy = [s.copy() for s in first_part]
 
@@ -47,144 +55,155 @@ def test_partition_iterator():
     assert first_copy[0] == first_part[0]
 
 
-def test_none_weight_param():
+def test_empty_graph():
+    G = nx.Graph()
+    G.add_nodes_from(range(5))
+    expected = [{0}, {1}, {2}, {3}, {4}]
+    assert comm.leiden_communities(G) == expected
+
+
+@pytest.mark.parametrize("metric, Q_func, gamma", _quality())
+def test_overall_increase(G, singletons, metric, Q_func, gamma):
+    Q = Q_func(G, singletons)
+    new_P = comm.leiden_communities(
+        G, metric=metric, resolution=gamma, seed=42
+    )
+    new_Q = Q_func(G, new_P)
+    assert new_Q > Q
+
+
+@pytest.mark.parametrize("metric", _metrics())
+def test_coverage_up_with_leiden_metrics(G, singletons, metric):
+    # check that `partition_quality` coverage increases for all metrics
+    # even though they not optimizing coverage. Also that coverage > 45%
+    for H in [G, nx.MultiGraph(G)]:
+        partition = comm.leiden_communities(
+            H, metric=metric, resolution=0.05, seed=10
+        )
+        coverage = comm.partition_quality(H, partition)[0]  # 0th return is coverage
+        assert coverage >= 0.45
+        assert coverage > comm.partition_quality(H, singletons)[0]
+
+
+def test_weight_kwarg():
     G = nx.karate_club_graph()
     nx.set_edge_attributes(
         G, {edge: i * i for i, edge in enumerate(G.edges)}, name="foo"
     )
 
-    partition1 = nx.community.leiden_communities(G, weight=None, seed=2)
-    partition2 = nx.community.leiden_communities(G, weight="foo", seed=2)
-    partition3 = nx.community.leiden_communities(G, weight="weight", seed=2)
+    partition1 = comm.leiden_communities(G, weight=None, seed=2)
+    partition2 = comm.leiden_communities(G, weight="foo", seed=2)
+    partition3 = comm.leiden_communities(G, weight="weight", seed=2)
 
     assert partition1 != partition2
     assert partition2 != partition3
+    assert partition1 != partition3
 
 
-def test_quality():
+def test_resolution_kwarg(G):
+    P1 = comm.leiden_communities(G, resolution=0.05, seed=12)
+    P2 = comm.leiden_communities(G, resolution=0.10, seed=12)
+    P3 = comm.leiden_communities(G, resolution=0.5, seed=12)
+    P4 = comm.leiden_communities(G, resolution=0.7, seed=12)
+    P5 = comm.leiden_communities(G, resolution=1.5, seed=12)
+    assert len(P1) < len(P2) < len(P3) < len(P4) < len(P5)
+
+    qmod = "modularity"
+    # Only three sizes of partitions: 2, 21, 77. Changes at r=0 and r=6.83
+    P1 = comm.leiden_communities(G, metric=qmod, resolution=0.0, seed=12)
+    P2 = comm.leiden_communities(G, metric=qmod, resolution=1.0, seed=12)
+    P3 = comm.leiden_communities(G, metric=qmod, resolution=7.0, seed=12)
+    assert len(P1) < len(P2) < len(P3)
+
+
+def test_LFR_communities_across_algos():
+    # same graph as for fixture G, but not multigraph (it'd need other seeds)
     G = nx.LFR_benchmark_graph(
         250, 3, 1.5, 0.009, average_degree=5, min_community=20, seed=10
     )
-    H = nx.MultiGraph(G)
+    # Results are random, but Louvain is consistent across seed.
+    # Resolution differs to get 3 communities.
+    # The LFR example constructs G to have 3 communities.
+    # So comparison is really about the nodes in the 3 communities being the same
+    # That works for all except the Leiden modularity variant.
+    C = nx.get_node_attributes(G, "community").values()
+    LFR_comm = {frozenset(c) for c in C}  # remove duplicate entries
+    print(f"{set([len(c) for c in LFR_comm])=}")
 
-    partition = nx.community.leiden_communities(
-        G, quality_function="modularity", resolution=0.05, seed=10
-    )
-    partition2 = nx.community.leiden_communities(
-        H, quality_function="modularity", resolution=0.05, seed=10
-    )
+    C = comm.louvain_communities(G, resolution=0.5, seed=10)
+    louvain_comm = {frozenset(c) for c in C}
+    print(f"{set([len(c) for c in louvain_comm])=}")
 
-    quality = nx.community.partition_quality(G, partition)[0]
-    quality2 = nx.community.partition_quality(H, partition2)[0]
+    C = comm.leiden_communities(G, metric="cpm", resolution=0.0001, seed=10)
+    cpm_comm = {frozenset(c) for c in C}
+    print(f"{set([len(c) for c in cpm_comm])=}")
 
-    assert quality >= 0.45
-    assert quality2 >= 0.45
+    C = comm.leiden_communities(G, metric="modularity", resolution=0.01, seed=3)
+    mod_comm = {frozenset(c) for c in C}
 
-
-def test_quality_cpm():
-    G = nx.LFR_benchmark_graph(
-        250, 3, 1.5, 0.009, average_degree=5, min_community=20, seed=10
-    )
-    H = nx.MultiGraph(G)
-    singleton_partition = [{u} for u in G]
-
-    r = 0.05
-    partition = nx.community.leiden_communities(G, resolution=r, seed=10)
-    partition2 = nx.community.leiden_communities(H, resolution=r, seed=10)
-
-    quality = nx.community.partition_quality(G, partition)[0]
-    quality2 = nx.community.partition_quality(H, partition2)[0]
-
-    assert quality > 0.45
-    assert quality2 > 0.45
-    assert quality > nx.community.partition_quality(G, singleton_partition)[0]
-    assert quality2 > nx.community.partition_quality(H, singleton_partition)[0]
+    assert len(louvain_comm) == len(cpm_comm) == len(mod_comm) == len(LFR_comm)
+    assert louvain_comm == cpm_comm == LFR_comm  # mod_comm has 3 different comms
 
 
-def test_resolution():
-    G = nx.LFR_benchmark_graph(
-        250, 3, 1.5, 0.009, average_degree=5, min_community=20, seed=10
-    )
+def test_barbell_communities_across_algos():
+    G = nx.barbell_graph(5, 3)
 
-    partition1 = nx.community.leiden_communities(G, resolution=0.05, seed=12)
-    partition2 = nx.community.leiden_communities(G, resolution=0.10, seed=12)
-    partition3 = nx.community.leiden_communities(G, resolution=0.5, seed=12)
+    # seed doesn't seem to matter for this example. Resolution does.
+    louvain_comm = comm.louvain_communities(G, resolution=1)
+    mod_comm = comm.leiden_communities(G, metric="modularity", resolution=3)
+    cpm_comm = comm.leiden_communities(G, metric="cpm", resolution=0.3)
 
-    assert len(partition1) < len(partition2)
-    assert len(partition2) < len(partition3)
+    assert louvain_comm == mod_comm == cpm_comm
 
 
-def test_empty_graph():
-    G = nx.Graph()
-    G.add_nodes_from(range(5))
-    expected = [{0}, {1}, {2}, {3}, {4}]
-    assert nx.community.leiden_communities(G) == expected
-
-
-def test_max_level():
-    G = nx.LFR_benchmark_graph(
-        250, 3, 1.5, 0.009, average_degree=5, min_community=20, seed=10
-    )
-    parts_iter = nx.community.leiden_partitions(G, resolution=0.1, seed=42)
-    for max_level, expected in enumerate(parts_iter, 1):
-        partition = nx.community.leiden_communities(
-            G, max_level=max_level, resolution=0.1, seed=42
+@pytest.mark.parametrize("metric", _metrics())
+def test_max_level_kwarg(G, metric):
+    P_iter = comm.leiden_partitions(G, resolution=0.1, seed=42, metric=metric)
+    for max_level, expected in enumerate(P_iter, start=1):
+        P = comm.leiden_communities(
+            G, max_level=max_level, resolution=0.1, seed=42, metric=metric
         )
-        assert partition == expected
-
+        assert P == expected
     assert max_level > 1  # Ensure we are actually testing max_level
+
     # max_level is an upper limit; it's okay if we stop before it's hit.
-    partition = nx.community.leiden_communities(
-        G, max_level=max_level + 1, resolution=0.1, seed=42
+    P = comm.leiden_communities(
+        G, max_level=max_level + 1, resolution=0.1, seed=42, metric=metric
     )
-    assert partition == expected
-    with pytest.raises(
-        ValueError, match="max_level argument must be a positive integer"
-    ):
-        nx.community.leiden_communities(G, max_level=0)
+    assert P == expected
+
+    with pytest.raises(ValueError, match="max_level argument must be.* positive"):
+        comm.leiden_communities(G, max_level=0)
 
 
-def test_connected_communities_LFR():
-    G = nx.LFR_benchmark_graph(
-        250, 3, 1.5, 0.009, average_degree=5, min_community=20, seed=10
-    )
-
-    partition = nx.community.leiden.leiden_communities(
+def test_communities_connected(G):
+    partition = comm.leiden.leiden_communities(
         G, weight=None, resolution=0.3, theta=0.1, seed=10
     )
-
     for C in partition:
-        assert _check_connected_community(G, C)
+        assert nx.is_connected(G.subgraph(C).copy())
 
 
-def test_quality_function_not_implemented():
+def test_mispelled_metric():
     G = nx.karate_club_graph()
-
     with pytest.raises(nx.NetworkXError):
-        leiden_communities(
-            G, quality_function="bad_quality_function", resolution=0.2, seed=1
-        )
+        leiden_communities(G, metric="bad_metric")
 
 
-def test_expected():
+def test_expected_stable_across_code_changes_cpm():
     G = nx.karate_club_graph()
-
-    part = leiden_communities(G, resolution=0.2, seed=1)
-
-    part_expected = [
+    P = leiden_communities(G, resolution=0.2, seed=1)
+    P_expected = [
         {0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21},
         {16, 4, 5, 6, 10},
         {9},
         {8, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},
     ]
-
-    assert _equivalent_partitions(part, part_expected)
+    assert _equivalent_partitions(P, P_expected)
 
     G = nx.karate_club_graph()
-
-    part = leiden_communities(G, weight=None, resolution=0.2, seed=1)
-
-    part_expected = [
+    P = leiden_communities(G, weight=None, resolution=0.2, seed=1)
+    P_expected = [
         {11},
         {12},
         {0, 1, 2, 3, 7, 8, 13},
@@ -198,8 +217,32 @@ def test_expected():
         {26},
         {32, 33, 14, 15, 18, 20, 22, 23, 27, 29},
     ]
+    assert _equivalent_partitions(P, P_expected)
 
-    assert _equivalent_partitions(part, part_expected)
+def test_expected_stable_across_code_changes_qmod():
+    qmod = "modularity"
+    G = nx.karate_club_graph()
+    P = leiden_communities(G, resolution=2, seed=10, metric=qmod)
+    print(f"{P}=")
+    P_expected = [
+        {0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21},
+        {16, 4, 5, 6, 10},
+        {32, 33, 8, 9, 14, 15, 18, 20, 22, 23, 26, 27, 29, 30},
+        {24, 25, 28, 31},
+    ]
+    assert _equivalent_partitions(P, P_expected)
+
+    G = nx.karate_club_graph()
+    P = leiden_communities(
+        G, weight=None, resolution=2, seed=10, metric=qmod
+    )
+    print(f"{P}=")
+    P_expected = [
+        {0, 1, 2, 3, 7, 9, 11, 12, 13, 17, 19, 21},
+        {16, 4, 5, 6, 10},
+        {8, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},
+    ]
+    assert _equivalent_partitions(P, P_expected)
 
 
 def test_connected_communities():
@@ -208,18 +251,11 @@ def test_connected_communities():
     r = 0.2
     part = leiden_communities(G, resolution=r, seed=n)
     for C in part:
-        assert _check_connected_community(G, C)
+        assert nx.is_connected(G.subgraph(C).copy())
 
-
-def test_connected_communities_modularity():
-    G = nx.karate_club_graph()
-    n = 42
-    r = 0.3
-    part = leiden_communities(
-        G, weight=None, quality_function="modularity", resolution=r, seed=n
-    )
+    part = leiden_communities(G, resolution=r, seed=n, metric="modularity")
     for C in part:
-        assert _check_connected_community(G, C)
+        assert nx.is_connected(G.subgraph(C).copy())
 
 
 def test_connected_communities_no_weights():
@@ -227,28 +263,23 @@ def test_connected_communities_no_weights():
     r = 0.3
     part = leiden_communities(G, weight=None, resolution=r, seed=111)
     for C in part:
-        assert _check_connected_community(G, C)
+        assert nx.is_connected(G.subgraph(C).copy())
 
 
-def test_directed_graphs_modularity():
+@pytest.mark.parametrize("metric", _metrics())
+def test_directed_graphs_modularity(metric):
     G = nx.gn_graph(n=100, seed=11)
     assert nx.is_directed(G)
     comms = leiden_communities(
-        G, quality_function="modularity", weight=None, resolution=0.2, seed=11
+        G, metric=metric, weight=None, resolution=0.2, seed=11
     )
-
-
-def test_directed_graphs_cpm():
-    G = nx.gn_graph(n=100, seed=11)
-    assert nx.is_directed(G)
-    comms = leiden_communities(G, weight=None, resolution=0.2, seed=11)
 
 
 def test_bipartite_graphs_modularity():
     G = nx.bipartite.random_graph(10, 20, 0.2, seed=11)
     with pytest.raises(nx.NetworkXError):
         leiden_communities(
-            G, quality_function="barber_modularity", resolution=0.2, seed=1
+            G, metric="barber_modularity", resolution=0.2, seed=1
         )
 
 
@@ -256,75 +287,5 @@ def test_bipartite_graphs_modularity_directed():
     G = nx.bipartite.random_graph(10, 20, 0.2, directed=True, seed=11)
     with pytest.raises(nx.NetworkXError):
         leiden_communities(
-            G, quality_function="barber_modularity", resolution=0.2, seed=1
+            G, metric="barber_modularity", resolution=0.2, seed=1
         )
-
-
-def test_modularity_increase_qf_parameter():
-    G = nx.LFR_benchmark_graph(
-        250, 3, 1.5, 0.009, average_degree=5, min_community=20, seed=10
-    )
-    partition = [{u} for u in G.nodes()]
-    q_mod = nx.community.modularity(G, partition)
-    partition = leiden_communities(
-        G, resolution=0.1, quality_function="modularity", seed=10
-    )
-
-    assert nx.community.modularity(G, partition) > q_mod
-
-
-def test_cpm_increase():
-    G = nx.LFR_benchmark_graph(
-        250, 3, 1.5, 0.009, average_degree=5, min_community=20, seed=10
-    )
-    partition = [{u} for u in G.nodes()]
-    r = 0.3
-    cpm = constant_potts_model(
-        G, partition, weight=None, node_weight=None, resolution=r
-    )
-    partition = leiden_communities(G, resolution=r, seed=10)
-
-    assert constant_potts_model(G, partition, weight=None, resolution=r) > cpm
-
-
-def test_resolution_cpm():
-    G = nx.LFR_benchmark_graph(
-        250, 3, 1.5, 0.009, average_degree=5, min_community=20, seed=10
-    )
-
-    partition1 = leiden_communities(G, resolution=0.05, seed=12)
-    partition2 = leiden_communities(G, resolution=0.2, seed=12)
-    partition3 = leiden_communities(G, resolution=0.7, seed=12)
-
-    assert len(partition1) < len(partition2)
-    assert len(partition2) < len(partition3)
-
-
-def test_resolution_modularity():
-    G = nx.LFR_benchmark_graph(
-        250, 3, 1.5, 0.009, average_degree=5, min_community=20, seed=10
-    )
-
-    partition1 = leiden_communities(
-        G, quality_function="modularity", resolution=0.01, seed=10
-    )
-    partition2 = leiden_communities(
-        G, quality_function="modularity", resolution=2.0, seed=10
-    )
-    partition3 = leiden_communities(
-        G, quality_function="modularity", resolution=10.0, seed=10
-    )
-
-    assert len(partition1) < len(partition2)
-    assert len(partition2) < len(partition3)
-
-
-def _equivalent_partitions(P1, P2):
-    P1 = {frozenset(C) for C in P1}
-    P2 = {frozenset(C) for C in P2}
-    return P1 == P2
-
-
-def _check_connected_community(G, community):
-    C = G.subgraph(community).copy()
-    return nx.is_connected(C)

--- a/networkx/algorithms/community/tests/test_leiden.py
+++ b/networkx/algorithms/community/tests/test_leiden.py
@@ -1,10 +1,10 @@
 import pytest
 
 import networkx as nx
-
-comm = nx.community
 from networkx.algorithms.community import leiden_communities, leiden_partitions
 from networkx.algorithms.community.quality import constant_potts_model, modularity
+
+comm = nx.community
 
 
 def _equivalent_partitions(P1, P2):
@@ -20,12 +20,15 @@ def G(request):
     G.add_edges_from(LFR_graph.edges())  # duplicate edges if multigraph
     return G
 
+
 @pytest.fixture
 def singletons(G):
     return [{node} for node in G]
 
+
 def _metrics():
     yield from ["cpm", "modularity"]
+
 
 def _quality():
     def cpm(G, P):
@@ -65,9 +68,7 @@ def test_empty_graph():
 @pytest.mark.parametrize("metric, Q_func, gamma", _quality())
 def test_overall_increase(G, singletons, metric, Q_func, gamma):
     Q = Q_func(G, singletons)
-    new_P = comm.leiden_communities(
-        G, metric=metric, resolution=gamma, seed=42
-    )
+    new_P = comm.leiden_communities(G, metric=metric, resolution=gamma, seed=42)
     new_Q = Q_func(G, new_P)
     assert new_Q > Q
 
@@ -77,9 +78,7 @@ def test_coverage_up_with_leiden_metrics(G, singletons, metric):
     # check that `partition_quality` coverage increases for all metrics
     # even though they not optimizing coverage. Also that coverage > 45%
     for H in [G, nx.MultiGraph(G)]:
-        partition = comm.leiden_communities(
-            H, metric=metric, resolution=0.05, seed=10
-        )
+        partition = comm.leiden_communities(H, metric=metric, resolution=0.05, seed=10)
         coverage = comm.partition_quality(H, partition)[0]  # 0th return is coverage
         assert coverage >= 0.45
         assert coverage > comm.partition_quality(H, singletons)[0]
@@ -128,15 +127,12 @@ def test_LFR_communities_across_algos():
     # That works for all except the Leiden modularity variant.
     C = nx.get_node_attributes(G, "community").values()
     LFR_comm = {frozenset(c) for c in C}  # remove duplicate entries
-    print(f"{set([len(c) for c in LFR_comm])=}")
 
     C = comm.louvain_communities(G, resolution=0.5, seed=10)
     louvain_comm = {frozenset(c) for c in C}
-    print(f"{set([len(c) for c in louvain_comm])=}")
 
     C = comm.leiden_communities(G, metric="cpm", resolution=0.0001, seed=10)
     cpm_comm = {frozenset(c) for c in C}
-    print(f"{set([len(c) for c in cpm_comm])=}")
 
     C = comm.leiden_communities(G, metric="modularity", resolution=0.01, seed=3)
     mod_comm = {frozenset(c) for c in C}
@@ -219,11 +215,11 @@ def test_expected_stable_across_code_changes_cpm():
     ]
     assert _equivalent_partitions(P, P_expected)
 
+
 def test_expected_stable_across_code_changes_qmod():
     qmod = "modularity"
     G = nx.karate_club_graph()
     P = leiden_communities(G, resolution=2, seed=10, metric=qmod)
-    print(f"{P}=")
     P_expected = [
         {0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21},
         {16, 4, 5, 6, 10},
@@ -233,10 +229,7 @@ def test_expected_stable_across_code_changes_qmod():
     assert _equivalent_partitions(P, P_expected)
 
     G = nx.karate_club_graph()
-    P = leiden_communities(
-        G, weight=None, resolution=2, seed=10, metric=qmod
-    )
-    print(f"{P}=")
+    P = leiden_communities(G, weight=None, resolution=2, seed=10, metric=qmod)
     P_expected = [
         {0, 1, 2, 3, 7, 9, 11, 12, 13, 17, 19, 21},
         {16, 4, 5, 6, 10},
@@ -270,22 +263,16 @@ def test_connected_communities_no_weights():
 def test_directed_graphs_modularity(metric):
     G = nx.gn_graph(n=100, seed=11)
     assert nx.is_directed(G)
-    comms = leiden_communities(
-        G, metric=metric, weight=None, resolution=0.2, seed=11
-    )
+    comms = leiden_communities(G, metric=metric, weight=None, resolution=0.2, seed=11)
 
 
 def test_bipartite_graphs_modularity():
     G = nx.bipartite.random_graph(10, 20, 0.2, seed=11)
     with pytest.raises(nx.NetworkXError):
-        leiden_communities(
-            G, metric="barber_modularity", resolution=0.2, seed=1
-        )
+        leiden_communities(G, metric="barber_modularity", resolution=0.2, seed=1)
 
 
 def test_bipartite_graphs_modularity_directed():
     G = nx.bipartite.random_graph(10, 20, 0.2, directed=True, seed=11)
     with pytest.raises(nx.NetworkXError):
-        leiden_communities(
-            G, metric="barber_modularity", resolution=0.2, seed=1
-        )
+        leiden_communities(G, metric="barber_modularity", resolution=0.2, seed=1)

--- a/networkx/algorithms/community/tests/test_leiden.py
+++ b/networkx/algorithms/community/tests/test_leiden.py
@@ -1,8 +1,6 @@
 import pytest
 
 import networkx as nx
-from networkx.algorithms.community import leiden_communities, leiden_partitions
-from networkx.algorithms.community.quality import constant_potts_model, modularity
 
 comm = nx.community
 
@@ -77,11 +75,10 @@ def test_overall_increase(G, singletons, metric, Q_func, gamma):
 def test_coverage_up_with_leiden_metrics(G, singletons, metric):
     # check that `partition_quality` coverage increases for all metrics
     # even though they not optimizing coverage. Also that coverage > 45%
-    for H in [G, nx.MultiGraph(G)]:
-        partition = comm.leiden_communities(H, metric=metric, resolution=0.05, seed=10)
-        coverage = comm.partition_quality(H, partition)[0]  # 0th return is coverage
-        assert coverage >= 0.45
-        assert coverage > comm.partition_quality(H, singletons)[0]
+    partition = comm.leiden_communities(G, metric=metric, resolution=0.05, seed=10)
+    coverage = comm.partition_quality(G, partition)[0]  # 0th return is coverage
+    assert coverage >= 0.45
+    assert coverage > comm.partition_quality(G, singletons)[0]
 
 
 def test_weight_kwarg():
@@ -149,7 +146,8 @@ def test_barbell_communities_across_algos():
     mod_comm = comm.leiden_communities(G, metric="modularity", resolution=3)
     cpm_comm = comm.leiden_communities(G, metric="cpm", resolution=0.3)
 
-    assert louvain_comm == mod_comm == cpm_comm
+    assert _equivalent_partitions(louvain_comm, mod_comm)
+    assert _equivalent_partitions(louvain_comm, cpm_comm)
 
 
 @pytest.mark.parametrize("metric", _metrics())
@@ -183,12 +181,12 @@ def test_communities_connected(G):
 def test_mispelled_metric():
     G = nx.karate_club_graph()
     with pytest.raises(nx.NetworkXError):
-        leiden_communities(G, metric="bad_metric")
+        comm.leiden_communities(G, metric="bad_metric")
 
 
 def test_expected_stable_across_code_changes_cpm():
     G = nx.karate_club_graph()
-    P = leiden_communities(G, resolution=0.2, seed=1)
+    P = comm.leiden_communities(G, resolution=0.2, seed=1)
     P_expected = [
         {0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21},
         {16, 4, 5, 6, 10},
@@ -198,7 +196,7 @@ def test_expected_stable_across_code_changes_cpm():
     assert _equivalent_partitions(P, P_expected)
 
     G = nx.karate_club_graph()
-    P = leiden_communities(G, weight=None, resolution=0.2, seed=1)
+    P = comm.leiden_communities(G, weight=None, resolution=0.2, seed=1)
     P_expected = [
         {11},
         {12},
@@ -219,7 +217,7 @@ def test_expected_stable_across_code_changes_cpm():
 def test_expected_stable_across_code_changes_qmod():
     qmod = "modularity"
     G = nx.karate_club_graph()
-    P = leiden_communities(G, resolution=2, seed=10, metric=qmod)
+    P = comm.leiden_communities(G, resolution=2, seed=10, metric=qmod)
     P_expected = [
         {0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21},
         {16, 4, 5, 6, 10},
@@ -229,7 +227,7 @@ def test_expected_stable_across_code_changes_qmod():
     assert _equivalent_partitions(P, P_expected)
 
     G = nx.karate_club_graph()
-    P = leiden_communities(G, weight=None, resolution=2, seed=10, metric=qmod)
+    P = comm.leiden_communities(G, weight=None, resolution=2, seed=10, metric=qmod)
     P_expected = [
         {0, 1, 2, 3, 7, 9, 11, 12, 13, 17, 19, 21},
         {16, 4, 5, 6, 10},
@@ -242,11 +240,11 @@ def test_connected_communities():
     G = nx.karate_club_graph()
     n = 42
     r = 0.2
-    part = leiden_communities(G, resolution=r, seed=n)
+    part = comm.leiden_communities(G, resolution=r, seed=n)
     for C in part:
         assert nx.is_connected(G.subgraph(C).copy())
 
-    part = leiden_communities(G, resolution=r, seed=n, metric="modularity")
+    part = comm.leiden_communities(G, resolution=r, seed=n, metric="modularity")
     for C in part:
         assert nx.is_connected(G.subgraph(C).copy())
 
@@ -254,7 +252,7 @@ def test_connected_communities():
 def test_connected_communities_no_weights():
     G = nx.karate_club_graph()
     r = 0.3
-    part = leiden_communities(G, weight=None, resolution=r, seed=111)
+    part = comm.leiden_communities(G, weight=None, resolution=r, seed=111)
     for C in part:
         assert nx.is_connected(G.subgraph(C).copy())
 
@@ -263,16 +261,16 @@ def test_connected_communities_no_weights():
 def test_directed_graphs_modularity(metric):
     G = nx.gn_graph(n=100, seed=11)
     assert nx.is_directed(G)
-    comms = leiden_communities(G, metric=metric, weight=None, resolution=0.2, seed=11)
+    comm.leiden_communities(G, metric=metric, weight=None, resolution=0.2, seed=11)
 
 
 def test_bipartite_graphs_modularity():
     G = nx.bipartite.random_graph(10, 20, 0.2, seed=11)
     with pytest.raises(nx.NetworkXError):
-        leiden_communities(G, metric="barber_modularity", resolution=0.2, seed=1)
+        comm.leiden_communities(G, metric="barber_modularity", resolution=0.2, seed=1)
 
 
 def test_bipartite_graphs_modularity_directed():
     G = nx.bipartite.random_graph(10, 20, 0.2, directed=True, seed=11)
     with pytest.raises(nx.NetworkXError):
-        leiden_communities(G, metric="barber_modularity", resolution=0.2, seed=1)
+        comm.leiden_communities(G, metric="barber_modularity", resolution=0.2, seed=1)


### PR DESCRIPTION
This PR is a follow-up to #8509 

The tests are reorganized using fixtures, and parametrization across "cpm" and "modularity" metrics. Doc-strings are reworded and rewrapped with example added to `leiden_communities()`. Hopefully they are improved, but that is often subjective.

Perhaps the most controversial change is to rename the kwarg `quality_function` to `metric`. The value is not a function. It is the name of the objective function to use: either "cpm" for Constant Potts Model, or "modularity" for Modularity. I tried the kwarg `method` like we use elsewhere. But the algorithm is the same, just the objective function has changed. So "method" isn't quite right.  I also tried `quality_metric`, but the term "quality", while historically relevant as the measure of "partition quality", is not descriptive with the adjective "partition".  And the length of the kwarg is annoying for code wrapping. So I am proposing `metric`.  I'm open to suggestions.

I tried to replace the name "resolution", but could not find a better word. I tried to describe it better in the doc-string using "low resolution" and "high resolution" to make the analogy that low res sees big stuff, while high res sees little stuff.

All original tests should still be there but now covering both metrics. New tests include trying to get at ground_truth examples. The LFR_benchmark_graph example has the constructed communities indicated as node attributes. So one test checks that those are the communities found by louvain(), leiden with "cpm" and leiden with "modularity". Results vary by `seed` value and `resolution` value, so I picked resolutions for each metric that usually gave about the right number of communities. The resulting 3 communities vary a little by seed, but its easy to find seeds that match **except** for leiden "modularity" for which seeds 0-10_000 do not produce the communities used to construct the graph. I will look at that more as I do the next follow-up PR focused on core code and comments.

I also added a test with a barbell graph that has obvious communities in each weight(cliques) and the bar(path) between them.

Futher follow-up planned:
- [ ] optimization & readability
- [ ] revisit Louvain code/docs to use ideas that came up during the implementation of leiden.

Removed an unused helper function (it was commented as for debugging and named `_is_valid_refinement`)

Overall leiden seems to have quite variable results from run to run. We may want to explore whether to reduce variation by removing randomness in node order, or by choosing a different default theta value. Louvain is comparatively stable from run to run. Once resolution is chosen to produce about 3 communities, it always selects the correct communities.

Another oddity I've noticed is that varying `resolution` produces a smoother profile with "cpm" than with "modularity". By profile I mean as resolution is changed, "cpm" gives many smaller changes in number of communities. "moudularity" leads to fewer and larger changes in the number of communities.