### PR TITLE
Replace lambda with itemgetter in traveling_salesman.py

### DIFF
--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -35,7 +35,7 @@ http://en.wikipedia.org/wiki/Travelling_salesman_problem
 """
 
 import math
-
+from operator import itemgetter
 import networkx as nx
 from networkx.algorithms.tree.mst import random_spanning_tree
 from networkx.utils import not_implemented_for, pairwise, py_random_state
@@ -627,7 +627,8 @@ def held_karp_ascent(G, weight="weight"):
             # Delete the edge (N, v) so that we cannot pick it.
             edge_data = G[N][n]
             G.remove_edge(N, n)
-            min_weight = min(G.in_edges(n, data=weight), key=lambda x: x[2])[2]
+            min_weight = min(G.in_edges(n, data=weight), key=itemgetter(2))[2]
+
             min_edges = [
                 (u, v, d) for u, v, d in G.in_edges(n, data=weight) if d == min_weight
             ]


### PR DESCRIPTION
In traveling_salesman.py, replaced lambda function on line 630 with 
itemgetter(2) from the operator module for better performance.

Line 602 was skipped because it uses a variable inside the lambda 
(x[2][weight]) which itemgetter cannot handle cleanly.

Added `from operator import itemgetter` to imports.

Tests: 44 passed, 1 skipped.

Note: I used AI assistance during this contribution and have reviewed 
all changes manually.
