### PR TITLE
Avoid O(E) lookup in nx.display -issue8639

### DIFF
--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -575,11 +575,23 @@ def display(
     }
 
     # Check arguments
-    for kwarg in kwargs:
+    known_node_attr = {}
+    known_edge_attr = {}
+    for kwarg, kwarg_value in kwargs.items():
         if kwarg not in defaults:
             raise nx.NetworkXError(
                 f"Unrecognized visualization keyword argument: {kwarg}"
             )
+        if "node" in kwarg and not isinstance(kwarg_value, dict):
+            if any(kwarg_value in node_data for (_, node_data) in G.nodes(data=True)):
+                known_node_attr[kwarg_value] = True
+            elif kwarg_value == kwarg.split("_")[-1]:
+                kwargs[kwarg] = defaults[kwarg]
+        elif "edge" in kwarg and not isinstance(kwarg_value, dict):
+            if any(kwarg_value in edge_data for (*_, edge_data) in G.edges(data=True)):
+                known_edge_attr[kwarg_value] = True
+            elif kwarg_value == kwarg.split("_")[-1]:
+                kwargs[kwarg] = defaults[kwarg]
 
     if canvas is None:
         canvas = plt.gca()
@@ -615,7 +627,7 @@ def display(
         # attributes which are on the graph
         if (
             attr is not None
-            and nx.get_node_attributes(node_subgraph, attr) == {}
+            and not known_node_attr.get(attr, False)
             and any(attr == v for k, v in kwargs.items() if "node" in k)
         ):
             return [attr for _ in seq]
@@ -672,7 +684,7 @@ def display(
 
         if (
             attr is not None
-            and nx.get_edge_attributes(edge_subgraph, attr) == {}
+            and not known_edge_attr.get(attr, False)
             and any(attr == v for k, v in kwargs.items() if "edge" in k)
         ):
             return [attr for _ in seq]
@@ -691,7 +703,7 @@ def display(
 
         if (
             attr is not None
-            and nx.get_edge_attributes(edge_subgraph, attr) == {}
+            and not known_edge_attr.get(attr, False)
             and attr in kwargs.values()
         ):
             return attr
@@ -711,7 +723,7 @@ def display(
 
         if (
             attr is not None
-            and nx.get_node_attributes(subgraph, attr) == {}
+            and not known_node_attr.get(attr, False)
             and attr in kwargs.values()
         ):
             return attr
@@ -840,6 +852,8 @@ def display(
         )
         pos = default_display_pos_attr
         kwargs["node_pos"] = default_display_pos_attr
+
+    known_node_attr[pos] = True
 
     # Each shape requires a new scatter object since they can't have different
     # shapes.

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -582,15 +582,15 @@ def display(
             raise nx.NetworkXError(
                 f"Unrecognized visualization keyword argument: {kwarg}"
             )
-        if "node" in kwarg and not isinstance(kwarg_value, dict):
+        if kwarg.startswith("node_") and not isinstance(kwarg_value, dict):
             if any(kwarg_value in node_data for (_, node_data) in G.nodes(data=True)):
                 known_node_attr[kwarg_value] = True
-            elif kwarg_value == kwarg.split("_")[-1]:
+            elif kwarg_value == kwarg.split("_", 1)[1]:
                 kwargs[kwarg] = defaults[kwarg]
-        elif "edge" in kwarg and not isinstance(kwarg_value, dict):
+        elif kwarg.startswith("edge_") and not isinstance(kwarg_value, dict):
             if any(kwarg_value in edge_data for (*_, edge_data) in G.edges(data=True)):
                 known_edge_attr[kwarg_value] = True
-            elif kwarg_value == kwarg.split("_")[-1]:
+            elif kwarg_value == kwarg.split("_", 1)[1]:
                 kwargs[kwarg] = defaults[kwarg]
 
     if canvas is None:


### PR DESCRIPTION
Fixes #8639 

This PR is linked to issue #8639, in which a performance problem with the function `nx.display` was revealed. The concern origins in calling `nx.get_[node/edge]_attributes` inside a `for`. This was solved doing a pre-procesing over the parameters `kwargs`, introduced when the function is called, and considering the following cases for the values, as @dschult suggested:

- kwarg_value is a dict (node or edge keyed) -- Not treated in this PR, but check with isinstance if it's a dict.. This case is considered in the PR #8255 
- if the kwarg value is a key in any of the node/edge attributes in the entire graph, then it is a graph-attribute-name which we will use to look up the kwarg specific attribute value for each node. If it is not defined in some node/edge we use the default value.
- if the kwarg value is not any of these, assume it is a value that will be used throughout the graph.

The proposed solution is to create two dicts: `knwon_node_attr` and `known_edge_attr`. Which stores weather if kwarg_value is a graph-attribute-name of any node/edge of the graph respectively. This dict are updated when we set new node attributes to avoid future errors (so far only happens with position). Then we can change an O(E) lookup for a O(1) lookup:

```diff
- nx.get_node_attributes(node_subgraph, attr) == {}
+ not known_node_attr.get(attr, False)

- nx.get_edge_attributes(edge_subgraph, attr) == {}
+ not known_edge_attr.get(attr, False)
```

Note that we can't do this change in line 849 because `pos` might not be a kwarg_value and be defined in some node. 

Examples run in my machine:
Performance: 
```py
>>> B = nx.barabasi_albert_graph(400, m=3, seed=19320)
>>> %timeit -n1 -r1 nx.display(B)
1.41 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
```
An error of calling the function with the default value has been solved:
```py
>>> G = nx.Graph()
>>> G.add_edge(1,2); G.add_edge(2,3);
>>> nx.display(G, edge_color = 'color'); plt.show() # <-- Shows both edges black
```
Examples with different attributes
```py
>>> G = nx.Graph()
>>> G.add_edge(1,2, attr1 = 'red'); G.add_edge(2,3, color = 'blue');
>>> nx.display(G, edge_color = 'attr1'); plt.show() # <-- Plots (1,2) red and (2,3) gray
>>> nx.display(G); plt.show() # <-- Plots (1,2) black and (2,3) blue
>>> nx.display(G, edge_arrowstyle = '->', edge_arrowsize = 10); plt.show(); # <-- Shows (2,3) blue, both with arrows
```
Example defining specific position:
```py
>>> G = nx.Graph()
>>> G.add_edge(1,2); G.add_edge(2,3);
>>> nx.set_node_attributes(G, {1: [0,0], 2: [0,1], 3: [1,0]}, name='pos')
>>> nx.display(G); plt.show() # <-- nodes in specified positions
>>> nx.set_node_attributes(G, {1: [0,0], 2: [1,0], 3: [0,1]}, name='attr1')
>>> nx.display(G, node_pos = 'attr1'); plt.show() # <-- nodes in specified positions
```