### PR TITLE
Cleanup butterflies tests.

### DIFF
--- a/networkx/algorithms/bipartite/tests/test_cluster.py
+++ b/networkx/algorithms/bipartite/tests/test_cluster.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 
 import networkx as nx
@@ -84,56 +86,32 @@ def test_ra_clustering_zero():
     assert bipartite.robins_alexander_clustering(G) == 0
 
 
-# ---------------------------------------------------------------------------
-# Tests for butterflies()
-# ---------------------------------------------------------------------------
-
-
 class TestButterflies:
-    """Tests for bipartite.butterflies()."""
+    @pytest.mark.parametrize("n", range(2, 6))
+    @pytest.mark.parametrize("nodes", (None, [0, 1], {0, 1}, [0, 1, 2]))
+    def test_complete_bipartite_graph_equipartition(self, n, nodes):
+        """For the complete bipartite graph K_mn with m == n, the total number
+        of butterflies == (n choose 2) ** 2 and the number of
+        butterflies-per-node is (n choose 2) * (n - 1)"""
+        G = nx.complete_bipartite_graph(n, n)
+        butterflies = nx.bipartite.butterflies(G, nodes=nodes)
 
-    def make(self, left, right, edges):
-        G = nx.Graph()
-        G.add_nodes_from(left, bipartite=0)
-        G.add_nodes_from(right, bipartite=1)
-        G.add_edges_from(edges)
-        return G
+        expected_per_node = math.comb(n, 2) * (n - 1)
+        nodes_expected_in_result = set(G) if nodes is None else set(nodes)
+        assert set(butterflies) == nodes_expected_in_result
+        assert all(v == expected_per_node for v in butterflies.values())
+        if nodes is None:
+            expected_total = math.comb(n, 2) ** 2
+            assert sum(butterflies.values()) // 4 == expected_total
 
-    # -- total count (sum // 4) ---------------------------------------------
-
-    def test_k22_total(self):
-        G = self.make([0, 1], [2, 3], [(0, 2), (0, 3), (1, 2), (1, 3)])
-        assert sum(bipartite.butterflies(G).values()) // 4 == 1
-
-    def test_k33_total(self):
-        G = nx.complete_bipartite_graph(3, 3)
-        assert sum(bipartite.butterflies(G).values()) // 4 == 9
-
-    def test_k44_total(self):
-        G = nx.complete_bipartite_graph(4, 4)
-        assert sum(bipartite.butterflies(G).values()) // 4 == 36
-
-    def test_k55_total(self):
-        G = nx.complete_bipartite_graph(5, 5)
-        assert sum(bipartite.butterflies(G).values()) // 4 == 100
-
-    def test_empty_graph(self):
-        G = self.make([0, 1], [2, 3], [])
+    @pytest.mark.parametrize(
+        "G", [nx.empty_graph(4), nx.Graph([(0, 1)]), nx.path_graph(4), nx.star_graph(4)]
+    )
+    def test_no_butterflies(self, G):
         assert all(v == 0 for v in bipartite.butterflies(G).values())
 
-    def test_single_edge(self):
-        G = self.make([0], [1], [(0, 1)])
-        assert sum(bipartite.butterflies(G).values()) == 0
-
-    def test_path_no_butterfly(self):
-        G = self.make([0, 1], [2, 3], [(0, 2), (1, 2), (1, 3)])
-        assert sum(bipartite.butterflies(G).values()) // 4 == 0
-
-    def test_star_no_butterfly(self):
-        G = self.make([0], [1, 2, 3, 4], [(0, 1), (0, 2), (0, 3), (0, 4)])
-        assert sum(bipartite.butterflies(G).values()) // 4 == 0
-
     def test_two_disjoint_k22(self):
+        # Expect sum of butterflies from each component
         G = nx.Graph()
         G.add_nodes_from([0, 1, 4, 5], bipartite=0)
         G.add_nodes_from([2, 3, 6, 7], bipartite=1)
@@ -141,73 +119,22 @@ class TestButterflies:
         G.add_edges_from([(4, 6), (4, 7), (5, 6), (5, 7)])
         assert sum(bipartite.butterflies(G).values()) // 4 == 2
 
-    def test_three_shared_neighbours(self):
-        G = self.make(
-            [0, 1, 2],
-            [3, 4],
-            [(0, 3), (0, 4), (1, 3), (1, 4), (2, 3), (2, 4)],
-        )
+    def test_different_sized_partitions(self):
+        G = nx.complete_bipartite_graph(3, 2)
         assert sum(bipartite.butterflies(G).values()) // 4 == 3
 
-    # -- per-node counts ----------------------------------------------------
-
-    def test_k22_per_node(self):
-        G = self.make([0, 1], [2, 3], [(0, 2), (0, 3), (1, 2), (1, 3)])
-        assert bipartite.butterflies(G) == {0: 1, 1: 1, 2: 1, 3: 1}
-
-    def test_k33_per_node(self):
-        G = nx.complete_bipartite_graph(3, 3)
-        bt = bipartite.butterflies(G)
-        assert all(v == 6 for v in bt.values())
-
-    def test_per_node_sum_divisible_by_four(self):
-        # Each butterfly contributes to exactly 4 nodes, so sum is divisible by 4.
-        G = nx.complete_bipartite_graph(4, 4)
-        bt = bipartite.butterflies(G)
-        assert sum(bt.values()) % 4 == 0
-
     def test_isolated_node_zero(self):
-        G = self.make([0, 1, 99], [2, 3], [(0, 2), (0, 3), (1, 2), (1, 3)])
-        assert bipartite.butterflies(G)[99] == 0
-
-    def test_all_nodes_in_result(self):
-        G = self.make([0, 1], [2, 3], [(0, 2), (0, 3), (1, 2), (1, 3)])
-        assert set(bipartite.butterflies(G).keys()) == set(G.nodes())
-
-    # -- nodes= parameter ---------------------------------------------------
-
-    def test_nodes_param_keys(self):
-        G = self.make([0, 1], [2, 3], [(0, 2), (0, 3), (1, 2), (1, 3)])
-        bt = bipartite.butterflies(G, nodes=[0, 1])
-        assert set(bt.keys()) == {0, 1}
-
-    def test_nodes_param_correct_count(self):
-        # nodes= filters the output dict but does not affect the computation.
-        # Counts must match the full-graph result, matching nx.triangles() convention.
-        G = self.make([0, 1], [2, 3], [(0, 2), (0, 3), (1, 2), (1, 3)])
-        bt_full = bipartite.butterflies(G)
-        bt_sub = bipartite.butterflies(G, nodes=[0, 1])
-        assert bt_sub[0] == bt_full[0]
-        assert bt_sub[1] == bt_full[1]
+        G = nx.complete_bipartite_graph(2, 2)
+        G.add_node(99)
+        assert nx.bipartite.butterflies(G) == {0: 1, 1: 1, 2: 1, 3: 1, 99: 0}
 
     def test_nodes_param_absent_node_ignored(self):
-        # A node not in G should be silently ignored, matching nx.triangles() behaviour.
-        G = self.make([0, 1], [2, 3], [(0, 2), (0, 3), (1, 2), (1, 3)])
+        # Nodes not in G are silently ignored, matching nx.triangles() behavior
+        G = nx.complete_bipartite_graph(2, 2)
         bt = bipartite.butterflies(G, nodes=[0, 99])
         assert set(bt.keys()) == {0}
         assert bt[0] == 1
 
-    # -- error handling -----------------------------------------------------
-
     def test_directed_raises(self):
         with pytest.raises(nx.NetworkXNotImplemented):
             bipartite.butterflies(nx.DiGraph([(0, 1), (1, 2)]))
-
-    def test_disconnected_no_raise(self):
-        G = nx.Graph()
-        G.add_nodes_from([0, 1, 4, 5], bipartite=0)
-        G.add_nodes_from([2, 3, 6, 7], bipartite=1)
-        G.add_edges_from([(0, 2), (0, 3), (1, 2), (1, 3)])
-        G.add_edges_from([(4, 6), (4, 7), (5, 6), (5, 7)])
-        bt = bipartite.butterflies(G)  # must not raise AmbiguousSolution
-        assert sum(bt.values()) // 4 == 2


### PR DESCRIPTION
Followup to #8591 

Condense the `butterflies` test suite via test parametrization and removing "helper" functions.

The main change is generalizing the first test on complete_bipartite_graphs. This is now parametrized on `n` for `complete_bipartite_graph(n, n)`. The formulae for the expected total number of butterflies (n choose 2)**2 and number of butterflies-per-node (n choose 2) * (n - 1) have been added so that the test generalizes across `n`. Everything that was originally tested before the refactor is still covered!