### PR TITLE
Fix star graph node count in dual_barabasi_albert_graph comment

### DIFF
--- a/networkx/generators/random_graphs.py
+++ b/networkx/generators/random_graphs.py
@@ -760,7 +760,7 @@ def dual_barabasi_albert_graph(
         Initial network for Barabási–Albert algorithm.
         A copy of `initial_graph` is used.
         It should be connected for most use cases.
-        If None, starts from an star graph on max(m1, m2) + 1 nodes.
+        If None, starts from a star graph on max(m1, m2) + 1 nodes.
     create_using : Graph constructor, optional (default=nx.Graph)
         Graph type to create. If graph instance, then cleared before populated.
         Multigraph and directed types are not supported and raise a ``NetworkXError``.
@@ -801,7 +801,7 @@ def dual_barabasi_albert_graph(
         return barabasi_albert_graph(n, m2, seed, create_using=create_using)
 
     if initial_graph is None:
-        # Default initial graph : star graph on max(m1, m2) nodes
+        # Default initial graph : star graph on max(m1, m2) + 1 nodes
         G = star_graph(max(m1, m2), create_using)
     else:
         if len(initial_graph) < max(m1, m2) or len(initial_graph) > n:


### PR DESCRIPTION
Two small consistency fixes in `dual_barabasi_albert_graph` (`networkx/generators/random_graphs.py`):

1. The inline comment for the default initial graph said `# Default initial graph : star graph on max(m1, m2) nodes`, but the code is `star_graph(max(m1, m2), create_using)`, and `star_graph(k)` returns a graph with `k + 1` nodes. So the default has `max(m1, m2) + 1` nodes. The single-`m` `barabasi_albert_graph` already documents this correctly as `# Default initial graph : star graph on (m + 1) nodes`, and `dual_barabasi_albert_graph`'s own docstring already says `max(m1, m2) + 1 nodes` — only the comment was off.

2. Grammar: the `m_2` parameter docstring said "starts from **an** star graph"; the `m` docstring in `barabasi_albert_graph` correctly says "a star graph".

Comment/docstring only — no behavior change.
