### PR TITLE
Fix group_betweenness_centrality on directed and size-3+ groups

### DIFF
--- a/benchmarks/benchmarks/benchmark_group_centrality.py
+++ b/benchmarks/benchmarks/benchmark_group_centrality.py
@@ -1,0 +1,76 @@
+"""Benchmarks for group centrality algorithms."""
+
+import networkx as nx
+
+
+class GroupBetweennessCentralityBenchmarks:
+    timeout = 120
+    nodes = [10, 100, 1000]
+    params = (
+        [f"wheel_graph({i})" for i in nodes]
+        + [f"directed_wheel({i})" for i in nodes]
+        + [f"weighted_path_graph({i})" for i in nodes]
+    )
+    param_names = ["graph"]
+
+    def setup(self, graph):
+        def directed_wheel(n):
+            # bidirectional edges on the rim with directed edges to the central node
+            G = nx.DiGraph(nx.cycle_graph(range(1, n)))
+            G.add_node(0)
+            G.add_edges_from((0, i) for i in range(1, n))
+            return G
+
+        def weighted_path_graph(n):
+            G = nx.path_graph(n)
+            nx.set_edge_attributes(G, 1, "weight")
+            return G
+
+        self.graphs_dict = {}
+        self.single_node_groups = {}
+        self.node_subset_groups = {}
+        self.weights = {}
+        for n in self.nodes:
+            self.graphs_dict[f"wheel_graph({n})"] = nx.wheel_graph(n)
+            self.single_node_groups[f"wheel_graph({n})"] = [0]
+            self.node_subset_groups[f"wheel_graph({n})"] = [1, 2, 3]
+            self.weights[f"wheel_graph({n})"] = None
+
+            self.graphs_dict[f"directed_wheel({n})"] = directed_wheel(n)
+            self.single_node_groups[f"directed_wheel({n})"] = [0]
+            self.node_subset_groups[f"directed_wheel({n})"] = [1, 2, 3]
+            self.weights[f"directed_wheel({n})"] = None
+
+            self.graphs_dict[f"weighted_path_graph({n})"] = weighted_path_graph(n)
+            self.single_node_groups[f"weighted_path_graph({n})"] = [n // 2]
+            self.node_subset_groups[f"weighted_path_graph({n})"] = [
+                n // 4,
+                n // 2,
+                3 * n // 4,
+            ]
+            self.weights[f"weighted_path_graph({n})"] = "weight"
+
+    def time_group_betweenness_centrality_single_node(self, graph):
+        _ = nx.group_betweenness_centrality(
+            self.graphs_dict[graph],
+            self.single_node_groups[graph],
+            normalized=False,
+            weight=self.weights[graph],
+        )
+
+    def time_group_betweenness_centrality_node_subset(self, graph):
+        _ = nx.group_betweenness_centrality(
+            self.graphs_dict[graph],
+            self.node_subset_groups[graph],
+            normalized=False,
+            weight=self.weights[graph],
+        )
+
+    def time_group_betweenness_centrality_node_subset_endpoints(self, graph):
+        _ = nx.group_betweenness_centrality(
+            self.graphs_dict[graph],
+            self.node_subset_groups[graph],
+            normalized=False,
+            weight=self.weights[graph],
+            endpoints=True,
+        )

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -124,72 +124,51 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
     if set_v - G.nodes:  # element(s) of C not in G
         raise nx.NodeNotFound(f"The node(s) {set_v - G.nodes} are in C but not in G.")
 
-    # pre-processing
-    PB, sigma, D = _group_preprocessing(G, set_v, weight)
+    # shortest path DAG from each source, done once since it dont depend on the group
+    if weight is None:
+        shortest_paths = {s: _single_source_shortest_path_basic(G, s) for s in G}
+    else:
+        shortest_paths = {
+            s: _single_source_dijkstra_path_basic(G, s, weight) for s in G
+        }
 
-    # the algorithm for each group
+    directed = G.is_directed()
+    n = len(G)
+
     for group in C:
-        group = set(group)  # set of nodes in group
-        # initialize the matrices of the sigma and the PB
-        GBC_group = 0
-        sigma_m = deepcopy(sigma)
-        PB_m = deepcopy(PB)
-        sigma_m_v = deepcopy(sigma_m)
-        PB_m_v = deepcopy(PB_m)
-        for v in group:
-            GBC_group += PB_m[v][v]
-            for x in group:
-                for y in group:
-                    dxvy = 0
-                    dxyv = 0
-                    dvxy = 0
-                    if not (
-                        sigma_m[x][y] == 0 or sigma_m[x][v] == 0 or sigma_m[v][y] == 0
-                    ):
-                        if D[x][v] == D[x][y] + D[y][v]:
-                            dxyv = sigma_m[x][y] * sigma_m[y][v] / sigma_m[x][v]
-                        if D[x][y] == D[x][v] + D[v][y]:
-                            dxvy = sigma_m[x][v] * sigma_m[v][y] / sigma_m[x][y]
-                        if D[v][y] == D[v][x] + D[x][y]:
-                            dvxy = sigma_m[v][x] * sigma[x][y] / sigma[v][y]
-                    sigma_m_v[x][y] = sigma_m[x][y] * (1 - dxvy)
-                    PB_m_v[x][y] = PB_m[x][y] - PB_m[x][y] * dxvy
-                    if y != v:
-                        PB_m_v[x][y] -= PB_m[x][v] * dxyv
-                    if x != v:
-                        PB_m_v[x][y] -= PB_m[v][y] * dvxy
-            sigma_m, sigma_m_v = sigma_m_v, sigma_m
-            PB_m, PB_m_v = PB_m_v, PB_m
+        group = set(group)
+        c = len(group)
 
-        # endpoints
-        v, c = len(G), len(group)
-        if not endpoints:
-            scale = 0
-            # if the graph is connected then subtract the endpoints from
-            # the count for all the nodes in the graph. else count how many
-            # nodes are connected to the group's nodes and subtract that.
-            if nx.is_directed(G):
-                if nx.is_strongly_connected(G):
-                    scale = c * (2 * v - c - 1)
-            elif nx.is_connected(G):
-                scale = c * (2 * v - c - 1)
-            if scale == 0:
-                for group_node1 in group:
-                    for node in D[group_node1]:
-                        if node != group_node1:
-                            if node in group:
-                                scale += 1
-                            else:
-                                scale += 2
-            GBC_group -= scale
+        # for each ordered pair (s, t) add the fraction of shortest paths going
+        # through the group: (sigma - sigma_avoid) / sigma
+        GBC_group = 0.0
+        for s in G:
+            S, P, sigma, _ = shortest_paths[s]
+            if s in group:
+                if endpoints:
+                    GBC_group += sum(1 for t in S if t != s)
+                continue
+            sigma_avoid = {}
+            for w in S:
+                if w == s:
+                    sigma_avoid[w] = sigma[s]  # same scale, only the ratio matter
+                elif w in group:
+                    sigma_avoid[w] = 0.0
+                else:
+                    sigma_avoid[w] = sum(sigma_avoid[p] for p in P[w])
+            for t in S:
+                if t == s:
+                    continue
+                if t in group:
+                    if endpoints:
+                        GBC_group += 1.0
+                else:
+                    GBC_group += (sigma[t] - sigma_avoid[t]) / sigma[t]
 
-        # normalized
         if normalized:
-            scale = 1 / ((v - c) * (v - c - 1))
-            GBC_group *= scale
-
-        # If undirected than count only the undirected edges
-        elif not G.is_directed():
+            GBC_group *= 1 / ((n - c) * (n - c - 1))
+        # undirected counts each pair twice
+        elif not directed:
             GBC_group /= 2
 
         GBC.append(GBC_group)

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -100,6 +100,46 @@ class TestGroupBetweennessCentrality:
         b_answer = 5.0
         assert b == b_answer
 
+    def test_group_betweenness_directed_not_strongly_connected(self):
+        """
+        Group betweenness on a directed graph that is not strongly connected
+        (gh-8559). A single-node group must equal the per-node betweenness, and
+        multi-node groups must not raise and must give the correct value.
+        """
+        G = nx.path_graph(4, create_using=nx.DiGraph)  # 0 -> 1 -> 2 -> 3
+        per_node = nx.betweenness_centrality(G, normalized=False, endpoints=False)
+        for v in G:
+            b = nx.group_betweenness_centrality(
+                G, {v}, normalized=False, endpoints=False
+            )
+            assert b == per_node[v]
+        # multi-node groups previously raised KeyError on such graphs
+        assert (
+            nx.group_betweenness_centrality(
+                G, {0, 2}, normalized=False, endpoints=False
+            )
+            == 1.0
+        )
+
+    def test_group_betweenness_multinode_directed(self):
+        """
+        Groups of size >= 3 on a directed path (gh-8559). Only the pair (0, 4)
+        of non-group nodes has a path, and it passes through the group.
+        """
+        G = nx.path_graph(5, create_using=nx.DiGraph)  # 0 -> 1 -> 2 -> 3 -> 4
+        assert (
+            nx.group_betweenness_centrality(
+                G, {1, 2, 3}, normalized=False, endpoints=False
+            )
+            == 1.0
+        )
+        assert (
+            nx.group_betweenness_centrality(
+                G, {1, 3}, normalized=False, endpoints=False
+            )
+            == 3.0
+        )
+
 
 class TestProminentGroup:
     np = pytest.importorskip("numpy")


### PR DESCRIPTION
Fixes #8559.

## Summary

`group_betweenness_centrality` could return negative values or raise `KeyError` on directed non-strongly-connected graphs. The endpoint correction and pairwise overlap terms assumed reachability that these graphs do not guarantee.

this replaces the Puzis matrix approach with a direct computation so for each source count shortest paths through the group as

`(sigma - sigma_avoid) / sigma`

where `sigma_avoid` is computed by a predecessor-DAG DP over shortest paths avoiding the group.

This also fixes wrong results that were silent for groups of size 3 or larger across directed, undirected, and weighted graphs.

## Tests

Added two regression tests. Also checked against a brute-force reference, against `betweenness_centrality` for single-node groups, and against existing tests. Previously correct inputs keep the same output.

## Notes

`prominent_group` has a separate deeper bug so it's left for future follow ups.

Compared old vs new against a brute-force `nx.all_shortest_paths` ground truth on 2000 random graphs covering directed/undirected, weighted/unweighted, `n = 5–11` and group sizes 1–3:

```text
new == brute force: 2000/2000
old: 1574 correct, 300 wrong, 126 crashed with KeyError
time: new 0.156s, old 0.324s, about 2.1x faster
```

So the new version matches the ground truth in all cases tested and is considerably faster.

<details><summary>comparison script</summary>

```python
import random
import subprocess
import time

import networkx as nx

BASE = "96ad598c"  # commit just before the fix

src = subprocess.check_output(
    ["git", "show", f"{BASE}:networkx/algorithms/centrality/group.py"], text=True
)
src = "\n".join(ln for ln in src.splitlines() if "_dispatchable" not in ln)
ns = {}
exec(compile(src, "old_group", "exec"), ns)
old_gbc = ns["group_betweenness_centrality"]
new_gbc = nx.group_betweenness_centrality


def brute_force(G, group, weight=None):
    group = set(group)
    directed = G.is_directed()
    total = 0.0
    for s in G:
        if s in group:
            continue
        for t in G:
            if t == s or t in group:
                continue
            try:
                paths = list(nx.all_shortest_paths(G, s, t, weight=weight))
            except nx.NetworkXNoPath:
                continue
            total += sum(1 for p in paths if any(n in group for n in p)) / len(paths)
    return total if directed else total / 2


rng = random.Random(0)
trials = 2000
new_ok = old_ok = old_wrong = old_crash = 0
t_new = t_old = 0.0

for _ in range(trials):
    n = rng.randint(5, 11)
    G = nx.gnp_random_graph(n, rng.uniform(0.25, 0.6),
                            seed=rng.randint(0, 1 << 30), directed=rng.random() < 0.5)
    weight = None
    if rng.random() < 0.5:
        for _, _, d in G.edges(data=True):
            d["weight"] = rng.randint(1, 5)
        weight = "weight"
    group = rng.sample(list(G), rng.randint(1, 3))

    ref = brute_force(G, group, weight=weight)

    t0 = time.perf_counter()
    new_val = new_gbc(G, group, weight=weight, normalized=False, endpoints=False)
    t_new += time.perf_counter() - t0
    new_ok += abs(new_val - ref) <= 1e-6

    t0 = time.perf_counter()
    try:
        old_val = old_gbc(G, group, weight=weight, normalized=False, endpoints=False)
        t_old += time.perf_counter() - t0
        if abs(old_val - ref) <= 1e-6:
            old_ok += 1
        else:
            old_wrong += 1
    except Exception:
        t_old += time.perf_counter() - t0
        old_crash += 1

print(f"new == brute force: {new_ok}/{trials}")
print(f"old: {old_ok} correct, {old_wrong} wrong, {old_crash} crashed")
print(f"time: new {t_new:.3f}s, old {t_old:.3f}s, {t_old / t_new:.1f}x")
```

## AI disclosure

I used an AI assistant to help double check the code + make sure I didn't miss anything stupid + run some local tests