### PR TITLE
DOC: note directed-graph behaviour in degree_centrality

### DIFF
--- a/networkx/algorithms/centrality/degree_alg.py
+++ b/networkx/algorithms/centrality/degree_alg.py
@@ -29,8 +29,16 @@ def degree_centrality(G):
     >>> nx.degree_centrality(G)
     {0: 1.0, 1: 1.0, 2: 0.6666666666666666, 3: 0.6666666666666666}
 
+    On a directed graph this sums the in- and out-degree, so the values
+    can exceed ``1``:
+
+    >>> D = nx.DiGraph([(1, 2), (1, 3), (2, 3), (3, 1)])
+    >>> nx.degree_centrality(D)
+    {1: 1.5, 2: 1.0, 3: 1.5}
+
     See Also
     --------
+    in_degree_centrality, out_degree_centrality
     betweenness_centrality, load_centrality, eigenvector_centrality
 
     Notes
@@ -41,6 +49,11 @@ def degree_centrality(G):
     For multigraphs or graphs with self loops the maximum degree might
     be higher than n-1 and values of degree centrality greater than 1
     are possible.
+
+    For a directed graph, ``G.degree()`` returns the sum of in- and
+    out-degree, so the values can lie in ``[0, 2]`` rather than ``[0, 1]``.
+    Use :func:`in_degree_centrality` or :func:`out_degree_centrality` if
+    you want the directed components on their own.
     """
     if len(G) <= 1:
         return {n: 1 for n in G}


### PR DESCRIPTION
\`degree_centrality\` on a \`DiGraph\` sums in- and out-degree and divides by \`N - 1\`, so values can land in \`[0, 2]\` rather than \`[0, 1]\`. The Notes section already calls out multigraphs and self-loops as range exceptions but didn't mention the directed case. Per @rossbar and @dschult in #8657, the preference is docs over a runtime warning.

Added a directed example to the docstring, an explicit \`[0, 2]\` range note, and cross-references to \`in_degree_centrality\` / \`out_degree_centrality\` in See Also.

AI use: Claude helped me draft the prose. I verified the docstring example output in a local Python session and read the maintainer discussion on the issue before committing.

fixes #8657