### PR TITLE
Fix typo in floyd_warshall_tree comment

### DIFF
--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -35,7 +35,7 @@ http://en.wikipedia.org/wiki/Travelling_salesman_problem
 """
 
 import math
-
+from operator import itemgetter
 import networkx as nx
 from networkx.algorithms.tree.mst import random_spanning_tree
 from networkx.utils import not_implemented_for, pairwise, py_random_state
@@ -627,7 +627,8 @@ def held_karp_ascent(G, weight="weight"):
             # Delete the edge (N, v) so that we cannot pick it.
             edge_data = G[N][n]
             G.remove_edge(N, n)
-            min_weight = min(G.in_edges(n, data=weight), key=lambda x: x[2])[2]
+            min_weight = min(G.in_edges(n, data=weight), key=itemgetter(2))[2]
+
             min_edges = [
                 (u, v, d) for u, v, d in G.in_edges(n, data=weight) if d == min_weight
             ]

--- a/networkx/algorithms/shortest_paths/dense.py
+++ b/networkx/algorithms/shortest_paths/dense.py
@@ -217,7 +217,7 @@ def floyd_warshall_tree(G, weight="weight"):
     inf = float("inf")
     pred, dist = _init_pred_dist(G, weight)
 
-    # dont check for those w, `from` which `no` path exists
+    # don't check for those w, `from` which `no` path exists
     for w, pred_w in pred.items():
         # out_w will store the adjacency list of the OUT_W tree of the paper,
         # it is a tree, parent --> list of children


### PR DESCRIPTION
Fix typo in comment in `floyd_warshall_tree`: `dont` → `don't`
