### PR TITLE
DOC: Clarify degree_centrality behavior for directed graphs

### DIFF
--- a/networkx/algorithms/centrality/degree_alg.py
+++ b/networkx/algorithms/centrality/degree_alg.py
@@ -11,7 +11,8 @@ def degree_centrality(G):
     """Compute the degree centrality for nodes.
 
     The degree centrality for a node v is the fraction of nodes it
-    is connected to.
+    is connected to. For directed graphs it is the average number
+    of in and out edges per node.
 
     Parameters
     ----------
@@ -28,17 +29,22 @@ def degree_centrality(G):
     >>> G = nx.Graph([(0, 1), (0, 2), (0, 3), (1, 2), (1, 3)])
     >>> nx.degree_centrality(G)
     {0: 1.0, 1: 1.0, 2: 0.6666666666666666, 3: 0.6666666666666666}
-    
-    For directed graphs, values can exceed 1.0:
+
+    For directed graphs, values are in [0, 2] and use the sum of in-degree and
+    out-degree. Consider `in_degree_centrality` and `out_degree_centrality` for
+    directed graphs too.
 
     >>> D = nx.DiGraph([(0, 1), (0, 2), (1, 2), (2, 0)])
     >>> nx.degree_centrality(D)
     {0: 1.5, 1: 1.0, 2: 1.5}
-    
 
     See Also
     --------
-    betweenness_centrality, load_centrality, eigenvector_centrality, in_degree_centrality, out_degree_centrality
+    betweenness_centrality
+    load_centrality
+    eigenvector_centrality
+    in_degree_centrality
+    out_degree_centrality
 
     Notes
     -----
@@ -48,8 +54,7 @@ def degree_centrality(G):
     For multigraphs or graphs with self loops the maximum degree might
     be higher than n-1 and values of degree centrality greater than 1
     are possible.
-    
-    For directed graphs the degree centrality is calculated using the sum of in-degree and out-degree of each node, so values can be from  0 to 2. Consider using ``in_degree_centrality`` and ``out_degree_centrality`` instead.
+
     """
     if len(G) <= 1:
         return {n: 1 for n in G}

--- a/networkx/algorithms/centrality/degree_alg.py
+++ b/networkx/algorithms/centrality/degree_alg.py
@@ -28,10 +28,17 @@ def degree_centrality(G):
     >>> G = nx.Graph([(0, 1), (0, 2), (0, 3), (1, 2), (1, 3)])
     >>> nx.degree_centrality(G)
     {0: 1.0, 1: 1.0, 2: 0.6666666666666666, 3: 0.6666666666666666}
+    
+    For directed graphs, values can exceed 1.0:
+
+    >>> D = nx.DiGraph([(0, 1), (0, 2), (1, 2), (2, 0)])
+    >>> nx.degree_centrality(D)
+    {0: 1.5, 1: 1.0, 2: 1.5}
+    
 
     See Also
     --------
-    betweenness_centrality, load_centrality, eigenvector_centrality
+    betweenness_centrality, load_centrality, eigenvector_centrality, in_degree_centrality, out_degree_centrality
 
     Notes
     -----
@@ -41,6 +48,8 @@ def degree_centrality(G):
     For multigraphs or graphs with self loops the maximum degree might
     be higher than n-1 and values of degree centrality greater than 1
     are possible.
+    
+    For directed graphs the degree centrality is calculated using the sum of in-degree and out-degree of each node, so values can be from  0 to 2. Consider using ``in_degree_centrality`` and ``out_degree_centrality`` instead.
     """
     if len(G) <= 1:
         return {n: 1 for n in G}


### PR DESCRIPTION
degree_centrality() in networkx gives greater than 1.0 when use it on directed graph 
so not changing the behaviour of tis just making a documentation about this what it does for directed graphs. so that users can use it and dont get confused.
Added an example - showing directed graph where values exceed 1 - so that user can see it themselves .
Added to see also -  pointed users to in_degree_centrality and out_degree_centrality which are better choice for directed graphs .
Added a note explaining why go upto 2 for directed graphs - beacuse it sums in-degree + out-degree.