### PR TITLE
DO NOT MERGE: See if test fails on main in CI.

### DIFF
--- a/networkx/utils/tests/test_decorators.py
+++ b/networkx/utils/tests/test_decorators.py
@@ -508,3 +508,27 @@ finally:
         next(node_iter)
         with pytest.raises(StopIteration):
             next(node_iter)
+
+    def test_lazy_compile_thread_safety(self):
+        # Regression test for gh-8658.
+        import threading
+
+        n = 64
+        wrappers = [argmap(lambda x: x, 0)(lambda x, s=s: s) for s in range(n)]
+        barrier = threading.Barrier(n)
+        errors = []
+
+        def worker(start):
+            barrier.wait()
+            try:
+                for i in range(n):
+                    assert wrappers[(start + i) % n](None) == (start + i) % n
+            except Exception as e:
+                errors.append(repr(e))
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert not errors, errors[:3]

--- a/networkx/utils/tests/test_decorators.py
+++ b/networkx/utils/tests/test_decorators.py
@@ -513,7 +513,7 @@ finally:
         # Regression test for gh-8658.
         import threading
 
-        n = 64
+        n = 1024
         wrappers = [argmap(lambda x: x, 0)(lambda x, s=s: s) for s in range(n)]
         barrier = threading.Barrier(n)
         errors = []


### PR DESCRIPTION
Just experimenting with the test proposed in #8659 

As noted in the discussion there and the linked issue, the likelihood of test failure is correlated to the ratio of spawned threads to available cores. I've validated this locally on variously-sized systems (m2 linux aarch64, ryzen 9590X) but I'm curious what happens in CI.