### PR TITLE
DOC: Add Returns, Raises and Examples to has_path docstring

### DIFF
--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -31,6 +31,32 @@ def has_path(G, source, target):
 
     target : node
        Ending node for path
+
+    Returns
+    -------
+    bool
+        True if a path exists between `source` and `target`, False otherwise.
+
+    Raises
+    ------
+    NodeNotFound
+        If `source` or `target` is not in `G`.
+
+    Examples
+    --------
+    >>> G = nx.path_graph(4)
+    >>> nx.has_path(G, 0, 3)
+    True
+
+    There is no path to an isolated node:
+
+    >>> G.add_node(4)
+    >>> nx.has_path(G, 0, 4)
+    False
+
+    See Also
+    --------
+    shortest_path
     """
     try:
         nx.shortest_path(G, source, target)


### PR DESCRIPTION
## Summary

The `has_path` docstring only documented its parameters — it had no `Returns`, `Raises`, or `Examples` section, unlike the other functions in `shortest_paths/generic.py`.

This PR adds:
- **Returns** — documents that it returns a `bool`.
- **Raises** — `NodeNotFound` is propagated when `source` or `target` is not in `G` (consistent with `shortest_path`).
- **Examples** — a short, runnable example showing a positive case and an isolated-node case.
- A **See Also** pointer to `shortest_path`.

## Verification

```
$ pytest --doctest-modules networkx/algorithms/shortest_paths/generic.py -q
7 passed
```

Docstring-only change; no behavior is modified.