### PR TITLE
DOC: add floating point example to minimum_spanning_tree docstring

### DIFF
--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -597,6 +597,25 @@ def minimum_spanning_tree(G, weight="weight", algorithm="kruskal", ignore_nan=Fa
     >>> sorted(T.edges(data=True))
     [(0, 1, {}), (1, 2, {}), (2, 3, {})]
 
+    Edge weights are compared as exact floating point numbers, so two weights
+    that look equal may differ by a tiny rounding error and change which edge
+    is dropped from a cycle. Here the edge ``(0, 1)`` is removed even though its
+    weight ``0.1 + 0.2`` is mathematically equal to ``0.3``, because in floating
+    point ``0.1 + 0.2`` is slightly larger than ``0.3``:
+
+    >>> 0.1 + 0.2 > 0.3
+    True
+    >>> G = nx.cycle_graph(3)
+    >>> G.add_edge(0, 1, weight=0.1 + 0.2)
+    >>> G.add_edge(1, 2, weight=0.3)
+    >>> G.add_edge(0, 2, weight=0.3)
+    >>> T = nx.minimum_spanning_tree(G)
+    >>> sorted(T.edges())
+    [(0, 2), (1, 2)]
+
+    To avoid such surprises, scale the weights to integers (for example by
+    multiplying by a power of ten) before building the tree. See the
+    :doc:`tutorial </tutorial>` for more on floating point considerations.
 
     Notes
     -----


### PR DESCRIPTION
Follow-up to #8389.

The four flow/cut functions listed in #8389 are already being handled in other PRs, and the issue invites adding floating point examples to *other* affected functions. Spanning-tree algorithms compare edge weights to decide which edge to drop from each cycle, so they are subject to the same floating point pitfalls discussed in #8324 and #8325.

This adds an example to the `minimum_spanning_tree` docstring showing how two weights that look equal (`0.1 + 0.2` vs `0.3`) can differ by a rounding error and change which edge is removed, and points readers to the tutorial section on floating point considerations added in #8324.

### Notes
- Example output is deterministic and platform-independent (`0.1 + 0.2 > 0.3` holds on all IEEE-754 doubles).
- Doctests pass (`testmod` on `mst.py`: 58 attempted, 0 failed) and `black` reports no changes.
- Scoped to a single function per the maintainer note that there is "no need to tackle them all in one PR."