### PR TITLE
DOC: add floating point example to max_weight_matching docstring

### DIFF
--- a/networkx/algorithms/matching.py
+++ b/networkx/algorithms/matching.py
@@ -353,6 +353,26 @@ def max_weight_matching(G, maxcardinality=False, weight="weight"):
     >>> sorted(nx.max_weight_matching(G))
     [(2, 4), (5, 3)]
 
+    The weight of a matching is the *sum* of its edge weights, which are
+    compared as exact floating point numbers. Two weights that look equal may
+    differ by a tiny rounding error and change which matching is selected. Here
+    the edge ``(0, 1)`` is matched even though its weight ``0.1 + 0.2`` is
+    mathematically equal to the ``0.3`` weights of the other two edges, because
+    in floating point ``0.1 + 0.2`` is slightly larger than ``0.3``:
+
+    >>> 0.1 + 0.2 > 0.3
+    True
+    >>> G = nx.Graph()
+    >>> G.add_edge(0, 1, weight=0.1 + 0.2)
+    >>> G.add_edge(1, 2, weight=0.3)
+    >>> G.add_edge(0, 2, weight=0.3)
+    >>> sorted(nx.max_weight_matching(G))
+    [(1, 0)]
+
+    To avoid such surprises, scale the weights to integers (for example by
+    multiplying by a power of ten) before computing the matching. See the
+    :doc:`tutorial </tutorial>` for more on floating point considerations.
+
     Notes
     -----
     If G has edges with weight attributes the edge data are used as


### PR DESCRIPTION
Follow-up to #8389.

The flow/cut functions listed in #8389 and `minimum_spanning_tree` are already being handled in other PRs, and the issue invites adding floating point examples to *other* affected functions. `max_weight_matching` maximises the sum of edge weights, so it is one of the "any time a min or max value is computed" cases discussed in #8324 and #8325. Its docstring already notes that floating point weights "could return a slightly suboptimal matching due to numeric precision errors", but it did not show an example of this.

This adds an example to the `max_weight_matching` docstring on a small triangle where edge `(0, 1)` is matched only because its weight `0.1 + 0.2` is slightly larger than the `0.3` weights of the other two edges, even though the three are mathematically equal. It then points readers to the tutorial section on floating point considerations and the recommended pattern of scaling weights to integers.

### Notes
- The example output is deterministic and platform-independent (`0.1 + 0.2 > 0.3` holds on all IEEE-754 doubles).
- Doctests pass for `max_weight_matching`, and `black`/`ruff` report no changes.
- Scoped to a single function per the maintainer note that there is "no need to tackle them all in one PR".