### PR TITLE
DOC: add floating point example to maximum_spanning_tree docstring

### DIFF
--- a/networkx/algorithms/tree/mst.py
+++ b/networkx/algorithms/tree/mst.py
@@ -723,6 +723,26 @@ def maximum_spanning_tree(G, weight="weight", algorithm="kruskal", ignore_nan=Fa
     >>> sorted(T.edges(data=True))
     [(0, 1, {}), (0, 3, {'weight': 2}), (1, 2, {})]
 
+    Edge weights are compared as exact floating point numbers, so two weights
+    that look equal may differ by a tiny rounding error and change which edge
+    is kept from a cycle. Here the edge ``(0, 1)`` is kept while ``(1, 2)`` is
+    dropped even though their weights ``0.1 + 0.2`` and ``0.3`` are
+    mathematically equal, because in floating point ``0.1 + 0.2`` is slightly
+    larger than ``0.3``:
+
+    >>> 0.1 + 0.2 > 0.3
+    True
+    >>> G = nx.cycle_graph(3)
+    >>> G.add_edge(0, 1, weight=0.1 + 0.2)
+    >>> G.add_edge(1, 2, weight=0.3)
+    >>> G.add_edge(0, 2, weight=1.0)
+    >>> T = nx.maximum_spanning_tree(G)
+    >>> sorted(T.edges())
+    [(0, 1), (0, 2)]
+
+    To avoid such surprises, scale the weights to integers (for example by
+    multiplying by a power of ten) before building the tree. See the
+    :doc:`tutorial </tutorial>` for more on floating point considerations.
 
     Notes
     -----


### PR DESCRIPTION
## What this does

Adds a floating-point handling example to the `maximum_spanning_tree` docstring, following up on #8389.

This mirrors the example added to `minimum_spanning_tree` in #8681. `maximum_spanning_tree` has the symmetric behaviour: when a cycle contains two edges whose weights are *mathematically* equal but differ by a tiny rounding error, the exact float comparison decides which edge the tree keeps. The example shows that the edge `(0, 1)` with weight `0.1 + 0.2` is kept over `(1, 2)` with weight `0.3`, because in floating point `0.1 + 0.2` is slightly larger than `0.3`. It then points to the integer-scaling workaround and the tutorial, consistent with the recommended pattern from #8324 / #8325.

## Example added

```pycon
>>> 0.1 + 0.2 > 0.3
True
>>> G = nx.cycle_graph(3)
>>> G.add_edge(0, 1, weight=0.1 + 0.2)
>>> G.add_edge(1, 2, weight=0.3)
>>> G.add_edge(0, 2, weight=1.0)
>>> T = nx.maximum_spanning_tree(G)
>>> sorted(T.edges())
[(0, 1), (0, 2)]
```

## Checks

- Doctest passes (`doctest.testmod` on `networkx/algorithms/tree/mst.py`: 58 attempted, 0 failed).
- `black --check` and `ruff check` clean.
- Documentation-only change; no behaviour change.

Part of #8389.