### PR TITLE
MAINT: Fix ci permissions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: [labeled, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   ## This code below is to make sure a new commit on a PR with the label
   ## retriggers the benchmark, otherwise the label needs to be removed and
@@ -14,9 +17,11 @@ jobs:
     outputs:
       result: ${{ steps.check.outputs.result }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         name: Check for benchmark label and new commit
         id: check
         with:
@@ -38,21 +43,24 @@ jobs:
     # if: contains(github.event.pull_request.labels.*.name, 'run:benchmark') || ${{ github.event.label.name == 'run:benchmark' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: benchmark
 
       - name: Run benchmarks
         id: benchmark
+        env:
+          PULL_REQUEST_BASE_LABEL: ${{ github.event.pull_request.base.label }}
+          PULL_REQUEST_HEAD_LABEL: ${{ github.event.pull_request.head.label }}
         run: |
           set -euxo pipefail
 
-          echo "Baseline:  ${{ github.event.pull_request.base.sha }} (${{ github.event.pull_request.base.label }})"
-          echo "Contender: ${GITHUB_SHA} (${{ github.event.pull_request.head.label }})"
+          echo "Baseline:  ${{ github.event.pull_request.base.sha }} (${PULL_REQUEST_BASE_LABEL})"
+          echo "Contender: ${GITHUB_SHA} (${PULL_REQUEST_HEAD_LABEL})"
 
           pixi run -e benchmark benchmark-continuous \
               ${{ github.event.pull_request.base.sha }} ${GITHUB_SHA} \
@@ -63,7 +71,7 @@ jobs:
              exit 1
           fi
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: asv-benchmark-results-${{ runner.os }}

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,5 +1,8 @@
 name: circleci
 
+permissions:
+  contents: read
+
 on: [status]
 jobs:
   image:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,14 +4,19 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   documentation:
     # Do not attempt to deploy documentation on forks
     if: github.repository_owner == 'networkx'
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: docs
       - name: Register graphviz plugins
@@ -30,7 +35,7 @@ jobs:
       #   - Make sure the name is the same as below: CI_DEPLOY_KEY
       - name: Install SSH agent
         if: github.ref == 'refs/heads/main'
-        uses: webfactory/ssh-agent@v0.10.0
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.CI_DEPLOY_KEY }}
 
@@ -40,7 +45,7 @@ jobs:
 
       - name: Deploy docs
         if: github.ref == 'refs/heads/main'
-        uses: JamesIves/github-pages-deploy-action@releases/v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # releases/v4
         with:
           git-config-name: nx-doc-deploy-bot
           git-config-email: nx-doc-deploy-bot@nomail

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: style
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -10,8 +13,10 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: lint
       - name: Lint

--- a/.github/workflows/milestone-merged-prs.yaml
+++ b/.github/workflows/milestone-merged-prs.yaml
@@ -7,6 +7,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   milestone_pr:
     name: attach to PR

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -6,12 +6,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   type-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: type-check
       - name: Run mypy

--- a/.github/workflows/nightly-release-test.yml
+++ b/.github/workflows/nightly-release-test.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 0 * * 0"
 
+permissions:
+  contents: read
+
 jobs:
   nightly:
     runs-on: ${{ matrix.os }}-latest
@@ -12,9 +15,11 @@ jobs:
         os: [ubuntu, macos]
         python-version: ["3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,14 +3,20 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
 jobs:
   cron:
     # Do not attempt to upload nightly through forks
     if: github.repository_owner == 'networkx'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: build-release
       - name: Build a wheel and a sdist

--- a/.github/workflows/pytest-randomly.yml
+++ b/.github/workflows/pytest-randomly.yml
@@ -4,13 +4,18 @@ on:
     # Run this workflow once a day
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   randomize-test-order:
     if: github.repository == 'networkx/networkx'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: test-randomly
       - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
     tags:
       - networkx-*
 
+permissions:
+  contents: read
+
 jobs:
   pypi-publish:
     name: upload release to PyPI
@@ -17,10 +20,11 @@ jobs:
       attestations: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
-      - uses: prefix-dev/setup-pixi@v0.9.6
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: build-release
       - name: Build wheels
@@ -35,4 +39,4 @@ jobs:
           subject-path: "dist/networkx-*"
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   base:
     runs-on: ${{ matrix.os }}-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,6 @@ jobs:
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: ${{ matrix.environment }}
-          persist-credentials: false
       - name: Test for warnings at import time
         run: pixi run -e ${{ matrix.environment }} check-import
       - name: Test NetworkX
@@ -55,7 +54,6 @@ jobs:
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: test-default-no-scipy-py312
-          persist-credentials: false
       - name: Test for warnings at import time
         run: pixi run -e test-default-no-scipy-py312 check-import
       - name: Test NetworkX
@@ -70,7 +68,6 @@ jobs:
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: test-default-py314
-          persist-credentials: false
       - name: Test Dispatching
         run: pixi run -e test-default-py314 test-dispatch
 
@@ -87,7 +84,6 @@ jobs:
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: ${{ matrix.environment }}
-          persist-credentials: false
       - name: Register graphviz plugins
         run: pixi run -e ${{ matrix.environment }} dot -c
       - name: Test NetworkX
@@ -106,7 +102,6 @@ jobs:
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: ${{ matrix.environment }}
-          persist-credentials: false
       - name: Install pre-release packages
         run: pixi run -e ${{ matrix.environment }} install-prerelease
       - name: Test NetworkX
@@ -121,7 +116,6 @@ jobs:
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: test-default-py313
-          persist-credentials: false
       - name: Run slow tests
         # NOTE: --runslow adds slow tests to the collection while -m slow
         # filters out tests that are *not* marked slow, leaving only the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,10 @@ jobs:
         os: [ubuntu, macos, windows]
         environment: [test-base-py313, test-base-py314, test-base-py314t]
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: ${{ matrix.environment }}
       - name: Test NetworkX
@@ -32,10 +34,13 @@ jobs:
         environment:
           [test-default-py312, test-default-py313, test-default-py314]
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: ${{ matrix.environment }}
+          persist-credentials: false
       - name: Test for warnings at import time
         run: pixi run -e ${{ matrix.environment }} check-import
       - name: Test NetworkX
@@ -44,10 +49,13 @@ jobs:
   default-without-scipy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: test-default-no-scipy-py312
+          persist-credentials: false
       - name: Test for warnings at import time
         run: pixi run -e test-default-no-scipy-py312 check-import
       - name: Test NetworkX
@@ -56,10 +64,13 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: test-default-py314
+          persist-credentials: false
       - name: Test Dispatching
         run: pixi run -e test-default-py314 test-dispatch
 
@@ -70,10 +81,13 @@ jobs:
         os: [ubuntu, macos, windows]
         environment: [test-extra-py312, test-extra-py313]
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: ${{ matrix.environment }}
+          persist-credentials: false
       - name: Register graphviz plugins
         run: pixi run -e ${{ matrix.environment }} dot -c
       - name: Test NetworkX
@@ -86,10 +100,13 @@ jobs:
         os: [ubuntu, macos]
         environment: [prerelease-py312, prerelease-py313, prerelease-py314]
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: ${{ matrix.environment }}
+          persist-credentials: false
       - name: Install pre-release packages
         run: pixi run -e ${{ matrix.environment }} install-prerelease
       - name: Test NetworkX
@@ -98,10 +115,13 @@ jobs:
   slow-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           environments: test-default-py313
+          persist-credentials: false
       - name: Run slow tests
         # NOTE: --runslow adds slow tests to the collection while -m slow
         # filters out tests that are *not* marked slow, leaving only the

--- a/.github/workflows/weekly-dispatch.yml
+++ b/.github/workflows/weekly-dispatch.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 0 * * 0" # Every Sunday at midnight UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -17,9 +20,11 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
I used `zizmor` to identify security issues in our `.github/workflows`. 
It pointed out we can
- set default permissions to `read`
- use SHAs instead of version tags to identify which actions script to use
- turn off persist-credentials to limit dangers of token use
- avoid template expansions which happen in the scope of user code by setting a variable before `run:` and then using shell variable expansion. The variable is set outside of the scope that user code can reach, and then a variable expansion is done in the `run:` which has built in containment.

So I did those things.

One danger is still reported, but I can't see why it is a danger for us. I'll look more. zizmor reports that using `pull_request_target` is often done in an unsafe way. But I think we are using it just fine here. That can be another PR if needed.