### PR TITLE
MAINT: Remove unused local variables in _extrema_bounding

### DIFF
--- a/networkx/algorithms/distance_measures.py
+++ b/networkx/algorithms/distance_measures.py
@@ -142,8 +142,8 @@ def _extrema_bounding(G, compute="diameter", weight=None):
         for i in candidates:
             # update eccentricity bounds
             d = dist[i]
-            ecc_lower[i] = low = max(ecc_lower[i], max(d, (current_ecc - d)))
-            ecc_upper[i] = upp = min(ecc_upper[i], current_ecc + d)
+            ecc_lower[i] = max(ecc_lower[i], max(d, (current_ecc - d)))
+            ecc_upper[i] = min(ecc_upper[i], current_ecc + d)
 
             # update min/max values of lower and upper bounds
             minlower = min(ecc_lower[i], minlower)


### PR DESCRIPTION
### Summary

`_extrema_bounding` (the shared backend for `diameter`, `radius`, `eccentricity`, `center`, and `periphery`) contains two dead chained-assignment targets in its bound-update loop:

```python
ecc_lower[i] = low = max(ecc_lower[i], max(d, (current_ecc - d)))
ecc_upper[i] = upp = min(ecc_upper[i], current_ecc + d)
```

The names `low` and `upp` are never read anywhere in the function — they look like leftovers from the commented-out debug `print` directly above this loop. This drops the unused bindings:

```python
ecc_lower[i] = max(ecc_lower[i], max(d, (current_ecc - d)))
ecc_upper[i] = min(ecc_upper[i], current_ecc + d)
```

The computed values are still stored in `ecc_lower`/`ecc_upper`, so the behavior is identical. These aren't flagged by CI because pyflakes (`F`) is disabled in the ruff config.

### Verification

- `black --check` and the CI-enabled `ruff` rules pass on the file.
- Module doctests pass (19 attempted, 0 failed).
- Sanity-checked `diameter`/`radius`/`center`/`periphery`/`eccentricity` on path, cycle, and Petersen graphs — results unchanged.