### PR TITLE
reject out-of-range bytes in graph6/sparse6 decoders

### DIFF
--- a/networkx/readwrite/graph6.py
+++ b/networkx/readwrite/graph6.py
@@ -118,7 +118,7 @@ def from_graph6_bytes(bytes_in):
         bytes_in = bytes_in[10:]
 
     data = [c - 63 for c in bytes_in]
-    if any(c > 63 for c in data):
+    if any(c < 0 or c > 63 for c in data):
         raise ValueError("each input character must be in range(63, 127)")
 
     n, data = data_to_n(data)

--- a/networkx/readwrite/sparse6.py
+++ b/networkx/readwrite/sparse6.py
@@ -141,6 +141,8 @@ def from_sparse6_bytes(string):
         raise nx.NetworkXError("Expected leading colon in sparse6")
 
     chars = [c - 63 for c in string[1:]]
+    if any(c < 0 or c > 63 for c in chars):
+        raise ValueError("each input character must be in range(63, 127)")
     n, data = data_to_n(chars)
     k = 1
     while 1 << k < n:

--- a/networkx/readwrite/tests/test_graph6.py
+++ b/networkx/readwrite/tests/test_graph6.py
@@ -16,7 +16,7 @@ def test_from_graph6_invariant_to_trailing_newline():
 
 def test_from_graph6_raises_header_newline():
     """graph6 headers must not be followed by a newline. See gh-7557."""
-    with pytest.raises(nx.NetworkXError):
+    with pytest.raises(ValueError):
         G = nx.from_graph6_bytes(b">>graph6<<\nP~~~~~~~~~~~~~~~~~~~~~~{")
 
 
@@ -44,6 +44,12 @@ class TestFromGraph6Bytes:
         Gin = nx.read_graph6(fh)
         assert nodes_equal(G.nodes(), Gin.nodes())
         assert edges_equal(G.edges(), Gin.edges())
+
+    def test_from_graph6_bytes_rejects_below_range(self):
+        # bytes below 63 are out of the valid range(63, 127) and must be
+        # rejected rather than silently producing a wrong graph
+        with pytest.raises(ValueError):
+            nx.from_graph6_bytes(b"C.")
 
 
 class TestReadGraph6:

--- a/networkx/readwrite/tests/test_sparse6.py
+++ b/networkx/readwrite/tests/test_sparse6.py
@@ -47,6 +47,14 @@ class TestSparseGraph6:
             ],
         )
 
+    def test_from_sparse6_bytes_rejects_out_of_range(self):
+        # bytes outside range(63, 127) must be rejected rather than silently
+        # decoding to a wrong graph
+        with pytest.raises(ValueError):
+            nx.from_sparse6_bytes(b":B" + bytes([10]) + b"N")
+        with pytest.raises(ValueError):
+            nx.from_sparse6_bytes(b":BcN" + bytes([200]))
+
     def test_from_bytes_multigraph_graph(self):
         graph_data = b":An"
         G = nx.from_sparse6_bytes(graph_data)


### PR DESCRIPTION
from_graph6_bytes only rejects characters above the valid range (the `c > 63` test), and from_sparse6_bytes does no range check at all. graph6 and sparse6 characters must satisfy `63 <= ord(c) < 127`, so any byte below 63 maps to a negative value that slips through and a file containing one decodes to a different graph with no error, even though from_graph6_bytes documents a ValueError for characters outside that range.

Before, an out-of-range byte either produced a silently wrong graph or surfaced later as an unrelated bit-count NetworkXError. After, both decoders raise the documented ValueError where the bytes are converted, so read_graph6 and read_sparse6 inherit the same guarantee without each repeating the check. The tradeoff is that inputs which previously decoded by accident now fail fast, which matches the documented contract for these formats.