### PR TITLE
escape quotes and backslashes in pajek make_qstr

### DIFF
--- a/networkx/readwrite/pajek.py
+++ b/networkx/readwrite/pajek.py
@@ -277,10 +277,14 @@ def parse_pajek(lines):
 
 def make_qstr(t):
     """Returns the string representation of t.
-    Add outer double-quotes if the string has a space.
+
+    Wrap the string in double-quotes if it contains whitespace, a double
+    quote, or a backslash, escaping the latter two so the Pajek reader
+    (which splits with shlex) recovers the original string unchanged.
     """
     if not isinstance(t, str):
         t = str(t)
-    if " " in t:
+    if any(c.isspace() or c in '"\\' for c in t):
+        t = t.replace("\\", "\\\\").replace('"', '\\"')
         t = f'"{t}"'
     return t

--- a/networkx/readwrite/tests/test_pajek.py
+++ b/networkx/readwrite/tests/test_pajek.py
@@ -126,3 +126,23 @@ class TestPajek:
         assert nodes_equal(list(G), list(H))
         assert edges_equal(list(G.edges()), list(H.edges()))
         assert G.graph == H.graph
+
+    def test_quotes_and_backslashes_roundtrip(self):
+        # Labels/attributes with double quotes or backslashes must survive a
+        # write/read round-trip instead of breaking tokenization or injecting
+        # extra attributes.  See make_qstr.
+        import io
+
+        G = nx.Graph()
+        G.add_node('ev il"x 7')  # embedded quote with whitespace
+        G.add_node(r"back\slash")  # backslash, no whitespace
+        G.add_node("n0", role='a" pwn "admin')  # value crafted to inject
+        G.add_edge('ev il"x 7', "n0", lbl=r"c:\path with space")
+        fh = io.BytesIO()
+        nx.write_pajek(G, fh)
+        fh.seek(0)
+        H = nx.read_pajek(fh)
+        assert nodes_equal(list(G), list(H))
+        assert H.nodes["n0"]["role"] == 'a" pwn "admin'
+        assert "pwn" not in H.nodes["n0"]
+        assert H["ev il\"x 7"]["n0"][0]["lbl"] == r"c:\path with space"

--- a/networkx/readwrite/tests/test_pajek.py
+++ b/networkx/readwrite/tests/test_pajek.py
@@ -145,4 +145,4 @@ class TestPajek:
         assert nodes_equal(list(G), list(H))
         assert H.nodes["n0"]["role"] == 'a" pwn "admin'
         assert "pwn" not in H.nodes["n0"]
-        assert H["ev il\"x 7"]["n0"][0]["lbl"] == r"c:\path with space"
+        assert H['ev il"x 7']["n0"][0]["lbl"] == r"c:\path with space"


### PR DESCRIPTION
make_qstr only wraps a value in double quotes when it contains a literal space, and it never escapes a double quote or backslash already in the value. The Pajek reader splits each line with shlex, so a node label or attribute value carrying a double quote either fails to read back ("No closing quotation") or breaks out into extra tokens, turning one attribute into several. A backslash with no surrounding space is dropped on read because shlex consumes it.

Before, write/read was lossy for those values; after, embedded backslashes and quotes are escaped and the value is quoted whenever it holds whitespace, a quote, or a backslash, so it tokenizes back unchanged. Escaping in the writer keeps it next to the shlex-based reader they pair with, matching how the GML writer already escapes its strings. The tradeoff is slightly longer output for values that previously passed through unquoted by accident.