### PR TITLE
MAINT: Minor touchups to lexicographical_toplogical_sort

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -449,6 +449,7 @@ def lexicographical_topological_sort(G, key=None):
 
         if node not in G:
             raise RuntimeError("Graph changed during iteration")
+        # G.edges() is used here instead of neighbors to handle MultiDiGraphs
         for _, child in G.edges(node):
             try:
                 indegree_map[child] -= 1

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -460,8 +460,8 @@ def lexicographical_topological_sort(G, key=None):
                     heapq.heappush(zero_indegree, create_tuple(child))
                 except TypeError as err:
                     raise TypeError(
-                        f"{err}\nConsider using `key=` parameter to resolve ambiguities in the sort order."
-                    )
+                        "Consider using `key=` parameter to resolve ambiguities in the sort order."
+                    ) from err
                 del indegree_map[child]
 
         yield node

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -345,13 +345,12 @@ def lexicographical_topological_sort(G, key=None):
     topological sort and to determine a single, unique ordering.  This can be useful in comparing
     sort results.
 
-    The lexicographical order can be customized by providing a function to the `key=` parameter.
-    The definition of the key function is the same as used in python's built-in `sort()`.
+    The lexicographical order can be customized by providing a function to the `key` parameter.
+    The definition of the key function is the same as used in Python's built-in `sorted`.
     The function takes a single argument and returns a key to use for sorting purposes.
 
     Lexicographical sorting can fail if the node names are un-sortable. See the example below.
     The solution is to provide a function to the `key=` argument that returns sortable keys.
-
 
     Parameters
     ----------
@@ -365,7 +364,7 @@ def lexicographical_topological_sort(G, key=None):
     Yields
     ------
     nodes
-        Yields the nodes of G in lexicographical topological sort order.
+        Yields the nodes of `G` in lexicographical topological sort order.
 
     Raises
     ------

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -399,8 +399,7 @@ def lexicographical_topological_sort(G, key=None):
     >>> list(nx.lexicographical_topological_sort(DG))
     Traceback (most recent call last):
     ...
-    TypeError: '<' not supported between instances of 'str' and 'int'
-    ...
+    TypeError: Consider using `key=` parameter to resolve ambiguities in the sort order.
 
     Incomparable nodes can be resolved using a `key` function. This example function
     allows comparison of integers and strings by returning a tuple where the first


### PR DESCRIPTION
I was recently on a plane reading through the `dag` module and wanted to take the opportunity to propose some minor improvements to `lexicographical_topological_sort`:
 - Minor docstring updates, including replacing `sort` (which no longer exists) with `sorted`
 - Added comment to the inner-loop over "children" explaining why they are extracted via edges rather than adjacency (which is used elsewhere in the module)
 - Replace custom exception chaining with the modern pattern.

Overall this implementation is very interesting and well-documented (IMO)!