### PR TITLE
CI: Add back --doctest-modules flag to base tests.

### DIFF
--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -189,6 +189,7 @@ collect_ignore = []
 
 needs_numpy = [
     "algorithms/approximation/traveling_salesman.py",
+    "algorithms/approximation/density.py",
     "algorithms/centrality/current_flow_closeness.py",
     "algorithms/centrality/laplacian.py",
     "algorithms/node_classification.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -341,7 +341,7 @@ rasterio = "*"
 # --- Task definitions ---
 
 [tool.pixi.feature.test.tasks]
-test-base = "pytest -n auto --durations=10 --pyargs networkx"
+test-base = "pytest -n auto --doctest-modules --durations=10 --pyargs networkx"
 test-default = "pytest -n auto --doctest-modules --durations=10 --pyargs networkx"
 check-import = "python -Werror -c 'import networkx'"
 test-slow = "pytest -n auto --durations=20 --runslow -m slow --pyargs networkx"


### PR DESCRIPTION
Another minor config wart from the pixi transition - should be running the doctests in the dependency-less test environment.

Caught this while looking at test failures in gh-8695, which should've been universal but were passing on the \*-base runs.