### PR TITLE
CI: Add image comparison tests to pre-release workflows.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -363,8 +363,8 @@ install-backend-stubs = """pip install --no-deps --pre \
   git+https://github.com/awslabs/nx-neptune.git@main"""
 
 [tool.pixi.feature.prerelease.tasks]
-install-prerelease = "pip install --upgrade pip && pip install --pre '.[default,test]' && pip list"
-test-prerelease = "pytest -n auto --doctest-modules --durations=10 --pyargs networkx"
+install-prerelease = "pip install --upgrade pip && pip install --pre '.[default,test]' && pip install pytest-mpl && pip list"
+test-prerelease = "pytest -n auto --mpl --doctest-modules --durations=10 --pyargs networkx"
 
 [tool.pixi.feature.release.tasks]
 build-dist = "python -m build --sdist --wheel"


### PR DESCRIPTION
Add pytest-mpl tests specifically to the pre-release jobs so that image comparison tests can catch any viz changes from prereleases of matplotlib.

Motivated by gh-8697. As noted in the discussion there - the main benefit here is giving us the opportunity to catch discrepancies and report upstream to matplotlib during the rc phase.