### PR TITLE
TST, MAINT: explict graphviz check for test_pydot

### DIFF
--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -13,6 +13,7 @@ General guidelines for writing good tests:
 """
 
 import os
+import subprocess
 import warnings
 from importlib.metadata import entry_points
 
@@ -171,8 +172,11 @@ except ImportError:
 try:
     import pydot
 
+    # Pydot also requires graphviz to be installed for layouts
+    subprocess.check_output("dot -V".split())
+
     has_pydot = True
-except ImportError:
+except (ImportError, FileNotFoundError):
     has_pydot = False
 
 try:

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -1,5 +1,6 @@
 """Unit tests for pydot drawing functions."""
 
+import subprocess
 from io import StringIO
 
 import pytest
@@ -9,8 +10,17 @@ from networkx.utils import graphs_equal
 
 pydot = pytest.importorskip("pydot")
 
+# NOTE: pydot layouts and drawing require graphviz to be installed. Skip these
+# tests if they are not found
+try:
+    subprocess.check_output("dot -V".split())
+    has_graphviz = True
+except FileNotFoundError:
+    has_graphviz = False
+
 
 class TestPydot:
+    @pytest.mark.skipif(not has_graphviz, reason="graphviz required for layout")
     @pytest.mark.parametrize("G", (nx.Graph(), nx.DiGraph()))
     @pytest.mark.parametrize("prog", ("neato", "dot"))
     def test_pydot(self, G, prog, tmp_path):
@@ -90,6 +100,7 @@ class TestPydot:
         assert graphs_equal(G, H)
 
 
+@pytest.mark.skipif(not has_graphviz, reason="graphviz required for layout")
 def test_pydot_issue_7581(tmp_path):
     """Validate that `nx_pydot.pydot_layout` handles nodes
     with characters like "\n", " ".
@@ -133,6 +144,7 @@ def test_hashable_pydot(graph_type):
     )
 
 
+@pytest.mark.skipif(not has_graphviz, reason="graphviz required for layout")
 def test_pydot_numerical_name():
     G = nx.Graph()
     G.add_edges_from([("A", "B"), (0, 1)])


### PR DESCRIPTION
This PR proposes to move the pydot-depends-on-graphviz from an implicit install-time check (i.e. the result of `pydot` being grouped together with `pygraphviz` in the `extra` dependencies) to a test-time check with finer granularity for test-skipping.

This configuration change is in preparation for pygraphviz 2.0, which removes the build-time graphviz dependency. With pygraphviz 2.0, it is possible to install & run pygraphviz without any graphviz installed; however, pydot still requires graphviz to be installed *specifically for executing layouts/drawing*.

This PR is a solution to the issue [identified over in gh-8694](https://github.com/networkx/networkx/pull/8694#issuecomment-4688112383).