### PR TITLE
Clarify attribute behavior in relabel_nodes when multiple nodes map to the same target

### DIFF
--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -14,8 +14,7 @@ def relabel_nodes(G, mapping, copy=True):
 
     When multiple nodes are mapped to the same target node, attribute
     handling is arbitrary. For predictable attribute handling when combining
-    nodes, consider using
-    :func:`~networkx.algorithms.minors.contraction.contracted_nodes`.
+    nodes, consider using :any:`contracted_nodes`.
 
     Parameters
     ----------
@@ -121,7 +120,7 @@ def relabel_nodes(G, mapping, copy=True):
     See Also
     --------
     convert_node_labels_to_integers
-    contracted_nodes
+    :any:`contracted_nodes`
     """
     # you can pass any callable e.g. f(old_label) -> new_label or
     # e.g. str(old_label) -> new_label, but we'll just make a dictionary here regardless

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -115,9 +115,9 @@ def relabel_nodes(G, mapping, copy=True):
 
     When multiple nodes are mapped to the same target node, attribute
     handling is order-dependent and may result in unexpected overwrites.
-    With ``copy=True`` and ``copy=False``, the resulting attributes of
-    the target node can differ depending on iteration order and internal
-    execution path. For predictable attribute handling when combining
+    The resulting attributes of the target node can differ depending on
+    iteration order and whether ``copy=True`` or not.
+    For predictable attribute handling when combining
     nodes, consider using :func:`contracted_nodes`.
 
     See Also

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -113,9 +113,17 @@ def relabel_nodes(G, mapping, copy=True):
     for edges between these two nodes. Note that this means non-numeric
     keys may be replaced by numeric keys.
 
+    When multiple nodes are mapped to the same target node, attribute
+    handling is order-dependent and may result in unexpected overwrites.
+    With ``copy=True`` and ``copy=False``, the resulting attributes of
+    the target node can differ depending on iteration order and internal
+    execution path. For predictable attribute handling when combining
+    nodes, consider using :func:`contracted_nodes`.
+
     See Also
     --------
     convert_node_labels_to_integers
+    contracted_nodes
     """
     # you can pass any callable e.g. f(old_label) -> new_label or
     # e.g. str(old_label) -> new_label, but we'll just make a dictionary here regardless

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -114,10 +114,7 @@ def relabel_nodes(G, mapping, copy=True):
     keys may be replaced by numeric keys.
 
     When multiple nodes are mapped to the same target node, attribute
-    handling is order-dependent and may result in unexpected overwrites.
-    The resulting attributes of the target node can differ depending on
-    iteration order and whether ``copy=True`` or not.
-    For predictable attribute handling when combining
+    handling is arbitrary. For predictable attribute handling when combining
     nodes, consider using :func:`contracted_nodes`.
 
     See Also

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -13,8 +13,8 @@ def relabel_nodes(G, mapping, copy=True):
     mapping includes overlap between old and new labels.
 
     When multiple nodes are mapped to the same target node, attribute
-    handling is arbitrary. For predictable attribute handling when combining
-    nodes, consider using :any:`contracted_nodes`.
+    handling depends on `copy` kwarg. For predictable attribute handling when
+    combining nodes, consider using :any:`contracted_nodes`.
 
     Parameters
     ----------

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -12,6 +12,11 @@ def relabel_nodes(G, mapping, copy=True):
     The original node ordering may not be preserved if `copy` is `False` and the
     mapping includes overlap between old and new labels.
 
+    When multiple nodes are mapped to the same target node, attribute
+    handling is arbitrary. For predictable attribute handling when combining
+    nodes, consider using
+    :func:`~networkx.algorithms.minors.contraction.contracted_nodes`.
+
     Parameters
     ----------
     G : graph
@@ -112,10 +117,6 @@ def relabel_nodes(G, mapping, copy=True):
     to the lowest non-negative integer not already used as a key
     for edges between these two nodes. Note that this means non-numeric
     keys may be replaced by numeric keys.
-
-    When multiple nodes are mapped to the same target node, attribute
-    handling is arbitrary. For predictable attribute handling when combining
-    nodes, consider using :func:`contracted_nodes`.
 
     See Also
     --------


### PR DESCRIPTION
Fixes #8093 

This PR improves documentation for nx.relabel_nodes by clarifying
behavior when multiple source nodes map to a single existing target
node.
In such cases, node attribute behavior can differ between
copy=True and copy=False due to differences in internal construction
order and in-place mutation.
This change does not modify functionality, only clarifies that this
edge case is not intended for node merging semantics.
It also points users toward nx.contracted_nodes for explicit and
deterministic node contraction behavior.

Related to #8093