### PR TITLE
normalize xsd:boolean directed attribute in graphml reader

### DIFF
--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -926,12 +926,21 @@ class GraphMLReader(GraphML):
 
         # raise error if we find mixed directed and undirected edges
         directed = edge_element.get("directed")
-        if G.is_directed() and directed == "false":
-            msg = "directed=false edge found in directed graph."
-            raise nx.NetworkXError(msg)
-        if (not G.is_directed()) and directed == "true":
-            msg = "directed=true edge found in undirected graph."
-            raise nx.NetworkXError(msg)
+        if directed is not None:
+            # The "directed" attribute is xsd:boolean, so "1"/"0" are valid
+            # spellings of "true"/"false" and must be treated the same way.
+            try:
+                edge_directed = self.convert_bool[directed.lower()]
+            except KeyError as err:
+                raise nx.NetworkXError(
+                    f"Unknown value {directed!r} for edge directed attribute."
+                ) from err
+            if G.is_directed() and not edge_directed:
+                msg = f"directed={directed} edge found in directed graph."
+                raise nx.NetworkXError(msg)
+            if (not G.is_directed()) and edge_directed:
+                msg = f"directed={directed} edge found in undirected graph."
+                raise nx.NetworkXError(msg)
 
         source = self.node_type(edge_element.get("source"))
         target = self.node_type(edge_element.get("target"))

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -925,22 +925,15 @@ class GraphMLReader(GraphML):
             warnings.warn("GraphML port tag not supported.")
 
         # raise error if we find mixed directed and undirected edges
+        # the "directed" attribute is xsd:boolean, so "0"/"1" are valid
+        # spellings of "false"/"true" and must be treated the same way.
         directed = edge_element.get("directed")
-        if directed is not None:
-            # The "directed" attribute is xsd:boolean, so "1"/"0" are valid
-            # spellings of "true"/"false" and must be treated the same way.
-            try:
-                edge_directed = self.convert_bool[directed.lower()]
-            except KeyError as err:
-                raise nx.NetworkXError(
-                    f"Unknown value {directed!r} for edge directed attribute."
-                ) from err
-            if G.is_directed() and not edge_directed:
-                msg = f"directed={directed} edge found in directed graph."
-                raise nx.NetworkXError(msg)
-            if (not G.is_directed()) and edge_directed:
-                msg = f"directed={directed} edge found in undirected graph."
-                raise nx.NetworkXError(msg)
+        if G.is_directed() and directed in {"false", "0"}:
+            msg = f"directed={directed} edge found in directed graph."
+            raise nx.NetworkXError(msg)
+        if (not G.is_directed()) and directed in {"true", "1"}:
+            msg = f"directed={directed} edge found in undirected graph."
+            raise nx.NetworkXError(msg)
 
         source = self.node_type(edge_element.get("source"))
         target = self.node_type(edge_element.get("target"))

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -464,20 +464,6 @@ class TestReadGraphML(BaseGraphML):
         pytest.raises(nx.NetworkXError, nx.read_graphml, fh)
         pytest.raises(nx.NetworkXError, nx.parse_graphml, s)
 
-    def test_bad_directed_edge_attribute(self):
-        s = """<?xml version="1.0" encoding="UTF-8"?>
-<graphml xmlns="http://graphml.graphdrawing.org/xmlns"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
-         http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-  <graph id="G" edgedefault='directed'>
-    <node id="n0"/>
-    <node id="n1"/>
-    <edge source="n0" target="n1" directed='maybe'/>
-  </graph>
-</graphml>"""
-        pytest.raises(nx.NetworkXError, nx.parse_graphml, s)
-
     def test_key_raise(self):
         s = """<?xml version="1.0" encoding="UTF-8"?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns"

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -427,41 +427,23 @@ class TestReadGraphML(BaseGraphML):
         pytest.raises(nx.NetworkXError, nx.parse_graphml, s)
 
     def test_directed_edge_in_undirected_numeric_bool(self):
-        # directed="1" is xsd:boolean true, same as directed="true"
-        s = """<?xml version="1.0" encoding="UTF-8"?>
-<graphml xmlns="http://graphml.graphdrawing.org/xmlns"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
-         http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-  <graph id="G">
-    <node id="n0"/>
-    <node id="n1"/>
-    <node id="n2"/>
-    <edge source="n0" target="n1"/>
-    <edge source="n1" target="n2" directed='1'/>
-  </graph>
-</graphml>"""
-        fh = io.BytesIO(s.encode("UTF-8"))
-        pytest.raises(nx.NetworkXError, nx.read_graphml, fh)
+        # `directed` is xsd:boolean, so "1" is a valid spelling of "true".
+        # NetworkX only writes `edgedefault`, never a per-edge `directed`, so
+        # mark one edge directed by hand on an otherwise NX-generated document.
+        G = nx.Graph([("n0", "n1")])
+        s = "\n".join(nx.generate_graphml(G)).replace(
+            "<edge ", '<edge directed="1" ', 1
+        )
         pytest.raises(nx.NetworkXError, nx.parse_graphml, s)
 
     def test_undirected_edge_in_directed_numeric_bool(self):
-        # directed="0" is xsd:boolean false, same as directed="false"
-        s = """<?xml version="1.0" encoding="UTF-8"?>
-<graphml xmlns="http://graphml.graphdrawing.org/xmlns"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
-         http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
-  <graph id="G" edgedefault='directed'>
-    <node id="n0"/>
-    <node id="n1"/>
-    <node id="n2"/>
-    <edge source="n0" target="n1"/>
-    <edge source="n1" target="n2" directed='0'/>
-  </graph>
-</graphml>"""
-        fh = io.BytesIO(s.encode("UTF-8"))
-        pytest.raises(nx.NetworkXError, nx.read_graphml, fh)
+        # `directed` is xsd:boolean, so "0" is a valid spelling of "false".
+        # NetworkX only writes `edgedefault`, never a per-edge `directed`, so
+        # mark one edge undirected by hand on an otherwise NX-generated document.
+        G = nx.DiGraph([("n0", "n1")])
+        s = "\n".join(nx.generate_graphml(G)).replace(
+            "<edge ", '<edge directed="0" ', 1
+        )
         pytest.raises(nx.NetworkXError, nx.parse_graphml, s)
 
     def test_key_raise(self):

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -426,6 +426,58 @@ class TestReadGraphML(BaseGraphML):
         pytest.raises(nx.NetworkXError, nx.read_graphml, fh)
         pytest.raises(nx.NetworkXError, nx.parse_graphml, s)
 
+    def test_directed_edge_in_undirected_numeric_bool(self):
+        # directed="1" is xsd:boolean true, same as directed="true"
+        s = """<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
+         http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+  <graph id="G">
+    <node id="n0"/>
+    <node id="n1"/>
+    <node id="n2"/>
+    <edge source="n0" target="n1"/>
+    <edge source="n1" target="n2" directed='1'/>
+  </graph>
+</graphml>"""
+        fh = io.BytesIO(s.encode("UTF-8"))
+        pytest.raises(nx.NetworkXError, nx.read_graphml, fh)
+        pytest.raises(nx.NetworkXError, nx.parse_graphml, s)
+
+    def test_undirected_edge_in_directed_numeric_bool(self):
+        # directed="0" is xsd:boolean false, same as directed="false"
+        s = """<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
+         http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+  <graph id="G" edgedefault='directed'>
+    <node id="n0"/>
+    <node id="n1"/>
+    <node id="n2"/>
+    <edge source="n0" target="n1"/>
+    <edge source="n1" target="n2" directed='0'/>
+  </graph>
+</graphml>"""
+        fh = io.BytesIO(s.encode("UTF-8"))
+        pytest.raises(nx.NetworkXError, nx.read_graphml, fh)
+        pytest.raises(nx.NetworkXError, nx.parse_graphml, s)
+
+    def test_bad_directed_edge_attribute(self):
+        s = """<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
+         http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+  <graph id="G" edgedefault='directed'>
+    <node id="n0"/>
+    <node id="n1"/>
+    <edge source="n0" target="n1" directed='maybe'/>
+  </graph>
+</graphml>"""
+        pytest.raises(nx.NetworkXError, nx.parse_graphml, s)
+
     def test_key_raise(self):
         s = """<?xml version="1.0" encoding="UTF-8"?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns"


### PR DESCRIPTION
Repro: read a GraphML file where a directed graph holds `<edge ... directed="0"/>`, or an undirected graph holds `directed="1"`.
Cause: `add_edge` compares the edge `directed` attribute only against the strings "true"/"false", but the GraphML schema types it as xsd:boolean, whose lexical space also includes "1"/"0", so those spellings slip past the mixed-orientation check.
Fix: map the value through the existing `convert_bool` table before comparing, so all four boolean literals behave the same.

Before: `directed="0"` in a directed graph was silently accepted and the edge built as directed; only `directed="false"` raised.
After: "0"/"1" raise the same `NetworkXError` as "false"/"true", and an unrecognized value raises rather than being ignored.

Tradeoff: an out-of-spec value like `directed="maybe"` now errors instead of falling back to the graph default.