### PR TITLE
CI: Fix circleci artifact redirector permissions.

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,13 +1,14 @@
 name: circleci
 
-permissions:
-  contents: read
+permissions: read-all
 
 on: [status]
 jobs:
   image:
     runs-on: ubuntu-latest
     name: Run CircleCI image artifact redirector
+    permissions:
+      statuses: write
     steps:
       - name: GitHub Action step
         uses: scientific-python/circleci-artifacts-redirector-action@5d358ff96e96429a5c64a969bb4a574555439f4f # v1.3.1
@@ -20,6 +21,8 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     name: Run CircleCI documentation artifact redirector
+    permissions:
+      statuses: write
     steps:
       - name: GitHub Action step
         uses: scientific-python/circleci-artifacts-redirector-action@5d358ff96e96429a5c64a969bb4a574555439f4f # v1.3.1
@@ -32,6 +35,8 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     name: Run CircleCI documentation artifact redirector
+    permissions:
+      statuses: write
     steps:
       - name: GitHub Action step
         uses: scientific-python/circleci-artifacts-redirector-action@5d358ff96e96429a5c64a969bb4a574555439f4f # v1.3.1

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -34,7 +34,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
-    name: Run CircleCI documentation artifact redirector
+    name: Run CircleCI coverage artifact redirector
     permissions:
       statuses: write
     steps:


### PR DESCRIPTION
Hopefully closes gh-8706

I borrowed the permissions pattern used in the [numpy CI config](https://github.com/numpy/numpy/blob/main/.github/workflows/circleci.yml).