### PR TITLE
Consistent behavior across in-place and copy graph relabeling

### DIFF
--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -178,10 +178,15 @@ def _relabel_copy(G, mapping):
     H = G.__class__()
     H.add_nodes_from(mapping.get(n, n) for n in G)
 
-    process_last = {n: G.nodes[n] for n in _relabel_order(G, mapping, strict=False) if n in G}
+    process_last = {
+        n: G.nodes[n] for n in _relabel_order(G, mapping, strict=False) if n in G
+    }
     process_first = [(n, d) for n, d in G.nodes.items() if n not in process_last]
 
-    H._node.update((mapping.get(n, n), d.copy()) for n, d in process_first + list(process_last.items()))
+    H._node.update(
+        (mapping.get(n, n), d.copy())
+        for n, d in process_first + list(process_last.items())
+    )
     if G.is_multigraph():
         new_edges = [
             (mapping.get(n1, n1), mapping.get(n2, n2), k, d.copy())

--- a/networkx/relabel.py
+++ b/networkx/relabel.py
@@ -128,26 +128,10 @@ def relabel_nodes(G, mapping, copy=True):
 
 
 def _relabel_inplace(G, mapping):
-    if len(mapping.keys() & mapping.values()) > 0:
-        # labels sets overlap
-        # can we topological sort and still do the relabeling?
-        D = nx.DiGraph(list(mapping.items()))
-        D.remove_edges_from(nx.selfloop_edges(D))
-        try:
-            nodes = reversed(list(nx.topological_sort(D)))
-        except nx.NetworkXUnfeasible as err:
-            raise nx.NetworkXUnfeasible(
-                "The node label sets are overlapping and no ordering can "
-                "resolve the mapping. Use copy=True."
-            ) from err
-    else:
-        # non-overlapping label sets, sort them in the order of G nodes
-        nodes = [n for n in G if n in mapping]
-
     multigraph = G.is_multigraph()
     directed = G.is_directed()
 
-    for old in nodes:
+    for old in _relabel_order(G, mapping, strict=True):
         # Test that old is in both mapping and G, otherwise ignore.
         try:
             new = mapping[old]
@@ -193,7 +177,11 @@ def _relabel_inplace(G, mapping):
 def _relabel_copy(G, mapping):
     H = G.__class__()
     H.add_nodes_from(mapping.get(n, n) for n in G)
-    H._node.update((mapping.get(n, n), d.copy()) for n, d in G.nodes.items())
+
+    process_last = {n: G.nodes[n] for n in _relabel_order(G, mapping, strict=False) if n in G}
+    process_first = [(n, d) for n, d in G.nodes.items() if n not in process_last]
+
+    H._node.update((mapping.get(n, n), d.copy()) for n, d in process_first + list(process_last.items()))
     if G.is_multigraph():
         new_edges = [
             (mapping.get(n1, n1), mapping.get(n2, n2), k, d.copy())
@@ -221,6 +209,25 @@ def _relabel_copy(G, mapping):
         )
     H.graph.update(G.graph)
     return H
+
+
+def _relabel_order(G, mapping, *, strict):
+    if len(mapping.keys() & mapping.values()) == 0:
+        return [n for n in G if n in mapping]
+
+    D = nx.DiGraph(mapping.items())
+    D.remove_edges_from(nx.selfloop_edges(D))
+
+    try:
+        return list(reversed(list(nx.topological_sort(D))))
+    except nx.NetworkXUnfeasible as err:
+        if strict:
+            raise nx.NetworkXUnfeasible(
+                "The node label sets are overlapping and no ordering can "
+                "resolve the mapping. Use copy=True."
+            ) from err
+
+        return [n for n in G if n in mapping]
 
 
 @nx._dispatchable(preserve_all_attrs=True, returns_graph=True)

--- a/networkx/tests/test_relabel.py
+++ b/networkx/tests/test_relabel.py
@@ -356,3 +356,15 @@ class TestRelabel:
         actual = {frozenset(e) for e in G.edges}
         expected = {frozenset(e) for e in [("a", 2), ("a", 3), ("b", 3)]}
         assert actual == expected
+
+    def test_relabel_existing_node_attributes_are_consistent(self):
+        G = nx.Graph()
+        G.add_nodes_from((n, {"val": n}) for n in range(5))
+
+        H = nx.relabel_nodes(G, {1: 4}, copy=True)
+
+        G2 = G.copy()
+        nx.relabel_nodes(G2, {1: 4}, copy=False)
+
+        assert H.nodes[4] == {"val": 1}
+        assert G2.nodes[4] == {"val": 1}


### PR DESCRIPTION
## Summary

Alternative to https://github.com/networkx/networkx/pull/8704.

Refactor relabel ordering logic into a shared `_relabel_order()` helper and fix an inconsistency between `copy=True` and `copy=False` when relabeling a node to an existing node label.

Previously:

```python
G = nx.Graph()
G.add_nodes_from((n, {"val": n}) for n in range(5))

H = nx.relabel_nodes(G, {1: 4}, copy=True)
H.nodes[4]
# {'val': 4}

nx.relabel_nodes(G, {1: 4}, copy=False)
G.nodes[4]
# {'val': 1}
```

The copy implementation processed node attributes in graph iteration order, causing the attributes from the original node `4` to overwrite those from node `1`. The inplace implementation instead preserved the attributes from the relabeled node.

This PR makes `copy=True` follow the same ordering semantics as `copy=False`, so both now produce:

```python
{'val': 1}
```
