### PR TITLE
write xsd:boolean true/false for dynamic gexf attvalues

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -533,15 +533,18 @@ class GEXFWriter(GEXF):
                 for val, start, end in v:
                     e = Element("attvalue")
                     e.attrib["for"] = attr_id
-                    e.attrib["value"] = str(val)
-                    # Handle nan, inf, -inf differently
-                    if val_type is float:
-                        if e.attrib["value"] == "inf":
-                            e.attrib["value"] = "INF"
-                        elif e.attrib["value"] == "nan":
-                            e.attrib["value"] = "NaN"
-                        elif e.attrib["value"] == "-inf":
-                            e.attrib["value"] = "-INF"
+                    if isinstance(val, bool):
+                        e.attrib["value"] = str(val).lower()
+                    else:
+                        e.attrib["value"] = str(val)
+                        # Handle nan, inf, -inf differently
+                        if val_type is float:
+                            if e.attrib["value"] == "inf":
+                                e.attrib["value"] = "INF"
+                            elif e.attrib["value"] == "nan":
+                                e.attrib["value"] = "NaN"
+                            elif e.attrib["value"] == "-inf":
+                                e.attrib["value"] = "-INF"
                     if start is not None:
                         e.attrib["start"] = str(start)
                     if end is not None:

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -61,6 +61,24 @@ def test_dynamic_graph_has_timeformat(time_attr, dyn_attr, tmp_path):
     assert nx.utils.nodes_equal(G.edges, H.edges)
 
 
+def test_dynamic_boolean_attvalue_is_lowercase(tmp_path):
+    """Boolean values in dynamic (spelled) attributes must be written as the
+    xsd:boolean literals 'true'/'false', matching the static path. Previously
+    the dynamic branch wrote Python's 'True'/'False'."""
+    G = nx.Graph(mode="dynamic")
+    G.add_node("n", flag=[(True, 0, 1), (False, 1, 2)])
+    fname = tmp_path / "bool.gexf"
+    nx.write_gexf(G, fname)
+    text = fname.read_text()
+    assert 'value="true"' in text
+    assert 'value="false"' in text
+    assert 'value="True"' not in text
+    assert 'value="False"' not in text
+    # Values still round-trip to Python bools
+    H = nx.read_gexf(fname)
+    assert H.nodes["n"]["flag"] == [(True, 0, 1), (False, 1, 2)]
+
+
 class TestGEXF:
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
Cause: GEXFWriter.add_attributes lowercases booleans on the static path `(str(v).lower())` but the dynamic spelled branch wrote `str(val)`.
Fix: lowercase bools in the dynamic branch, same as the static one.

Before, a node attr like `flag=[(True, 0, 1)]` serialized as `value="True"`; after it is `value="true"/"false"`, the xsd:boolean form the static path already produces. networkx reads both back, so existing round-trips are unaffected; the difference is output that conformant GEXF readers accept.