### PR TITLE
ENH: Add Infomap as a backend-only community detection algorithm

### DIFF
--- a/doc/reference/algorithms/community.rst
+++ b/doc/reference/algorithms/community.rst
@@ -86,6 +86,14 @@ Leiden Community Detection
     leiden_communities
     leiden_partitions
 
+Infomap Community Detection
+---------------------------
+.. automodule:: networkx.algorithms.community.infomap
+.. autosummary::
+    :toctree: generated/
+
+    infomap_communities
+
 Fluid Communities
 -----------------
 .. automodule:: networkx.algorithms.community.asyn_fluid

--- a/networkx/algorithms/community/__init__.py
+++ b/networkx/algorithms/community/__init__.py
@@ -25,4 +25,5 @@ from networkx.algorithms.community.quality import *
 from networkx.algorithms.community.community_utils import *
 from networkx.algorithms.community.louvain import *
 from networkx.algorithms.community.leiden import *
+from networkx.algorithms.community.infomap import *
 from networkx.algorithms.community.local import *

--- a/networkx/algorithms/community/infomap.py
+++ b/networkx/algorithms/community/infomap.py
@@ -17,10 +17,11 @@ def infomap_communities(G, weight="weight", seed=None, num_trials=1):
 
     Infomap detects community structure by minimizing the *map equation*, the
     expected per-step description length of a random walk on the network. Unlike
-    modularity-based methods such as :any:`louvain_communities` and
-    :any:`leiden_communities`, Infomap is a flow-based method: it groups nodes
-    among which flow persists, which makes it well suited to directed and
-    weighted networks. [1]_ [2]_
+    the modularity-based methods :any:`louvain_communities` and
+    :any:`leiden_communities`, Infomap is a *flow-based* method: it detects
+    communities by compressing the description of a random walk rather than by
+    optimizing modularity. This makes it a natural fit for networks where
+    community structure is carried by the direction and volume of flow. [1]_ [2]_
 
     This function has no NetworkX implementation; it dispatches to a backend
     such as ``infomap`` that registers an implementation.

--- a/networkx/algorithms/community/infomap.py
+++ b/networkx/algorithms/community/infomap.py
@@ -1,0 +1,70 @@
+"""Functions for detecting communities based on the Infomap algorithm
+(the map equation).
+
+These functions do not have NetworkX implementations.
+They may only be run with an installable :doc:`backend </backends>`
+that supports them.
+"""
+
+import networkx as nx
+
+__all__ = ["infomap_communities"]
+
+
+@nx._dispatchable(edge_attrs="weight", implemented_by_nx=False)
+def infomap_communities(G, weight="weight", seed=None, num_trials=1):
+    r"""Find communities in `G` using the Infomap algorithm (backend required)
+
+    Infomap detects community structure by minimizing the *map equation*, the
+    expected per-step description length of a random walk on the network. Unlike
+    modularity-based methods such as :any:`louvain_communities` and
+    :any:`leiden_communities`, Infomap is a flow-based method: it groups nodes
+    among which flow persists, which makes it well suited to directed and
+    weighted networks. [1]_ [2]_
+
+    This function has no NetworkX implementation; it dispatches to a backend
+    such as ``infomap`` that registers an implementation.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+        An undirected or directed graph. Edge weights are interpreted as flow.
+    weight : string or None, optional (default="weight")
+        The name of an edge attribute holding the numerical weight. If None,
+        every edge has weight 1.
+    seed : integer or None, optional (default=None)
+        Seed for the backend's random number generator, for reproducible runs.
+    num_trials : int, optional (default=1)
+        Number of outer-most loop replications to run before picking the best
+        solution (the one with the lowest codelength).
+
+    Returns
+    -------
+    list
+        A list of disjoint sets (a partition of `G`). Each set is one community
+        and together they contain every node in `G`, with original node labels.
+
+    Examples
+    --------
+    >>> import networkx as nx
+    >>> G = nx.karate_club_graph()
+    >>> nx.community.infomap_communities(G, backend="infomap")  # doctest: +SKIP
+    [{0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21}, {8, 9, 14, 15, 18, 20, 22, ...}, ...]
+
+    References
+    ----------
+    .. [1] Rosvall, M. & Bergstrom, C.T. Maps of random walks on complex
+       networks reveal community structure. PNAS 105, 1118-1123 (2008).
+       https://doi.org/10.1073/pnas.0706851105
+    .. [2] Edler, D., Holmgren, A. & Rosvall, M. The MapEquation software
+       package. https://www.mapequation.org
+
+    See Also
+    --------
+    :any:`louvain_communities`
+    :any:`leiden_communities`
+    """
+    raise NotImplementedError(
+        "'infomap_communities' is not implemented by networkx. "
+        "Please try a different backend."
+    )

--- a/networkx/algorithms/community/tests/test_infomap.py
+++ b/networkx/algorithms/community/tests/test_infomap.py
@@ -1,0 +1,67 @@
+import pytest
+
+import networkx as nx
+from networkx.algorithms.community import infomap_communities
+
+# Infomap is not implemented by networkx, so only run the substantive tests for
+# backends that implement it.
+no_backends_for_infomap = (
+    "not set(nx.config.backend_priority.algos) & infomap_communities.backends"
+)
+
+
+def test_infomap_with_nx_backend():
+    G = nx.karate_club_graph()
+    with pytest.raises(NotImplementedError):
+        nx.community.infomap_communities(G, backend="networkx")
+
+
+@pytest.mark.skipif(no_backends_for_infomap)
+def test_valid_partition():
+    G = nx.karate_club_graph()
+    partition = nx.community.infomap_communities(G)
+    assert nx.community.is_partition(G, partition)
+
+
+@pytest.mark.skipif(no_backends_for_infomap)
+def test_labels_preserved():
+    G = nx.karate_club_graph()
+    partition = nx.community.infomap_communities(G)
+    assert set().union(*partition) == set(G.nodes())
+
+
+@pytest.mark.skipif(no_backends_for_infomap)
+def test_directed():
+    # Infomap is flow-based and supports directed graphs.
+    G = nx.gnc_graph(50, seed=42)
+    partition = nx.community.infomap_communities(G)
+    assert nx.community.is_partition(G, partition)
+
+
+@pytest.mark.skipif(no_backends_for_infomap)
+def test_isolated_nodes():
+    G = nx.karate_club_graph()
+    G.add_node("isolated")
+    partition = nx.community.infomap_communities(G)
+    assert {"isolated"} in partition
+
+
+@pytest.mark.skipif(no_backends_for_infomap)
+def test_weight_param():
+    G = nx.karate_club_graph()
+    nx.set_edge_attributes(
+        G, {edge: i * i for i, edge in enumerate(G.edges)}, name="foo"
+    )
+    partition_none = nx.community.infomap_communities(G, weight=None, seed=2)
+    partition_foo = nx.community.infomap_communities(G, weight="foo", seed=2)
+
+    assert nx.community.is_partition(G, partition_none)
+    assert nx.community.is_partition(G, partition_foo)
+
+
+@pytest.mark.skipif(no_backends_for_infomap)
+def test_seed_reproducible():
+    G = nx.karate_club_graph()
+    p1 = nx.community.infomap_communities(G, seed=42)
+    p2 = nx.community.infomap_communities(G, seed=42)
+    assert sorted(map(sorted, p1)) == sorted(map(sorted, p2))


### PR DESCRIPTION
## Summary

Adds `nx.community.infomap_communities` as a **backend-only** dispatchable function (no default NetworkX implementation), following the pattern established for Leiden in gh-7743 / gh-7690.

Infomap is a flow-based community detection method that minimizes the *map equation*. Unlike the modularity-based methods `louvain_communities` and `leiden_communities`, it detects communities by compressing the description of a random walk rather than by optimizing modularity, which makes it a natural fit for networks where community structure is carried by the direction and volume of flow. There is no pure-Python implementation here by design — the value of Infomap is its maintained C++ flow engine (directed flow, teleportation, multilayer, memory/state), so backend-only dispatch is the right initial design. A native NetworkX implementation may follow later, mirroring Leiden’s gh-7743 → gh-8509 path; this PR is the shared dispatch entry point either way.

```python
>>> import networkx as nx
>>> G = nx.karate_club_graph()
>>> nx.community.infomap_communities(G, backend="infomap")  # doctest: +SKIP
[{0, 1, 2, ...}, {8, 9, ...}, ...]
```

## What's included

- `networkx/algorithms/community/infomap.py` — the dispatchable stub (`@nx._dispatchable(edge_attrs="weight", implemented_by_nx=False)`).
- `networkx/algorithms/community/tests/test_infomap.py` — a contract test plus backend-gated tests (skip unless a backend implementing Infomap is installed, mirroring `test_leiden.py`).
- Reference entry under the community docs.

## Implementing backend

A backend is already implemented and verified end-to-end against this branch in the `infomap` package: mapequation/infomap#667. It registers via the `networkx.backends` / `networkx.backend_info` entry points and delegates to the Infomap C++ engine.

## Open questions for reviewers

1. **`seed` semantics.** `louvain_communities` / `leiden_communities` use `@py_random_state("seed")`, which converts `seed` to a NumPy `RandomState` before dispatch. Infomap's engine takes an **integer** seed for its C++ RNG, so this stub omits `py_random_state` and documents `seed` as an integer (matching the `seed=123`-style usage in the backend). Is that acceptable, or would you prefer the `py_random_state` convention with the backend extracting an int from the random state?

2. **Backend-specific options.** Infomap supports many parameters beyond `weight`/`seed`/`num_trials` (e.g. `two_level`, `flow_model`, `markov_time`). Rather than widening the shared API, the design relies on **backend-only keyword arguments** forwarded to the backend (as in gh-7743). Confirming this is the preferred approach and that the stub should stay minimal.

3. **`num_trials` default.** Included as a standard cross-backend parameter (default `1`). Happy to drop it from the shared signature and treat it as backend-only if you'd rather keep the API surface minimal like Leiden's.

## Design note: MultiGraph handling

The initial scope is simple graphs (`Graph`/`DiGraph`); state/multilayer networks are deferred. The stub intentionally does **not** restrict `MultiGraph`/`MultiDiGraph`, leaving graph-type support for each backend to advertise and reject — baking `@not_implemented_for("multigraph")` into the shared API would foreclose a future backend that does support them. The `infomap` backend in mapequation/infomap#667 rejects multigraphs itself. Happy to add a stub-level restriction instead if you'd prefer that policy.

Closes #8653