### PR TITLE
reject xml-illegal characters in gexf and graphml writers

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -18,6 +18,7 @@ specification and http://gexf.net/basic.html for examples.
 """
 
 import itertools
+import re
 import time
 from xml.etree.ElementTree import (
     Element,
@@ -31,6 +32,12 @@ import networkx as nx
 from networkx.utils import open_file
 
 __all__ = ["write_gexf", "read_gexf", "relabel_gexf_graph", "generate_gexf"]
+
+# Characters outside the XML 1.0 "Char" production (e.g. most C0 controls and
+# unpaired surrogates). xml.etree writes them verbatim, so a graph carrying one
+# in a node id, label or attribute serializes to a document that cannot be
+# parsed back. Match them up front and fail loudly instead.
+_illegal_xml_chars = re.compile("[\x00-\x08\x0b\x0c\x0e-\x1f\ud800-\udfff\ufffe\uffff]")
 
 
 @open_file(1, mode="wb")
@@ -362,10 +369,23 @@ class GEXFWriter(GEXF):
             self.add_graph(graph)
 
     def __str__(self):
+        self.check_xml_chars()
         if self.prettyprint:
             self.indent(self.xml)
         s = tostring(self.xml).decode(self.encoding)
         return s
+
+    def check_xml_chars(self):
+        # xml.etree emits characters illegal in XML 1.0 without complaint, so
+        # the resulting document cannot be read back. Walk the built tree and
+        # reject any node id, label, attribute name or value carrying one.
+        for elem in self.xml.iter():
+            for s in (elem.text, *elem.keys(), *elem.attrib.values()):
+                if s is not None and (m := _illegal_xml_chars.search(s)):
+                    raise nx.NetworkXError(
+                        f"{s!r} contains character {m.group()!r} which is not "
+                        "allowed in XML and cannot be written to GEXF"
+                    )
 
     def add_graph(self, G):
         # first pass through G collecting edge ids
@@ -727,6 +747,7 @@ class GEXFWriter(GEXF):
 
     def write(self, fh):
         # Serialize graph G in GEXF to the open fh
+        self.check_xml_chars()
         if self.prettyprint:
             self.indent(self.xml)
         document = ElementTree(self.xml)

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -41,11 +41,18 @@ http://graphml.graphdrawing.org/primer/graphml-primer.html
 for examples.
 """
 
+import re
 import warnings
 from collections import defaultdict
 
 import networkx as nx
 from networkx.utils import open_file
+
+# Characters outside the XML 1.0 "Char" production (e.g. most C0 controls and
+# unpaired surrogates). xml.etree writes them verbatim, so a graph carrying one
+# in a node id, label or attribute serializes to a document that cannot be
+# parsed back. Match them up front and fail loudly instead.
+_illegal_xml_chars = re.compile("[\x00-\x08\x0b\x0c\x0e-\x1f\ud800-\udfff\ufffe\uffff]")
 
 __all__ = [
     "write_graphml",
@@ -498,10 +505,23 @@ class GraphMLWriter(GraphML):
     def __str__(self):
         from xml.etree.ElementTree import tostring
 
+        self.check_xml_chars()
         if self.prettyprint:
             self.indent(self.xml)
         s = tostring(self.xml).decode(self.encoding)
         return s
+
+    def check_xml_chars(self):
+        # xml.etree emits characters illegal in XML 1.0 without complaint, so
+        # the resulting document cannot be read back. Walk the built tree and
+        # reject any node id, label, attribute name or value carrying one.
+        for elem in self.xml.iter():
+            for s in (elem.text, *elem.keys(), *elem.attrib.values()):
+                if s is not None and (m := _illegal_xml_chars.search(s)):
+                    raise nx.NetworkXError(
+                        f"{s!r} contains character {m.group()!r} which is not "
+                        "allowed in XML and cannot be written to GraphML"
+                    )
 
     def attr_type(self, name, scope, value):
         """Infer the attribute type of data named name. Currently this only
@@ -662,6 +682,7 @@ class GraphMLWriter(GraphML):
     def dump(self, stream):
         from xml.etree.ElementTree import ElementTree
 
+        self.check_xml_chars()
         if self.prettyprint:
             self.indent(self.xml)
         document = ElementTree(self.xml)

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -79,6 +79,23 @@ def test_dynamic_boolean_attvalue_is_lowercase(tmp_path):
     assert H.nodes["n"]["flag"] == [(True, 0, 1), (False, 1, 2)]
 
 
+@pytest.mark.parametrize("ch", ["\x00", "\x07", "\x08", "\x0c", "\x1f"])
+@pytest.mark.parametrize("where", ["id", "label", "attr"])
+def test_illegal_xml_chars_rejected(ch, where):
+    """Characters not allowed by XML 1.0 are written verbatim by xml.etree,
+    yielding a document that cannot be parsed back. They are rejected at write
+    time instead of producing a silently unreadable file."""
+    G = nx.Graph()
+    if where == "id":
+        G.add_node(f"a{ch}b")
+    elif where == "label":
+        G.add_node("n", label=f"a{ch}b")
+    else:
+        G.add_node("n", attr=f"a{ch}b")
+    pytest.raises(nx.NetworkXError, nx.write_gexf, G, io.BytesIO())
+    pytest.raises(nx.NetworkXError, lambda: "\n".join(nx.generate_gexf(G)))
+
+
 class TestGEXF:
     @classmethod
     def setup_class(cls):

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -1495,6 +1495,23 @@ def test_exception_for_unsupported_datatype_edge_attr():
         nx.write_graphml(G, fh)
 
 
+@pytest.mark.parametrize("ch", ["\x00", "\x07", "\x08", "\x0c", "\x1f"])
+@pytest.mark.parametrize("where", ["id", "label", "attr"])
+def test_illegal_xml_chars_rejected(ch, where):
+    """Characters not allowed by XML 1.0 are written verbatim by xml.etree,
+    yielding a document that cannot be parsed back. The stdlib writer rejects
+    them at write time instead of producing a silently unreadable file."""
+    G = nx.Graph()
+    if where == "id":
+        G.add_node(f"a{ch}b")
+    elif where == "label":
+        G.add_node("n", label=f"a{ch}b")
+    else:
+        G.add_node("n", attr=f"a{ch}b")
+    pytest.raises(nx.NetworkXError, nx.write_graphml_xml, G, io.BytesIO())
+    pytest.raises(nx.NetworkXError, lambda: "\n".join(nx.generate_graphml(G)))
+
+
 def test_exception_for_unsupported_datatype_graph_attr():
     """Test that a detailed exception is raised when an attribute is of a type
     not supported by GraphML, e.g. a list"""


### PR DESCRIPTION
The GEXF writer, and the stdlib GraphML writer that `write_graphml` falls back to when lxml is missing, drop node ids, labels, attribute names and attribute values straight into an `xml.etree` tree. A character that XML 1.0 does not allow (NUL, BEL, most of `0x00`-`0x1f`, lone surrogates) gets serialized verbatim, so a graph that carries one in its data writes a file that `read_gexf`/`read_graphml` then refuse with `ParseError: not well-formed`. `0x0c` is quietly turned into a space, which corrupts the value without any error at all.

Before, the bad bytes left the writer and the problem only showed up later when something read the file back. After, both writers scan the assembled tree once before serializing and raise `NetworkXError` naming the offending value. The tradeoff is that a write which used to "succeed" now fails, but that output was already unreadable, so this trades a corrupt file found downstream for a clear error at the write call. The check lives in the writer because that is the layer that knows it is producing XML.