### PR TITLE
DOC: Add Hiveplotlib to Drawing Docs and External Examples Gallery

### DIFF
--- a/doc/reference/drawing.rst
+++ b/doc/reference/drawing.rst
@@ -15,6 +15,7 @@ dedicated and fully-featured graph visualization tools are
 `Cytoscape <http://www.cytoscape.org/>`_,
 `Gephi <https://gephi.org/>`_,
 `Graphviz <http://www.graphviz.org/>`_,
+`Hiveplotlib <https://hiveplotlib.readthedocs.io/>`_,
 `iplotx <https://iplotx.readthedocs.io/>`_ and, for
 `LaTeX <http://www.latex-project.org/>`_ typesetting,
 `PGF/TikZ <https://github.com/pgf-tikz/pgf/>`_.
@@ -25,13 +26,14 @@ choice.
 
 .. tip::
 
-   ``iplotx`` accepts NetworkX native data structures without exporting to a file.
-   An example is provided below.
+   ``iplotx`` and ``hiveplotlib`` accept NetworkX native data structures without
+   exporting to a file. An example of each is provided below.
 
 More information on the features provided here are available at
  - matplotlib:  http://matplotlib.org/
  - pygraphviz:  http://pygraphviz.github.io/
  - iplotx: https://iplotx.readthedocs.io/
+ - hiveplotlib: https://hiveplotlib.readthedocs.io/
 
 Matplotlib
 ==========
@@ -73,6 +75,46 @@ See Also
 --------
 - `iplotx <https://iplotx.readthedocs.io/>`_
 - `iplotx.network <https://iplotx.readthedocs.io/en/latest/api/plotting.html#plotting-api>`_
+
+
+Hive Plots with Hiveplotlib
+===========================
+``hiveplotlib`` draws hive plots, a layout that places nodes on a few radial axes
+by a partition variable and orders them along each axis by a chosen sorting variable.
+Positions are determined by the data rather than a layout algorithm, so the result is
+reproducible and makes structural properties of the graph directly legible. A
+NetworkX graph can be passed directly, and Networkx node and edge metrics
+(such as node ``pagerank``) can be computed on the fly to drive the layout.
+
+Examples
+--------
+.. code-block:: python
+
+  >>> from hiveplotlib import HivePlot
+  >>> p = [[0.3, 0.005, 0.0],
+  ...      [0.005, 0.3, 0.03],
+  ...      [0.0, 0.03, 0.3]]
+  >>> G = nx.stochastic_block_model(sizes=[15, 15, 15], p=p, seed=0)
+  >>> hp = HivePlot(
+  ...     graph=G,
+  ...     partition_variable="block",
+  ...     sorting_variables="pagerank",
+  ...     node_graph_metrics="pagerank",
+  ...     repeat_axes=True,
+  ... )
+  >>> hp.plot()
+
+By default, ``hiveplotlib`` uses Matplotlib for rendering, but hive plots can also be
+easily rendered with Bokeh, Plotly, and HoloViews. They can also be rasterized with
+Datashader for larger networks.
+
+See Also
+--------
+- `Hiveplotlib <https://hiveplotlib.readthedocs.io/>`_
+- `Creating hive plots from NetworkX <https://hiveplotlib.readthedocs.io/stable/notebooks/creating_hive_plots_from_networkx.html>`_
+- `Computing graph metrics <https://hiveplotlib.readthedocs.io/stable/notebooks/computing_graph_metrics.html>`_
+- `Visualizing with other backends <https://hiveplotlib.readthedocs.io/stable/notebooks/hive_plot_viz_outside_matplotlib.html>`_
+- `Hive plots for large networks <https://hiveplotlib.readthedocs.io/stable/notebooks/hive_plots_for_large_networks.html>`_
 
 
 Graphviz AGraph (dot)

--- a/examples/external/plot_hiveplotlib.py
+++ b/examples/external/plot_hiveplotlib.py
@@ -1,0 +1,71 @@
+"""
+===========
+Hiveplotlib
+===========
+
+`Hiveplotlib <https://hiveplotlib.readthedocs.io/>`_ is a network visualization
+library for hive plots, a layout in which nodes are partitioned onto a small
+number of radial axes and positioned along each axis by a sorting variable.
+Since positions are determined by the data rather than a layout algorithm, hive
+plots are reproducible and make structural properties of a graph directly legible.
+
+Below, we visualize Zachary's Karate Club with both a conventional layout and a
+hive plot.
+"""
+
+import matplotlib.pyplot as plt
+import networkx as nx
+from hiveplotlib import HivePlot
+
+# sphinx_gallery_thumbnail_number = 2
+
+G = nx.karate_club_graph()
+
+# %%
+# Conventional View: Circular Layout
+# ----------------------------------
+#
+# Zachary's Karate Club is usually drawn as a circular layout. That view shows
+# every connection, but the relationship between the two factions is
+# hard to read off the resulting alignment of edges.
+
+# color nodes by faction
+faction_color = [
+    "royalblue" if data["club"] == "Mr. Hi" else "darkorange"
+    for _, data in G.nodes(data=True)
+]
+
+fig, ax = plt.subplots(figsize=(8, 8))
+nx.draw_circular(
+    G, with_labels=True, node_color=faction_color, font_color="white", ax=ax
+)
+plt.show()
+
+# %%
+# Hive Plot View
+# --------------
+#
+# We pass the NetworkX graph directly to the ``HivePlot`` class, partitioning nodes
+# onto axes by their ``club`` membership and sorting each axis by node ``degree``
+# (requesting ``degree`` as a computed metric at construction time).
+#
+# Using repeat axes lets us see within-faction edges, while coloring
+# distinguishes within-faction connections (blue/orange) from between-faction
+# ones (gray).
+hp = HivePlot(
+    graph=G,
+    partition_variable="club",
+    sorting_variables="degree",
+    node_graph_metrics="degree",
+    repeat_axes=True,
+    non_repeat_edge_kwargs={"color": "darkgray"},
+)
+hp.update_edges("Mr. Hi", "Mr. Hi", color="royalblue")
+hp.update_edges("Officer", "Officer", color="darkorange")
+
+# only two partition groups, so drop one of the two redundant sets of
+# between-faction edges
+hp.reset_edges(axis_id_1="Mr. Hi_repeat", axis_id_2="Officer")
+
+fig, ax = hp.plot()
+plt.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ example = [
     'igraph>=0.11',
     'scikit-learn>=1.5',
     'iplotx>=0.9.0',
+    'hiveplotlib[networkx]>=0.28',
 ]
 extra = [
     'lxml>=4.6',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ example = [
     'igraph>=0.11',
     'scikit-learn>=1.5',
     'iplotx>=0.9.0',
-    'hiveplotlib[networkx]>=0.28',
+    'hiveplotlib>=0.28',
 ]
 extra = [
     'lxml>=4.6',

--- a/requirements/example.txt
+++ b/requirements/example.txt
@@ -8,4 +8,4 @@ cairocffi>=1.7
 igraph>=0.11
 scikit-learn>=1.5
 iplotx>=0.9.0
-hiveplotlib[networkx]>=0.28
+hiveplotlib>=0.28

--- a/requirements/example.txt
+++ b/requirements/example.txt
@@ -8,3 +8,4 @@ cairocffi>=1.7
 igraph>=0.11
 scikit-learn>=1.5
 iplotx>=0.9.0
+hiveplotlib[networkx]>=0.28


### PR DESCRIPTION
Hi, I'm the creator and maintainer of [Hiveplotlib](https://pypi.org/project/hiveplotlib/), an open-source Python package for visualizing networks with hive plots in Matplotlib / Plotly / various Holoviz backends.

I just did a [new release](https://hiveplotlib.readthedocs.io/stable/changelog.html#version-0-28-0-released-jun-18-2026) intended to improve the integration between NetworkX and Hiveplotlib and am now optimistic that the tool is mature enough to mention in your docs.

This draft PR proposes doc additions discussing Hiveplotlib. I made changes to the Drawing page, and I added a standalone external example.

If this feels out of place for your docs or opens up too many directions of the myriad ways one can draw a hive plot, happy to leave this as "no hard feelings" and kill the PR entirely.

Or if you think this needs heavy edits, I'm happy to make whatever changes to have it meet your expectations.

One relevant tangent, I of course don't want to create work for any of you, but if anyone has any thoughts / ideas for things they wish Hiveplotlib had, I'd certainly appreciate any feedback on how I could make the tool more useful!

(Note, I drafted all changes for this PR using Claude, but have revised / approved every line of changes myself. I also confirmed the docs still build locally without warnings, and I ran precommit before pushing to my branch. Apologies if I've made any GitHub workflow mistakes, as I predominantly use GitLab.)

Thanks!
