### PR TITLE
Optimize Leiden data handling

### DIFF
--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -234,7 +234,7 @@ def leiden_partitions(
     # - set node_attributes dict keyed by node attr to dict keyed by node
 
     # delta function gives change in metric when merging two communities.
-    # The change due to splitting a set U from C is negating e.g. -delta_func(U, C-U)
+    # The change due to splitting a set U from C is negated e.g. -delta_func(U, C-U)
     # For one node, the change from moving node u from A to B is:
     # q_delta = delta_func(u, B) - delta_func(u, A-{u})
 
@@ -540,7 +540,7 @@ def leiden_partitions(
 
     while improvement_made:
         # _move_nodes_fast (name from paper) is like _one_level in nx.louvain
-        # Move nodes to new community with greatest increase in quality/matric
+        # Move nodes to new community with greatest increase in quality/metric
         # Start with the unrefined partition from previous stage.
         P = _move_nodes_fast(G, node2com, delta_func, seed=seed)
 
@@ -635,7 +635,7 @@ def _merge_node_subset(C, delta_func, seed, theta):
 
     # T[i] > 0 means community i is well connected to others
     # Definition of T in line 37 of pseudocode in paper (supplemental mat.)
-    # uses condition for "cpm" matric: E(C, S-C) >= gamma * |C| * (|S| - |C|)
+    # uses condition for "cpm" metric: E(C, S-C) >= gamma * |C| * (|S| - |C|)
     # where |X| is the node_weight of the set X of nodes.
     # We generalize to any metric by using condition T(i) > 0
     T = {i: delta_func(u, C - {u}) for i, u in enumerate(C)}

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -205,7 +205,7 @@ def leiden_partitions(
     list of sets of nodes
         A partition of `G` as a list of disjoint sets of nodes. Each set represents
         one community of nodes and each node of `G` appears in exactly one set.
-        The quality metric of the yielded partitions increases with each iteration.
+        The quality metric is nondecreasing across the yielded partitions.
 
     References
     ----------
@@ -536,8 +536,8 @@ def leiden_partitions(
         improvement_made = (Q_new - Q) > 0.0000001
         Q = Q_new
 
-        # Aggregate communities into the nodes for the next stage.
-        # Edges in next stage if any edges between nodes at this stage.
+        # Aggregate communities to make nodes for the next stage.
+        # Edges in next stage whenever any edges between nodes at this stage.
         # Sum node and edge data to get aggregated graph data.
         G, node2com = _create_aggregate_graph(G, P_refined, node_attributes)
 
@@ -551,6 +551,8 @@ def leiden_partitions(
 
         if metric == "cpm":
             node_weights = node_attributes["node_weight"]
+            # set node_Weight on graph so metric_function can find it
+            nx.set_node_attributes(G, node_weights, "node_weight")
         elif metric == "modularity":
             if is_directed:
                 in_degrees = node_attributes["in_degree"]
@@ -603,7 +605,7 @@ def _move_nodes_fast(G, node2com, delta_func, seed):
             # Requeue nbrs from other coms if not already in queue
             # Add to end of queue (revisit after currently queued nodes)
             nodes_to_revisit = u_nbrs - P[best_com]
-            dict_deque.update(dict.fromkeys(nodes_to_revisit))
+            dict_deque.update((n, None) for n in nodes_to_revisit)
 
     # remove empty sets from P
     return [p for p in P if p]
@@ -709,13 +711,15 @@ def _create_aggregate_graph(G, P_refined, node_attributes):
                 for attr_name, attr_dict in node_attributes.items():
                     agg_vals[attr_name] += attr_dict[G_node]
 
-            H.add_node(H_node_id, nodes=original_nodes, **agg_vals)
+            H.add_node(H_node_id, nodes=original_nodes)
             for attr_name in node_attributes:
                 H_node_attributes[attr_name][H_node_id] = agg_vals[attr_name]
             H_node_id += 1
-    # load H_node_attr into node_attributes dict (overwrites G data)
-    # This is a hack to morph node info in main function so delta_func can use it
-    # We could store this info as graph node data, but that is slower and fatter.
+    # load H_node_attr into node_attributes dict (overwrites G data with H data).
+    # The dict node_attributes is used in delta_func. When metric_function needs
+    # a node attr (see "node_weight" in "cpm") add to the graph too (after this
+    # function returns). The node_attributes dict is a hack to update node info
+    # inside delta_func. Could store it on H but that is slower and fatter.
     for attr_name in node_attributes:
         node_attributes[attr_name] = H_node_attributes[attr_name]
 

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -107,7 +107,7 @@ def leiden_communities(
     Examples
     --------
     >>> G = nx.barbell_graph(3, 4)
-    >>> cpm_comm = nx.community.leiden_communities(G, resolution=0.2, seed=62537129)
+    >>> cpm_comm = nx.community.leiden_communities(G, resolution=0.2, seed=62537113)
     >>> len(cpm_comm)
     3
     >>> sorted(sorted(c) for c in cpm_comm)
@@ -115,7 +115,7 @@ def leiden_communities(
 
     Higher resolution produces smaller sub-communities:
 
-    >>> cpm_comm = nx.community.leiden_communities(G, resolution=0.4, seed=62537129)
+    >>> cpm_comm = nx.community.leiden_communities(G, resolution=0.4, seed=62537114)
     >>> len(cpm_comm)
     4
     >>> sorted(sorted(c) for c in cpm_comm)

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -275,7 +275,7 @@ def leiden_partitions(
         node_attributes = ["node_weight"]
         nx.set_node_attributes(G, 1, name="node_weight")
 
-        metric = functools.partial(
+        metric_function = functools.partial(
             constant_potts_model,
             resolution=resolution,
             node_weight="node_weight",
@@ -333,7 +333,7 @@ def leiden_partitions(
 
     elif metric == "modularity":
         # Setup for (unipartite) modularity
-        metric = functools.partial(
+        metric_function = functools.partial(
             modularity,
             resolution=resolution,
             weight="weight",
@@ -423,7 +423,7 @@ def leiden_partitions(
         def barber_modularity():
             return
 
-        metric = barber_modularity
+        metric_function = barber_modularity
 
         node_attributes = ["red_degree", "blue_degree"]
 
@@ -479,7 +479,7 @@ def leiden_partitions(
         )
 
     # The setup phase has ended, the main algorithm now begins.
-    Q = metric(G, partition)
+    Q = metric_function(G, partition)
 
     improvement_made = True
     node2com = None
@@ -500,7 +500,7 @@ def leiden_partitions(
         P_refined_flat = [comm for P_ref in P_refined for comm in P_ref]
 
         # Stop when overall change is close to zero.
-        Q_new = metric(G, P_refined_flat)
+        Q_new = metric_function(G, P_refined_flat)
         improvement_made = (Q_new - Q) > 0.0000001
         Q = Q_new
 

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -241,36 +241,39 @@ def leiden_partitions(
     # For one node, the change from moving node u from A to B is:
     # q_delta = delta({u}, B) - delta({u}, A-{u})
 
-    is_directed = G.is_directed()
-    if G.is_multigraph():
+    orig_G = G  # make copy of original G to allow mutations
+    del G
+    is_directed = orig_G.is_directed()
+    if orig_G.is_multigraph():
         # Convert Multi(Di)Graph to (Di)Graph by summing edges
-        graph = nx.DiGraph() if is_directed else nx.Graph()
-        graph.add_nodes_from(G)
+        G = nx.DiGraph() if is_directed else nx.Graph()
+        G.add_nodes_from(orig_G)
         if weight is None:
-            graph.add_weighted_edges_from(
-                (u, v, len(kd)) for u, nbrs in G._adj.items() for v, kd in nbrs.items()
+            orig_adj = orig_G._adj.items()
+            G.add_weighted_edges_from(
+                (u, v, len(kd)) for u, nbrs in orig_adj for v, kd in nbrs.items()
             )
         else:
-            graph.add_weighted_edges_from(
+            G.add_weighted_edges_from(
                 (u, v, sum(dd.get(weight, 1) for dd in kd.values()))
-                for u, nbrs in G._adj.items()
+                for u, nbrs in orig_G._adj.items()
                 for v, kd in nbrs.items()
             )
     else:
-        # same nodes & class as G
-        graph = nx.empty_graph(G, create_using=G.__class__)
+        # same nodes & class as orig_G
+        G = nx.empty_graph(orig_G, create_using=orig_G.__class__)
         if weight is None:
-            graph.add_weighted_edges_from((*e, 1) for e in G.edges())
+            G.add_weighted_edges_from((*e, 1) for e in orig_G.edges())
         else:
-            graph.add_weighted_edges_from(G.edges(data=weight, default=1))
+            G.add_weighted_edges_from(orig_G.edges(data=weight, default=1))
     # node attr "nodes" holds the original nodes represented by this current node
     # initialize to point to itself
-    nx.set_node_attributes(graph, {n: {n} for n in G}, "nodes")
+    nx.set_node_attributes(G, {n: {n} for n in orig_G}, "nodes")
 
     if metric == "cpm":
         # Setup for constant potts model
         node_attributes = ["node_weight"]
-        nx.set_node_attributes(graph, 1, name="node_weight")
+        nx.set_node_attributes(G, 1, name="node_weight")
 
         metric = functools.partial(
             constant_potts_model,
@@ -285,25 +288,23 @@ def leiden_partitions(
 
             @line_profiler.profile
             def delta(nodes_to_add, community):
-                comm_size = sum(graph.nodes[u]["node_weight"] for u in community)
+                comm_size = sum(G.nodes[u]["node_weight"] for u in community)
                 if isinstance(nodes_to_add, set):
-                    nodes_size = sum(
-                        graph.nodes[u]["node_weight"] for u in nodes_to_add
-                    )
+                    nodes_size = sum(G.nodes[u]["node_weight"] for u in nodes_to_add)
 
                     if len(nodes_to_add) < len(community):
                         a, c = nodes_to_add, community
                     else:
                         a, c = community, nodes_to_add
-                    edges = graph.in_edges(a, data="weight", default=1)
+                    edges = G.in_edges(a, data="weight", default=1)
                     E_in = sum(wt for _, v, wt in edges if v in c)
-                    edges = graph.out_edges(a, data="weight", default=1)
+                    edges = G.out_edges(a, data="weight", default=1)
                     E_out = sum(wt for _, v, wt in edges if v in c)
                 else:
-                    nodes_size = graph.nodes[nodes_to_add]["node_weight"]
-                    nbrs = graph._pred[nodes_to_add].items()
+                    nodes_size = G.nodes[nodes_to_add]["node_weight"]
+                    nbrs = G._pred[nodes_to_add].items()
                     E_in = sum(d["weight"] for nbr, d in nbrs if nbr in community)
-                    nbrs = graph._succ[nodes_to_add].items()
+                    nbrs = G._succ[nodes_to_add].items()
                     E_out = sum(d["weight"] for nbr, d in nbrs if nbr in community)
 
                 return E_in + E_out - gamma * comm_size * nodes_size
@@ -314,20 +315,18 @@ def leiden_partitions(
 
             @line_profiler.profile
             def delta(nodes_to_add, community):
-                comm_size = sum(graph.nodes[u]["node_weight"] for u in community)
+                comm_size = sum(G.nodes[u]["node_weight"] for u in community)
                 if isinstance(nodes_to_add, set):
-                    nodes_size = sum(
-                        graph.nodes[u]["node_weight"] for u in nodes_to_add
-                    )
+                    nodes_size = sum(G.nodes[u]["node_weight"] for u in nodes_to_add)
                     if len(nodes_to_add) < len(community):
                         a, c = nodes_to_add, community
                     else:
                         a, c = community, nodes_to_add
-                    edges = graph.edges(a, data="weight", default=1)
+                    edges = G.edges(a, data="weight", default=1)
                     E = sum(wt for _, nbr, wt in edges if nbr in c)
                 else:
-                    nodes_size = graph.nodes[nodes_to_add]["node_weight"]
-                    nbrs = graph._adj[nodes_to_add].items()
+                    nodes_size = G.nodes[nodes_to_add]["node_weight"]
+                    nbrs = G._adj[nodes_to_add].items()
                     E = sum(d["weight"] for nbr, d in nbrs if nbr in community)
 
                 return E - gamma * comm_size * nodes_size
@@ -342,15 +341,15 @@ def leiden_partitions(
         if is_directed:
             # Setup for directed modularity
             node_attributes = ["in_degree", "out_degree"]
-            in_degrees = graph.in_degree(weight="weight")
-            out_degrees = graph.out_degree(weight="weight")
+            in_degrees = G.in_degree(weight="weight")
+            out_degrees = G.out_degree(weight="weight")
 
             m = sum(wt for u, wt in in_degrees) + sum(wt for u, wt in out_degrees)
-            for u, v, data in graph.edges(data=True):
+            for u, v, data in G.edges(data=True):
                 data["weight"] = data.get("weight", 1) / m
 
-            nx.set_node_attributes(graph, dict(in_degrees), "in_degree")
-            nx.set_node_attributes(graph, dict(out_degrees), "out_degree")
+            nx.set_node_attributes(G, dict(in_degrees), "in_degree")
+            nx.set_node_attributes(G, dict(out_degrees), "out_degree")
 
             gamma = 2 * resolution
 
@@ -367,9 +366,9 @@ def leiden_partitions(
                     c_in = sum(in_degrees[u] for u in c)
                     c_out = sum(out_degrees[u] for u in c)
 
-                    edges = graph.in_edges(a, data="weight", default=1)
+                    edges = G.in_edges(a, data="weight", default=1)
                     E_in = sum(wt for _, v, wt in edges if v in c)
-                    edges = graph.out_edges(a, data="weight", default=1)
+                    edges = G.out_edges(a, data="weight", default=1)
                     E_out = sum(wt for _, v, wt in edges if v in c)
                 else:
                     a_in = in_degrees[nodes_to_add]
@@ -377,9 +376,9 @@ def leiden_partitions(
                     c_in = sum(in_degrees[u] for u in community)
                     c_out = sum(out_degrees[u] for u in community)
 
-                    nbrs = graph._pred[nodes_to_add].items()
+                    nbrs = G._pred[nodes_to_add].items()
                     E_in = sum(d["weight"] for nbr, d in nbrs if nbr in community)
-                    nbrs = graph._succ[nodes_to_add].items()
+                    nbrs = G._succ[nodes_to_add].items()
                     E_out = sum(d["weight"] for nbr, d in nbrs if nbr in community)
 
                 return E_in + E_out - gamma * (a_in * c_out + a_out * c_in)
@@ -387,24 +386,24 @@ def leiden_partitions(
         else:
             # Setup for undirected modularity
             node_attributes = ["degree"]
-            degrees = graph.degree(weight="weight")
+            degrees = G.degree(weight="weight")
 
             m = sum(deg for u, deg in degrees) / 2
-            for u, v, data in graph.edges(data=True):
+            for u, v, data in G.edges(data=True):
                 data["weight"] = data.get(weight, 1) / m
-            nx.set_node_attributes(graph, {u: deg / m for u, deg in degrees}, "degree")
+            nx.set_node_attributes(G, {u: deg / m for u, deg in degrees}, "degree")
             gamma = 2 * resolution
 
             @line_profiler.profile
             def delta(nodes_to_add, community):
-                comm_size = sum(graph.nodes[u]["degree"] for u in community)
+                comm_size = sum(G.nodes[u]["degree"] for u in community)
                 if isinstance(nodes_to_add, set):
-                    nodes_size = sum(graph.nodes[u]["degree"] for u in nodes_to_add)
-                    edges = graph.edges(nodes_to_add, data="weight", default=1)
+                    nodes_size = sum(G.nodes[u]["degree"] for u in nodes_to_add)
+                    edges = G.edges(nodes_to_add, data="weight", default=1)
                     E = sum(wt for _, v, wt in edges if v in community)
                 else:
-                    nodes_size = graph.nodes[nodes_to_add]["degree"]
-                    nbrs = graph._adj[nodes_to_add].items()
+                    nodes_size = G.nodes[nodes_to_add]["degree"]
+                    nbrs = G._adj[nodes_to_add].items()
                     E = sum(d["weight"] for nbr, d in nbrs if nbr in community)
 
                 return E - gamma * nodes_size * comm_size
@@ -440,7 +439,7 @@ def leiden_partitions(
         #         "expecting node attribute 'bipartite', with values 0 or 1"
         #     )
 
-        degrees = graph.degree(weight="weight")
+        degrees = G.degree(weight="weight")
         m = sum(deg for u, deg in degrees) / 2
 
         red_degree = {u: G.degree(u, weight="weight") / m for u in red_nodes}
@@ -451,24 +450,24 @@ def leiden_partitions(
         for u in red_nodes:
             blue_degree[u] = 0
 
-        nx.set_node_attributes(graph, red_degree, "red_degree")
-        nx.set_node_attributes(graph, blue_degree, "blue_degree")
+        nx.set_node_attributes(G, red_degree, "red_degree")
+        nx.set_node_attributes(G, blue_degree, "blue_degree")
 
-        for u, v, data in graph.edges(data=True):
+        for u, v, data in G.edges(data=True):
             data["weight"] *= 1 / m
 
         def delta(nodes_to_add, community):
-            comm_red = sum(graph.nodes[u]["red_degree"] for u in community)
-            comm_blue = sum(graph.nodes[u]["blue_degree"] for u in community)
+            comm_red = sum(G.nodes[u]["red_degree"] for u in community)
+            comm_blue = sum(G.nodes[u]["blue_degree"] for u in community)
             if isinstance(nodes_to_add, set):
-                nodes_red = sum(graph.nodes[u]["red_degree"] for u in nodes_to_add)
-                nodes_blue = sum(graph.nodes[u]["blue_degree"] for u in nodes_to_add)
-                edges = graph.edges(nodes_to_add, data="weight", default=1)
+                nodes_red = sum(G.nodes[u]["red_degree"] for u in nodes_to_add)
+                nodes_blue = sum(G.nodes[u]["blue_degree"] for u in nodes_to_add)
+                edges = G.edges(nodes_to_add, data="weight", default=1)
                 E = sum(wt for _, v, wt in edges if v in community)
             else:
-                nodes_red = graph.nodes[nodes_to_add]["red_degree"]
-                nodes_blue = graph.nodes[nodes_to_add]["blue_degree"]
-                nbrs = graph._adj[nodes_to_add].items()
+                nodes_red = G.nodes[nodes_to_add]["red_degree"]
+                nodes_blue = G.nodes[nodes_to_add]["blue_degree"]
+                nbrs = G._adj[nodes_to_add].items()
                 E = sum(d["weight"] for nbr, d in nbrs if nbr in community)
 
             return E - resolution * (nodes_red * comm_blue + nodes_blue * comm_red)
@@ -480,7 +479,7 @@ def leiden_partitions(
         )
 
     # The setup phase has ended, the main algorithm now begins.
-    Q = metric(graph, partition)
+    Q = metric(G, partition)
 
     improvement_made = True
     node2com = None
@@ -494,40 +493,40 @@ def leiden_partitions(
         # unrefined partition of the previous stage. The dict
         # node2com specifies how these initial communities
         # are to be set. If None, use singleton communities.
-        P = _move_nodes_fast(graph, node2com, delta, seed=seed)
+        P = _move_nodes_fast(G, node2com, delta, seed=seed)
 
-        P_refined = _refine_partition(graph, P, delta, seed=seed, theta=theta)
+        P_refined = _refine_partition(G, P, delta, seed=seed, theta=theta)
 
         P_refined_flat = [comm for P_ref in P_refined for comm in P_ref]
 
         # Stop when overall change is close to zero.
-        Q_new = metric(graph, P_refined_flat)
+        Q_new = metric(G, P_refined_flat)
         improvement_made = (Q_new - Q) > 0.0000001
         Q = Q_new
 
-        graph, node2com = _create_aggregate_graph(graph, P_refined, node_attributes)
+        G, node2com = _create_aggregate_graph(G, P_refined, node_attributes)
 
         # the partition of the original underlying graph is read from
         # the node attribute 'nodes', which is set during _create_aggregate_graph(...)
         # Each node in graph represents a community in the original graph
         # and the node holds this information in the attribute 'nodes'.
-        # We yield a copy to protect the graph data structure for later iterations.
-        yield [set(graph.nodes[u]["nodes"]).copy() for u in graph]
+        # Yield a copy to protect the graph data structure for later iterations.
+        yield [nodes.copy() for _, nodes in G.nodes(data="nodes")]
 
     return
 
 
 @line_profiler.profile
-def _move_nodes_fast(graph, node2com, delta_func, seed):
+def _move_nodes_fast(G, node2com, delta_func, seed):
     if node2com is None:
-        P = [{node} for node in graph]
-        node2com = {node: i for i, node in enumerate(graph)}
+        P = [{node} for node in G]
+        node2com = {node: i for i, node in enumerate(G)}
     else:
-        P = [set() for _ in graph]
-        for i, node in enumerate(graph):
+        P = [set() for _ in G]
+        for i, node in enumerate(G):
             P[node2com[i]].add(node)
 
-    rand_nodes = list(graph)
+    rand_nodes = list(G)
     seed.shuffle(rand_nodes)
     node_queue = deque(rand_nodes)
     dict_deque = dict.fromkeys(reversed(rand_nodes))
@@ -538,7 +537,7 @@ def _move_nodes_fast(graph, node2com, delta_func, seed):
         dict_deque.pop(dd_u := next(iter(dict_deque)))
         assert u == dd_u
 
-        neighbor_coms = {node2com[v] for v in nx.all_neighbors(graph, u)}
+        neighbor_coms = {node2com[v] for v in nx.all_neighbors(G, u)}
 
         best_delta = 0
         old_com = node2com[u]
@@ -571,8 +570,8 @@ def _move_nodes_fast(graph, node2com, delta_func, seed):
             P[old_com].remove(u)
             P[best_com].add(u)
 
-            nbrs = graph._adj[u].keys()
-            nodes_to_visit = nbrs - P[best_com]
+            u_nbrs = G._adj[u].keys()
+            nodes_to_visit = u_nbrs - P[best_com]
 
             for v in nodes_to_visit:
                 assert (v not in dict_deque) == (v not in node_queue)

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -297,7 +297,7 @@ def leiden_partitions(
                     else:
                         a, c = community, nodes_to_add
                     edges = G.in_edges(a, data="weight", default=1)
-                    E_in = sum(wt for _, v, wt in edges if v in c)
+                    E_in = sum(wt for v, _, wt in edges if v in c)
                     edges = G.out_edges(a, data="weight", default=1)
                     E_out = sum(wt for _, v, wt in edges if v in c)
                 else:
@@ -367,7 +367,7 @@ def leiden_partitions(
                     c_out = sum(out_degrees[u] for u in c)
 
                     edges = G.in_edges(a, data="weight", default=1)
-                    E_in = sum(wt for _, v, wt in edges if v in c)
+                    E_in = sum(wt for v, _, wt in edges if v in c)
                     edges = G.out_edges(a, data="weight", default=1)
                     E_out = sum(wt for _, v, wt in edges if v in c)
                 else:

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -6,6 +6,8 @@ import math
 import random
 from collections import deque
 
+import line_profiler
+
 import networkx as nx
 from networkx.algorithms.community.quality import constant_potts_model, modularity
 from networkx.utils import not_implemented_for, py_random_state
@@ -157,6 +159,7 @@ def leiden_communities(
 
 @py_random_state("seed")
 @nx._dispatchable(edge_attrs="weight")
+@line_profiler.profile
 def leiden_partitions(
     G,
     *,
@@ -221,7 +224,6 @@ def leiden_partitions(
     """
 
     partition = [{u} for u in G]
-    refinement_mapping = None
 
     if nx.is_empty(G):
         yield partition
@@ -299,6 +301,7 @@ def leiden_partitions(
             # Setup for undirected constant potts model
             gamma = resolution
 
+            @line_profiler.profile
             def delta(nodes_to_add, community):
                 comm_size = sum(graph.nodes[u]["node_weight"] for u in community)
                 nodes_size = sum(graph.nodes[u]["node_weight"] for u in nodes_to_add)
@@ -443,6 +446,7 @@ def leiden_partitions(
     Q = metric(graph, partition)
 
     improvement_made = True
+    node2com = None
 
     while improvement_made:
         # _move_nodes_fast plays the same role as _one_level in the
@@ -451,9 +455,9 @@ def leiden_partitions(
 
         # leiden initialises nodes into communities based on the
         # unrefined partition of the previous stage. The dict
-        # refinement_mapping specifies how these initial communities
+        # node2com specifies how these initial communities
         # are to be set. If None, use singleton communities.
-        P = _move_nodes_fast(graph, refinement_mapping, delta, seed=seed)
+        P = _move_nodes_fast(graph, node2com, delta, seed=seed)
 
         P_refined = _refine_partition(graph, P, delta, seed=seed, theta=theta)
 
@@ -464,9 +468,7 @@ def leiden_partitions(
         improvement_made = (Q_new - Q) > 0.0000001
         Q = Q_new
 
-        graph, refinement_mapping = _create_aggregate_graph(
-            graph, P_refined, node_attributes
-        )
+        graph, node2com = _create_aggregate_graph(graph, P_refined, node_attributes)
 
         # the partition of the original underlying graph is read from
         # the node attribute 'nodes', which is set during _create_aggregate_graph(...)
@@ -478,24 +480,27 @@ def leiden_partitions(
     return
 
 
-def _move_nodes_fast(graph, partition, delta_func, seed):
-    # use refinement_mapping as beginning partition. If None, use singletons
-    if partition is None:
-        P = [{u} for u in graph]
-        node2com = {u: i for i, u in enumerate(graph)}
+@line_profiler.profile
+def _move_nodes_fast(graph, node2com, delta_func, seed):
+    if node2com is None:
+        P = [{node} for node in graph]
+        node2com = {node: i for i, node in enumerate(graph)}
     else:
-        P = [set() for _ in partition]
-        node2com = {}
-        for i, u in enumerate(graph):
-            P[partition[i]].add(u)
-            node2com[u] = partition[i]
+        P = [set() for _ in graph]
+        for i, node in enumerate(graph):
+            P[node2com[i]].add(node)
 
-    rand_nodes = list(graph.nodes)
+    rand_nodes = list(graph)
     seed.shuffle(rand_nodes)
     node_queue = deque(rand_nodes)
+    dict_deque = dict.fromkeys(reversed(rand_nodes))
 
     while node_queue:
         u = node_queue.pop()
+
+        dict_deque.pop(dd_u := next(iter(dict_deque)))
+        assert u == dd_u
+
         neighbor_coms = {node2com[v] for v in nx.all_neighbors(graph, u)}
 
         best_delta = 0
@@ -529,18 +534,21 @@ def _move_nodes_fast(graph, partition, delta_func, seed):
             P[old_com].remove(u)
             P[best_com].add(u)
 
-            neighbours = set(graph._adj[u])
-            nodes_to_visit = neighbours - P[best_com]
+            nbrs = graph._adj[u].keys()
+            nodes_to_visit = nbrs - P[best_com]
 
             for v in nodes_to_visit:
-                if v not in node_queue:
+                assert (v not in dict_deque) == (v not in node_queue)
+                if v not in node_queue:  # this looks O(|node+queue|). maybe continue?
                     node_queue.appendleft(v)
+            dict_deque.update(dict.fromkeys(nodes_to_visit))
 
-    P = list(filter(None, P))
+    P = [p for p in P if p]
 
     return P
 
 
+@line_profiler.profile
 def _refine_partition(
     G,
     P,
@@ -569,6 +577,7 @@ def _refine_partition(
     return P_refined
 
 
+@line_profiler.profile
 def _merge_node_subset(
     G,
     C,
@@ -617,15 +626,15 @@ def _merge_node_subset(
                 continue
 
             # We only consider merging u into a community that
-            # is within S. This is what is means for the resulting
+            # is within S. This is what it means for the resulting
             # partition to be a refinement of S.
 
             # this application of delta_func relates to the
             # definition of T in line :37 from pseudocode in paper
             if delta_func(new_comm, C - new_comm) > 0:
-                # the change in quality the occurs from moving node u
+                # the change in quality that occurs from moving node u
                 # into the new community
-                q_add = delta_func({u}, C_refined[i])
+                q_add = delta_func({u}, new_comm)
 
                 # the overall quality delta is therefore the sum
                 # of the change in quality from removing u from its
@@ -679,61 +688,44 @@ def _create_aggregate_graph(G, P_refined, node_attributes):
     communities in the new graph which comes from P. Each inner list holds
     the refined sets of nodes each of which becomes a new node. So P_refined
     contains P as the outer list and its refinement as the inner lists which
-    holds the refined community sets that make up the new graph's nodes.
+    hold the refined community sets that make up the new graph's nodes.
     """
+    nodes_G2H = {}
     H = G.__class__()
-    old2new = {}
-    new_node2com = {}
-    new_node_id = 0
-    for new_comm, refined_sets in enumerate(P_refined):
+    H_node2com = {}
+    H_node_id = 0
+    for H_comm, refined_sets in enumerate(P_refined):
         for refined_comm in refined_sets:
             # each set from the refined_sets defines
             # a node in the new aggregated graph. Name it new_node_id.
-            new_node2com[new_node_id] = new_comm
+            H_node2com[H_node_id] = H_comm
             agg_vals = {attribute: 0 for attribute in node_attributes}
 
             # contains the original graph nodes defining this new community
             original_nodes = set()
 
             # old_node is node from previous stage, not original graph
-            for old_node in refined_comm:
-                old2new[old_node] = new_node_id
+            for G_node in refined_comm:
+                nodes_G2H[G_node] = H_node_id
 
                 # aggregate node attributes
-                original_nodes.update(G.nodes[old_node]["nodes"])
+                ######## store G.nodes[*]["nodes"] in a dict?
+                original_nodes.update(G.nodes[G_node]["nodes"])
                 for node_attribute in node_attributes:
-                    agg_vals[node_attribute] += G.nodes[old_node][node_attribute]
+                    agg_vals[node_attribute] += G.nodes[G_node][node_attribute]
 
-            H.add_node(new_node_id, nodes=original_nodes, **agg_vals)
-            new_node_id += 1
+            H.add_node(H_node_id, nodes=original_nodes, **agg_vals)
+            H_node_id += 1
 
     H_adj = H._adj
     for u, v, uv_weight in G.edges(data="weight", default=1):
-        new_u = old2new[u]
-        new_v = old2new[v]
-        if new_u != new_v:
-            new_unbrs = H_adj[new_u]
-            if new_v in new_unbrs:
-                new_unbrs[new_v]["weight"] += uv_weight
+        H_u = nodes_G2H[u]
+        H_v = nodes_G2H[v]
+        if H_u != H_v:
+            H_unbrs = H_adj[H_u]
+            if H_v in H_unbrs:
+                H_unbrs[H_v]["weight"] += uv_weight
             else:
-                H.add_edge(new_u, new_v, weight=uv_weight)
+                H.add_edge(H_u, H_v, weight=uv_weight)
 
-    return H, new_node2com
-
-
-def _convert_multigraph(G, weight, is_directed):
-    """Convert a Multigraph to normal Graph"""
-    H.empty_graph(G, create_using=(nx.DiGraph if is_directed else nx.Graph))
-    H.add_weighted_edges_from(G.edges(data=weight, default=1))
-    return H
-    if is_directed:
-        H = nx.DiGraph()
-    else:
-        H = nx.Graph()
-
-    for u, v, wt in G.edges(data=weight, default=1):
-        if H.has_edge(u, v):
-            H[u][v]["weight"] += wt
-        else:
-            H.add_edge(u, v, weight=wt)
-    return H
+    return H, H_node2com

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -274,11 +274,13 @@ def leiden_partitions(
     G.graph["edge_wts"] = edge_wts
 
     if is_directed:
-        in_edge_wts = {u: {} for u in G}
         for u, nbrs in edge_wts.items():
             for v, wt in nbrs.items():
-                in_edge_wts[v][u] = wt
-        G.graph["in_edge_wts"] = in_edge_wts
+                v_wts = edge_wts[v]
+                if u in v_wts:
+                    v_wts[u] += wt
+                else:
+                    v_wts[u] = wt
 
     # node attr "nodes" holds the original nodes represented by this current node
     nx.set_node_attributes(G, {n: {n} for n in orig_G}, "nodes")
@@ -303,30 +305,30 @@ def leiden_partitions(
             # - gamma
             # - node_weights
             # - edge_wts
-            # - in_edge_wts
             def delta_func(nodes_to_add, community):
-                comm_size = sum(node_weights[u] for u in community)
+                if not community:
+                    return 0
                 if isinstance(nodes_to_add, set):
                     nodes_size = sum(node_weights[u] for u in nodes_to_add)
+                    comm_size = sum(node_weights[u] for u in community)
 
                     if len(nodes_to_add) <= len(community):
                         A, C = nodes_to_add, community
                     else:
                         A, C = community, nodes_to_add
-                    E_in = sum(
-                        wt for u in A for v, wt in in_edge_wts[u].items() if v in C
-                    )
-                    E_out = sum(
-                        wt for u in A for v, wt in edge_wts[u].items() if v in C
-                    )
+                    E = sum(wt for u in A for v, wt in edge_wts[u].items() if v in C)
                 else:
-                    nodes_size = node_weights[nodes_to_add]
+                    u = nodes_to_add
+                    nodes_size = node_weights[u]
+                    if len(community) == 1:
+                        v = next(iter(community))
+                        comm_size = node_weights[v]
+                        E = edge_wts[u].get(v, 0)
+                    else:
+                        comm_size = sum(node_weights[u] for u in community)
+                        E = sum(wt for v, wt in edge_wts[u].items() if v in community)
 
-                    u, C = nodes_to_add, community
-                    E_in = sum(wt for v, wt in in_edge_wts[u].items() if v in C)
-                    E_out = sum(wt for v, wt in edge_wts[u].items() if v in C)
-
-                return E_in + E_out - gamma * comm_size * nodes_size
+                return E - gamma * comm_size * nodes_size
 
         else:
             # Setup for undirected constant potts model
@@ -337,9 +339,11 @@ def leiden_partitions(
             # - node_weights
             # - edge_wts
             def delta_func(nodes_to_add, community):
-                comm_size = sum(node_weights[u] for u in community)
+                if not community:
+                    return 0
                 if isinstance(nodes_to_add, set):
                     nodes_size = sum(node_weights[u] for u in nodes_to_add)
+                    comm_size = sum(node_weights[u] for u in community)
 
                     if len(nodes_to_add) <= len(community):
                         A, C = nodes_to_add, community
@@ -347,10 +351,15 @@ def leiden_partitions(
                         A, C = community, nodes_to_add
                     E = sum(wt for u in A for v, wt in edge_wts[u].items() if v in C)
                 else:
-                    nodes_size = node_weights[nodes_to_add]
-
-                    u, C = nodes_to_add, community
-                    E = sum(wt for v, wt in edge_wts[u].items() if v in C)
+                    u = nodes_to_add
+                    nodes_size = node_weights[u]
+                    if len(community) > 1:
+                        comm_size = sum(node_weights[v] for v in community)
+                        E = sum(wt for v, wt in edge_wts[u].items() if v in community)
+                    else:
+                        v = next(iter(community))
+                        comm_size = node_weights[v]
+                        E = edge_wts[u].get(v, 0)
 
                 return E - gamma * comm_size * nodes_size
 
@@ -364,28 +373,21 @@ def leiden_partitions(
 
         if is_directed:
             # Setup for directed modularity
-            gamma = 2 * resolution
-
-            # scale edge weights by total so m == 1 and can be removed from formulas
             m = sum(wt for u, nbrs in edge_wts.items() for v, wt in nbrs.items())
-            for u, nbrs in in_edge_wts.items():
-                for v, wt in nbrs.items():
-                    in_edge_wts[u][v] /= m
-            for u, nbrs in edge_wts.items():
-                for v, wt in nbrs.items():
-                    edge_wts[u][v] /= m
+            gamma = 2 * resolution / m
 
-            in_degrees = {u: sum(nbrs.values()) for u, nbrs in in_edge_wts.items()}
-            out_degrees = {u: sum(nbrs.values()) for u, nbrs in edge_wts.items()}
+            in_degrees = dict(G.in_degree(weight="weight"))
+            out_degrees = dict(G.out_degree(weight="weight"))
             node_attributes = {"in_degree": in_degrees, "out_degree": out_degrees}
 
             # Note: delta_func uses objects in defining namespace:
             # - gamma
             # - in_degrees
             # - out_degrees
-            # - in_edge_wts
             # - edge_wts
             def delta_func(nodes_to_add, community):
+                if not community:
+                    return 0
                 if isinstance(nodes_to_add, set):
                     if len(nodes_to_add) <= len(community):
                         A, C = nodes_to_add, community
@@ -397,33 +399,27 @@ def leiden_partitions(
                     C_in = sum(in_degrees[u] for u in C)
                     C_out = sum(out_degrees[u] for u in C)
 
-                    E_in = sum(
-                        wt for u in A for v, wt in in_edge_wts[u].items() if v in C
-                    )
-                    E_out = sum(
-                        wt for u in A for v, wt in edge_wts[u].items() if v in C
-                    )
+                    E = sum(wt for u in A for v, wt in edge_wts[u].items() if v in C)
                 else:
-                    A_in = in_degrees[nodes_to_add]
-                    A_out = out_degrees[nodes_to_add]
-                    C_in = sum(in_degrees[u] for u in community)
-                    C_out = sum(out_degrees[u] for u in community)
+                    u = nodes_to_add
+                    A_in = in_degrees[u]
+                    A_out = out_degrees[u]
+                    if len(community) == 1:
+                        v = next(iter(community))
+                        C_in = in_degrees[v]
+                        C_out = out_degrees[v]
+                        E = edge_wts[u].get(v, 0)
+                    else:
+                        C_in = sum(in_degrees[u] for u in community)
+                        C_out = sum(out_degrees[u] for u in community)
+                        E = sum(wt for v, wt in edge_wts[u].items() if v in community)
 
-                    u, C = nodes_to_add, community
-                    E_in = sum(wt for v, wt in in_edge_wts[u].items() if v in C)
-                    E_out = sum(wt for v, wt in edge_wts[u].items() if v in C)
-
-                return E_in + E_out - gamma * (A_in * C_out + A_out * C_in)
+                return E - gamma * (A_in * C_out + A_out * C_in)
 
         else:
             # Setup for undirected modularity
-            gamma = 2 * resolution
-
-            # scale edge weights by total so m == 1 and can be removed from formulas
             m = sum(wt for u, nbrs in edge_wts.items() for v, wt in nbrs.items())
-            for u, nbrs in edge_wts.items():
-                for v, wt in nbrs.items():
-                    edge_wts[u][v] /= m
+            gamma = 2 * resolution / m
 
             degrees = {u: sum(nbrs.values()) for u, nbrs in edge_wts.items()}
             node_attributes = {"degree": degrees}
@@ -433,8 +429,10 @@ def leiden_partitions(
             # - degrees
             # - edge_wts
             def delta_func(nodes_to_add, community):
-                comm_size = sum(degrees[u] for u in community)
+                if not community:
+                    return 0
                 if isinstance(nodes_to_add, set):
+                    comm_size = sum(degrees[u] for u in community)
                     nodes_size = sum(degrees[u] for u in nodes_to_add)
 
                     if len(nodes_to_add) <= len(community):
@@ -443,10 +441,15 @@ def leiden_partitions(
                         A, C = community, nodes_to_add
                     E = sum(wt for u in A for v, wt in edge_wts[u].items() if v in C)
                 else:
-                    nodes_size = degrees[nodes_to_add]
-
-                    u, C = nodes_to_add, community
-                    E = sum(wt for v, wt in edge_wts[u].items() if v in C)
+                    u = nodes_to_add
+                    nodes_size = degrees[u]
+                    if len(community) == 1:
+                        v = next(iter(community))
+                        comm_size = degrees[v]
+                        E = edge_wts[u].get(v, 0)
+                    else:
+                        comm_size = sum(degrees[u] for u in community)
+                        E = sum(wt for v, wt in edge_wts[u].items() if v in community)
 
                 return E - gamma * nodes_size * comm_size
 
@@ -549,8 +552,6 @@ def leiden_partitions(
 
         # unpack node data of new G to this namespace so delta_func() can use it
         edge_wts = G.graph["edge_wts"]
-        if is_directed:
-            in_edge_wts = G.graph["in_edge_wts"]
 
         if metric == "cpm":
             node_weights = node_attributes["node_weight"]
@@ -596,9 +597,9 @@ def _move_nodes_fast(G, node2com, delta_func, seed):
 
         # decrease in metric when u is removed from its old community
         P_old_com = P[old_com]
-        u_rem = delta_func(u, P_old_com - {u})
+        without_u = P_old_com - {u}
 
-        if best_add > u_rem:
+        if best_add > (delta_func(u, without_u) if without_u else 0):
             node2com[u] = best_com
             P_old_com.remove(u)
             P[best_com].add(u)
@@ -613,17 +614,17 @@ def _move_nodes_fast(G, node2com, delta_func, seed):
 
 
 def _merge_node_subset(C, delta_func, seed, theta):
-    C_refined = [{u} for u in C]
-    # R contains well-connected nodes within C
-    R = {u: i for i, u in enumerate(C) if delta_func(u, C - {u}) > 0}
-
     # T[i] > 0 means community i is well connected to others
     # Definition of T in line 37 of pseudocode in paper (supplemental mat.)
     # uses condition for "cpm" metric: E(C, S-C) >= gamma * |C| * (|S| - |C|)
     # where |X| is the node_weight of the set X of nodes.
     # We generalize to any metric by using condition T(i) > 0
-    T = {i: delta_func(u, C - {u}) for i, u in enumerate(C)}
+    T = {i: (delta_func(u, C - {u}) if C - {u} else 0) for i, u in enumerate(C)}
 
+    # R contains well-connected nodes within C
+    R = {u: i for i, u in enumerate(C) if T[i] > 0}
+
+    C_refined = [{u} for u in C]
     for u, comm_i in R.items():
         # Only process nodes that are still in a singleton community {u}
         # - Find candidate communities for u to merge with
@@ -657,12 +658,13 @@ def _merge_node_subset(C, delta_func, seed, theta):
             new_comm_i = seed.choices(cand_comms, weights=cand_wts)[0]
 
             C_refined[comm_i].remove(u)
-            T[comm_i] = 0
+            T[comm_i] = 0  # comm_i is now empty (only looking at singleton comms)
             new_comm = C_refined[new_comm_i]
             new_comm.add(u)
             # Note: delta_func here has a set as 1st arg:
             #       returns delta when combining the two sets.
-            T[new_comm_i] = delta_func(new_comm, C - new_comm)
+            C_removed = C - new_comm
+            T[new_comm_i] = delta_func(new_comm, C_removed) if C_removed else 0
 
     return [c for c in C_refined if c]
 
@@ -720,29 +722,30 @@ def _create_aggregate_graph(G, P_refined, node_attributes):
     for attr_name in node_attributes:
         node_attributes[attr_name] = H_node_attributes[attr_name]
 
-    # Handle edge_wts, edges and in_edge_wts
+    # Handle edge_wts and edges
     is_directed = H.is_directed()
     H_edge_wts = {H_node: {} for H_node in H}
-    for u, nbrs in G.graph["edge_wts"].items():
+    for u, nbrs in G.adjacency():
         H_u = nodes_G2H[u]
         H_unbrs = H_edge_wts[H_u]
-        for v, uv_weight in nbrs.items():
+        for v, dd in nbrs.items():
             H_v = nodes_G2H[v]
             if H_u != H_v:
                 if H_v in H_unbrs:
-                    H_unbrs[H_v] += uv_weight
+                    H_unbrs[H_v] += dd["weight"]
                 else:
-                    H_unbrs[H_v] = uv_weight
+                    H_unbrs[H_v] = dd["weight"]
     H.add_weighted_edges_from(
         (u, v, wt) for u, nbrs in H_edge_wts.items() for v, wt in nbrs.items()
     )
     H.graph["edge_wts"] = H_edge_wts
 
     if is_directed:
-        H_in_edge_wts = {u: {} for u in H}
         for u, nbrs in H_edge_wts.items():
             for v, wt in nbrs.items():
-                H_in_edge_wts[v][u] = wt
-        H.graph["in_edge_wts"] = H_in_edge_wts
-
+                v_wts = H_edge_wts[v]
+                if u in v_wts:
+                    v_wts[u] += wt
+                else:
+                    v_wts[u] = wt
     return H, H_node2com

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -6,8 +6,6 @@ import math
 import random
 from collections import deque
 
-import line_profiler
-
 import networkx as nx
 from networkx.algorithms.community.quality import constant_potts_model, modularity
 from networkx.utils import not_implemented_for, py_random_state
@@ -159,7 +157,6 @@ def leiden_communities(
 
 @py_random_state("seed")
 @nx._dispatchable(edge_attrs="weight")
-@line_profiler.profile
 def leiden_partitions(
     G,
     *,
@@ -234,47 +231,76 @@ def leiden_partitions(
     # - node attributes initialized based on metric impact on node_weights aggregated
     # - define the metric function based on metric
     # - define the corresponding delta function
-    # - set node_attributes to names of node attrs summed when merging based on metric
+    # - set node_attributes dict keyed by node attr to dict keyed by node
 
     # delta function gives change in metric when merging two communities.
-    # The change due to splitting a set U from C is negating e.g. -delta(U, C-U)
+    # The change due to splitting a set U from C is negating e.g. -delta_func(U, C-U)
     # For one node, the change from moving node u from A to B is:
-    # q_delta = delta({u}, B) - delta({u}, A-{u})
+    # q_delta = delta_func(u, B) - delta_func(u, A-{u})
 
     orig_G = G  # make copy of original G to allow mutations
-    del G
     is_directed = orig_G.is_directed()
     if orig_G.is_multigraph():
         # Convert Multi(Di)Graph to (Di)Graph by summing edges
         G = nx.DiGraph() if is_directed else nx.Graph()
         G.add_nodes_from(orig_G)
+        G.add_edges_from(orig_G.edges())
         if weight is None:
-            orig_adj = orig_G._adj.items()
-            G.add_weighted_edges_from(
-                (u, v, len(kd)) for u, nbrs in orig_adj for v, kd in nbrs.items()
-            )
-        else:
-            G.add_weighted_edges_from(
-                (u, v, sum(dd.get(weight, 1) for dd in kd.values()))
+            edge_wts = {
+                u: {v: len(kd) for v, kd in nbrs.items()}
                 for u, nbrs in orig_G._adj.items()
-                for v, kd in nbrs.items()
-            )
+            }
+            if is_directed:
+                in_edge_wts = {
+                    u: {v: len(kd) for v, kd in nbrs.items()}
+                    for u, nbrs in orig_G._pred.items()
+                }
+        else:
+            edge_wts = {
+                u: {
+                    v: sum(dd.get(weight, 1) for dd in kd.values())
+                    for v, kd in nbrs.items()
+                }
+                for u, nbrs in orig_G._adj.items()
+            }
+            if is_directed:
+                in_edge_wts = {
+                    u: {
+                        v: sum(dd.get(weight, 1) for dd in kd.values())
+                        for v, kd in nbrs.items()
+                    }
+                    for u, nbrs in orig_G._pred.items()
+                }
     else:
         # same nodes & class as orig_G
         G = nx.empty_graph(orig_G, create_using=orig_G.__class__)
+        G.add_edges_from(orig_G.edges)
         if weight is None:
-            G.add_weighted_edges_from((*e, 1) for e in orig_G.edges())
+            edge_wts = {u: {v: 1 for v in nbrs} for u, nbrs in orig_G._adj.items()}
+            if is_directed:
+                in_edge_wts = {
+                    u: {v: 1 for v in nbrs} for u, nbrs in orig_G._pred.items()
+                }
         else:
-            G.add_weighted_edges_from(orig_G.edges(data=weight, default=1))
+            edge_wts = {
+                u: {v: dd.get(weight, 1) for v, dd in nbrs.items()}
+                for u, nbrs in orig_G._adj.items()
+            }
+            if is_directed:
+                in_edge_wts = {
+                    u: {v: dd.get(weight, 1) for v, dd in nbrs.items()}
+                    for u, nbrs in orig_G._pred.items()
+                }
+    G.graph["edge_wts"] = edge_wts
+    if is_directed:
+        G.graph["in_edge_wts"] = in_edge_wts
+
     # node attr "nodes" holds the original nodes represented by this current node
     # initialize to point to itself
     nx.set_node_attributes(G, {n: {n} for n in orig_G}, "nodes")
 
     if metric == "cpm":
         # Setup for constant potts model
-        node_attributes = ["node_weight"]
-        nx.set_node_attributes(G, 1, name="node_weight")
-
         metric_function = functools.partial(
             constant_potts_model,
             resolution=resolution,
@@ -282,30 +308,39 @@ def leiden_partitions(
             weight="weight",
         )
 
+        node_weights = dict.fromkeys(G, 1)
+        node_attributes = {"node_weight": node_weights}
+
         if is_directed:
             # Setup for directed constant potts model
             gamma = 2 * resolution
 
-            @line_profiler.profile
-            def delta(nodes_to_add, community):
-                comm_size = sum(G.nodes[u]["node_weight"] for u in community)
+            # Note: delta_func uses objects in defining namespace:
+            # - gamma
+            # - node_weights
+            # - edge_wts
+            # - in_edge_wts
+            def delta_func(nodes_to_add, community):
+                comm_size = sum(node_weights[u] for u in community)
                 if isinstance(nodes_to_add, set):
-                    nodes_size = sum(G.nodes[u]["node_weight"] for u in nodes_to_add)
+                    nodes_size = sum(node_weights[u] for u in nodes_to_add)
 
-                    if len(nodes_to_add) < len(community):
-                        a, c = nodes_to_add, community
+                    if len(nodes_to_add) <= len(community):
+                        A, C = nodes_to_add, community
                     else:
-                        a, c = community, nodes_to_add
-                    edges = G.in_edges(a, data="weight", default=1)
-                    E_in = sum(wt for v, _, wt in edges if v in c)
-                    edges = G.out_edges(a, data="weight", default=1)
-                    E_out = sum(wt for _, v, wt in edges if v in c)
+                        A, C = community, nodes_to_add
+                    E_in = sum(
+                        wt for u in A for v, wt in in_edge_wts[u].items() if v in C
+                    )
+                    E_out = sum(
+                        wt for u in A for v, wt in edge_wts[u].items() if v in C
+                    )
                 else:
-                    nodes_size = G.nodes[nodes_to_add]["node_weight"]
-                    nbrs = G._pred[nodes_to_add].items()
-                    E_in = sum(d["weight"] for nbr, d in nbrs if nbr in community)
-                    nbrs = G._succ[nodes_to_add].items()
-                    E_out = sum(d["weight"] for nbr, d in nbrs if nbr in community)
+                    nodes_size = node_weights[nodes_to_add]
+
+                    u, C = nodes_to_add, community
+                    E_in = sum(wt for v, wt in in_edge_wts[u].items() if v in C)
+                    E_out = sum(wt for v, wt in edge_wts[u].items() if v in C)
 
                 return E_in + E_out - gamma * comm_size * nodes_size
 
@@ -313,21 +348,25 @@ def leiden_partitions(
             # Setup for undirected constant potts model
             gamma = resolution
 
-            @line_profiler.profile
-            def delta(nodes_to_add, community):
-                comm_size = sum(G.nodes[u]["node_weight"] for u in community)
+            # Note: delta_func uses objects in defining namespace:
+            # - gamma
+            # - node_weights
+            # - edge_wts
+            def delta_func(nodes_to_add, community):
+                comm_size = sum(node_weights[u] for u in community)
                 if isinstance(nodes_to_add, set):
-                    nodes_size = sum(G.nodes[u]["node_weight"] for u in nodes_to_add)
-                    if len(nodes_to_add) < len(community):
-                        a, c = nodes_to_add, community
+                    nodes_size = sum(node_weights[u] for u in nodes_to_add)
+
+                    if len(nodes_to_add) <= len(community):
+                        A, C = nodes_to_add, community
                     else:
-                        a, c = community, nodes_to_add
-                    edges = G.edges(a, data="weight", default=1)
-                    E = sum(wt for _, nbr, wt in edges if nbr in c)
+                        A, C = community, nodes_to_add
+                    E = sum(wt for u in A for v, wt in edge_wts[u].items() if v in C)
                 else:
-                    nodes_size = G.nodes[nodes_to_add]["node_weight"]
-                    nbrs = G._adj[nodes_to_add].items()
-                    E = sum(d["weight"] for nbr, d in nbrs if nbr in community)
+                    nodes_size = node_weights[nodes_to_add]
+
+                    u, C = nodes_to_add, community
+                    E = sum(wt for v, wt in edge_wts[u].items() if v in C)
 
                 return E - gamma * comm_size * nodes_size
 
@@ -338,78 +377,97 @@ def leiden_partitions(
             resolution=resolution,
             weight="weight",
         )
+
         if is_directed:
             # Setup for directed modularity
-            node_attributes = ["in_degree", "out_degree"]
-            in_degrees = G.in_degree(weight="weight")
-            out_degrees = G.out_degree(weight="weight")
-
-            m = sum(wt for u, wt in in_degrees) + sum(wt for u, wt in out_degrees)
-            for u, v, data in G.edges(data=True):
-                data["weight"] = data.get("weight", 1) / m
-
-            nx.set_node_attributes(G, dict(in_degrees), "in_degree")
-            nx.set_node_attributes(G, dict(out_degrees), "out_degree")
-
             gamma = 2 * resolution
 
-            @line_profiler.profile
-            def delta(nodes_to_add, community):
+            # scale edge weights by total so m == 1 and can be removed from formulas
+            m = sum(wt for u, nbrs in edge_wts.items() for v, wt in nbrs.items())
+            for u, nbrs in in_edge_wts.items():
+                for v, wt in nbrs.items():
+                    in_edge_wts[u][v] /= m
+            for u, nbrs in edge_wts.items():
+                for v, wt in nbrs.items():
+                    edge_wts[u][v] /= m
+
+            in_degrees = {u: sum(nbrs.values()) for u, nbrs in in_edge_wts.items()}
+            out_degrees = {u: sum(nbrs.values()) for u, nbrs in edge_wts.items()}
+            node_attributes = {"in_degree": in_degrees, "out_degree": out_degrees}
+
+            # Note: delta_func uses objects in defining namespace:
+            # - gamma
+            # - in_degrees
+            # - out_degrees
+            # - in_edge_wts
+            # - edge_wts
+            def delta_func(nodes_to_add, community):
                 if isinstance(nodes_to_add, set):
-                    if len(nodes_to_add) < len(community):
-                        a, c = nodes_to_add, community
+                    if len(nodes_to_add) <= len(community):
+                        A, C = nodes_to_add, community
                     else:
-                        a, c = community, nodes_to_add
+                        A, C = community, nodes_to_add
 
-                    a_in = sum(in_degrees[u] for u in a)
-                    a_out = sum(out_degrees[u] for u in a)
-                    c_in = sum(in_degrees[u] for u in c)
-                    c_out = sum(out_degrees[u] for u in c)
+                    A_in = sum(in_degrees[u] for u in A)
+                    A_out = sum(out_degrees[u] for u in A)
+                    C_in = sum(in_degrees[u] for u in C)
+                    C_out = sum(out_degrees[u] for u in C)
 
-                    edges = G.in_edges(a, data="weight", default=1)
-                    E_in = sum(wt for v, _, wt in edges if v in c)
-                    edges = G.out_edges(a, data="weight", default=1)
-                    E_out = sum(wt for _, v, wt in edges if v in c)
+                    E_in = sum(
+                        wt for u in A for v, wt in in_edge_wts[u].items() if v in C
+                    )
+                    E_out = sum(
+                        wt for u in A for v, wt in edge_wts[u].items() if v in C
+                    )
                 else:
-                    a_in = in_degrees[nodes_to_add]
-                    a_out = out_degrees[nodes_to_add]
-                    c_in = sum(in_degrees[u] for u in community)
-                    c_out = sum(out_degrees[u] for u in community)
+                    A_in = in_degrees[nodes_to_add]
+                    A_out = out_degrees[nodes_to_add]
+                    C_in = sum(in_degrees[u] for u in community)
+                    C_out = sum(out_degrees[u] for u in community)
 
-                    nbrs = G._pred[nodes_to_add].items()
-                    E_in = sum(d["weight"] for nbr, d in nbrs if nbr in community)
-                    nbrs = G._succ[nodes_to_add].items()
-                    E_out = sum(d["weight"] for nbr, d in nbrs if nbr in community)
+                    u, C = nodes_to_add, community
+                    E_in = sum(wt for v, wt in in_edge_wts[u].items() if v in C)
+                    E_out = sum(wt for v, wt in edge_wts[u].items() if v in C)
 
-                return E_in + E_out - gamma * (a_in * c_out + a_out * c_in)
+                return E_in + E_out - gamma * (A_in * C_out + A_out * C_in)
 
         else:
             # Setup for undirected modularity
-            node_attributes = ["degree"]
-            degrees = G.degree(weight="weight")
-
-            m = sum(deg for u, deg in degrees) / 2
-            for u, v, data in G.edges(data=True):
-                data["weight"] = data.get(weight, 1) / m
-            nx.set_node_attributes(G, {u: deg / m for u, deg in degrees}, "degree")
             gamma = 2 * resolution
 
-            @line_profiler.profile
-            def delta(nodes_to_add, community):
-                comm_size = sum(G.nodes[u]["degree"] for u in community)
+            # scale edge weights by total so m == 1 and can be removed from formulas
+            m = sum(wt for u, nbrs in edge_wts.items() for v, wt in nbrs.items())
+            for u, nbrs in edge_wts.items():
+                for v, wt in nbrs.items():
+                    edge_wts[u][v] /= m
+
+            degrees = {u: sum(nbrs.values()) for u, nbrs in edge_wts.items()}
+            node_attributes = {"degree": degrees}
+
+            # Note: delta_func uses objects in defining namespace:
+            # - gamma
+            # - degrees
+            # - edge_wts
+            def delta_func(nodes_to_add, community):
+                comm_size = sum(degrees[u] for u in community)
                 if isinstance(nodes_to_add, set):
-                    nodes_size = sum(G.nodes[u]["degree"] for u in nodes_to_add)
-                    edges = G.edges(nodes_to_add, data="weight", default=1)
-                    E = sum(wt for _, v, wt in edges if v in community)
+                    nodes_size = sum(degrees[u] for u in nodes_to_add)
+
+                    if len(nodes_to_add) <= len(community):
+                        A, C = nodes_to_add, community
+                    else:
+                        A, C = community, nodes_to_add
+                    E = sum(wt for u in A for v, wt in edge_wts[u].items() if v in C)
                 else:
-                    nodes_size = G.nodes[nodes_to_add]["degree"]
-                    nbrs = G._adj[nodes_to_add].items()
-                    E = sum(d["weight"] for nbr, d in nbrs if nbr in community)
+                    nodes_size = degrees[nodes_to_add]
+
+                    u, C = nodes_to_add, community
+                    E = sum(wt for v, wt in edge_wts[u].items() if v in C)
 
                 return E - gamma * nodes_size * comm_size
 
     elif metric == "barber_modularity":
-        # Setup for undirected bipartite barber modularity (not yet fully implemented)
+        # Setup for undirected bipartite barber modularity (not fully implemented)
 
         if is_directed:
             raise nx.NetworkXError("barber_modularity not implemented for DiGraph")
@@ -425,50 +483,46 @@ def leiden_partitions(
 
         metric_function = barber_modularity
 
-        node_attributes = ["red_degree", "blue_degree"]
+        # scale edge weights by total so m == 1 and can be removed from formulas
+        m = sum(wt for u, nbrs in edge_wts.items() for v, wt in nbrs.items())
+        for u, nbrs in edge_wts.items():
+            for v, wt in nbrs.items():
+                edge_wts[u][v] /= m
 
         red_nodes = {u for u, c in G.nodes(data="bipartite") if c == 0}
         blue_nodes = {u for u, c in G.nodes(data="bipartite") if c == 1}
+        # TODO add check for this being a bipartite graph
 
-        # expect the bipartite graph G to follow the NetworkX convention to have node
-        # a node attribe bipartite taking value 0 or 1, so should check this using
-        # something like the following:
-        #
-        # if len(red_nodes.union(blue_nodes)) < len(G):
-        #    raise nx.NetworkXError(
-        #         "expecting node attribute 'bipartite', with values 0 or 1"
-        #     )
+        red_degrees = {u: sum(edge_wts[u].values()) for u in red_nodes}
+        red_degrees.update((u, 0) for u in blue_nodes)
+        blue_degrees = {u: sum(edge_wts[u].values()) for u in blue_nodes}
+        blue_degrees.update((u, 0) for u in red_nodes)
 
-        degrees = G.degree(weight="weight")
-        m = sum(deg for u, deg in degrees) / 2
+        node_attributes = {"red_degree": red_degrees, "blue_degree": blue_degrees}
 
-        red_degree = {u: G.degree(u, weight="weight") / m for u in red_nodes}
-        for u in blue_nodes:
-            red_degree[u] = 0
-
-        blue_degree = {u: G.degree(u, weight="weight") / m for u in blue_nodes}
-        for u in red_nodes:
-            blue_degree[u] = 0
-
-        nx.set_node_attributes(G, red_degree, "red_degree")
-        nx.set_node_attributes(G, blue_degree, "blue_degree")
-
-        for u, v, data in G.edges(data=True):
-            data["weight"] *= 1 / m
-
-        def delta(nodes_to_add, community):
-            comm_red = sum(G.nodes[u]["red_degree"] for u in community)
-            comm_blue = sum(G.nodes[u]["blue_degree"] for u in community)
+        # Note: delta_func uses objects in defining namespace:
+        # - gamma
+        # - red_degrees
+        # - blue_degrees
+        # - edge_wts
+        def delta_func(nodes_to_add, community):
+            comm_red = sum(red_degrees[u] for u in community)
+            comm_blue = sum(blue_degrees[u] for u in community)
             if isinstance(nodes_to_add, set):
-                nodes_red = sum(G.nodes[u]["red_degree"] for u in nodes_to_add)
-                nodes_blue = sum(G.nodes[u]["blue_degree"] for u in nodes_to_add)
-                edges = G.edges(nodes_to_add, data="weight", default=1)
-                E = sum(wt for _, v, wt in edges if v in community)
+                nodes_red = sum(red_degrees[u] for u in nodes_to_add)
+                nodes_blue = sum(blue_degrees[u] for u in nodes_to_add)
+
+                if len(nodes_to_add) <= len(community):
+                    A, C = nodes_to_add, community
+                else:
+                    A, C = community, nodes_to_add
+                E = sum(wt for u in A for v, wt in edge_wts[u].items() if v in C)
             else:
-                nodes_red = G.nodes[nodes_to_add]["red_degree"]
-                nodes_blue = G.nodes[nodes_to_add]["blue_degree"]
-                nbrs = G._adj[nodes_to_add].items()
-                E = sum(d["weight"] for nbr, d in nbrs if nbr in community)
+                nodes_red = red_degrees[nodes_to_add]
+                nodes_blue = blue_degrees[nodes_to_add]
+
+                u, C = nodes_to_add, community
+                E = sum(wt for v, wt in edge_wts[u].items() if v in C)
 
             return E - resolution * (nodes_red * comm_blue + nodes_blue * comm_red)
 
@@ -482,174 +536,130 @@ def leiden_partitions(
     Q = metric_function(G, partition)
 
     improvement_made = True
-    node2com = None
+    node2com = {node: i for i, node in enumerate(G)}
 
     while improvement_made:
-        # _move_nodes_fast plays the same role as _one_level in the
-        # networkx implementation of the louvain algorithm
-        # when moving nodes to find the greatest increase in quality,
+        # _move_nodes_fast (name from paper) is like _one_level in nx.louvain
+        # Move nodes to new community with greatest increase in quality/matric
+        # Start with the unrefined partition from previous stage.
+        P = _move_nodes_fast(G, node2com, delta_func, seed=seed)
 
-        # leiden initialises nodes into communities based on the
-        # unrefined partition of the previous stage. The dict
-        # node2com specifies how these initial communities
-        # are to be set. If None, use singleton communities.
-        P = _move_nodes_fast(G, node2com, delta, seed=seed)
-
-        P_refined = _refine_partition(G, P, delta, seed=seed, theta=theta)
-
-        P_refined_flat = [comm for P_ref in P_refined for comm in P_ref]
+        # Refine the communities using _merge_node_subset (name from paper)
+        P_refined = [_merge_node_subset(C, delta_func, seed, theta) for C in P]
+        P_refined_flat = [comm for p in P_refined for comm in p]
 
         # Stop when overall change is close to zero.
         Q_new = metric_function(G, P_refined_flat)
         improvement_made = (Q_new - Q) > 0.0000001
         Q = Q_new
 
+        # Aggregate communities into the nodes for the next stage.
+        # Edges in next stage if any edges between nodes at this stage.
+        # Sum node and edge data to get aggregated graph data.
         G, node2com = _create_aggregate_graph(G, P_refined, node_attributes)
 
-        # the partition of the original underlying graph is read from
-        # the node attribute 'nodes', which is set during _create_aggregate_graph(...)
-        # Each node in graph represents a community in the original graph
-        # and the node holds this information in the attribute 'nodes'.
-        # Yield a copy to protect the graph data structure for later iterations.
+        # Each node in G represents a community in the original graph
+        # held in G.nodes(data="nodes").
+        # Yield a copy to protect this data structure for later stages.
         yield [nodes.copy() for _, nodes in G.nodes(data="nodes")]
 
+        # unpack node data of new G to this namespace so delta_func() can use it
+        edge_wts = G.graph["edge_wts"]
+        if is_directed:
+            in_edge_wts = G.graph["in_edge_wts"]
+
+        if metric == "cpm":
+            node_weights = node_attributes["node_weight"]
+        elif metric == "modularity":
+            if is_directed:
+                in_degrees = node_attributes["in_degree"]
+                out_degrees = node_attributes["out_degree"]
+            else:
+                degrees = node_attributes["degree"]
+        elif metric == "barber_modularity":
+            red_degrees = node_attributes["red_degree"]
+            blue_degrees = node_attributes["blue_degree"]
     return
 
 
-@line_profiler.profile
 def _move_nodes_fast(G, node2com, delta_func, seed):
-    if node2com is None:
-        P = [{node} for node in G]
-        node2com = {node: i for i, node in enumerate(G)}
-    else:
-        P = [set() for _ in G]
-        for i, node in enumerate(G):
-            P[node2com[i]].add(node)
+    P = [set() for _ in node2com]
+    for node, comm in node2com.items():
+        P[comm].add(node)
 
-    rand_nodes = list(G)
+    rand_nodes = list(node2com)
     seed.shuffle(rand_nodes)
-    node_queue = deque(rand_nodes)
-    dict_deque = dict.fromkeys(reversed(rand_nodes))
 
-    while node_queue:
-        u = node_queue.pop()
+    # Use dict as a partial deque (pop_left, pop and update_right with no dups).
+    # pop_left takes two steps using next(iter()) and pop.
+    # update adds to the end only if not in queue already.
+    # membership check is O(1) (speedup over deque).
+    dict_deque = dict.fromkeys(rand_nodes)
+    while dict_deque:
+        # pop first node in queue
+        u = next(iter(dict_deque))
+        dict_deque.pop(u)
 
-        dict_deque.pop(dd_u := next(iter(dict_deque)))
-        assert u == dd_u
-
-        neighbor_coms = {node2com[v] for v in nx.all_neighbors(G, u)}
-
-        best_delta = 0
         old_com = node2com[u]
-        best_com = old_com
+        # get neighbors (both in & out when directed)
+        u_nbrs = set(nx.all_neighbors(G, u))
+        nbr_coms = {node2com[v] for v in u_nbrs} - {old_com}
+        if not nbr_coms:
+            continue
 
-        # this value is the overall change in quality that occurs
-        # when node u is removed from its current community
-        q_rem = delta_func(u, P[old_com] - {u})
+        # find community to move u to with biggest increase in metric
+        best_add, best_com = max((delta_func(u, P[c]), c) for c in nbr_coms)
 
-        # for each node in the queue, we measure the change in quality
-        # from moving that node to each other community, keeping track of
-        # the community that gives the greatest improvement best_com
-        for new_com in neighbor_coms:
-            if new_com != old_com:
-                # this quantity is the overall change in quality that
-                # occurs when the node u is added to the new community
-                q_add = delta_func(u, P[new_com])
+        # decrease in metric when u is removed from its old community
+        P_old_com = P[old_com]
+        u_rem = delta_func(u, P_old_com - {u})
 
-                # the overall change in quality therefore from moving
-                # node u from old_com to new_com is as follows
-                Q_delta = q_add - q_rem
-
-                if Q_delta > best_delta:
-                    best_delta = Q_delta
-                    best_com = new_com
-
-        if best_delta > 0:
+        if best_add > u_rem:
             node2com[u] = best_com
-
-            P[old_com].remove(u)
+            P_old_com.remove(u)
             P[best_com].add(u)
 
-            u_nbrs = G._adj[u].keys()
-            nodes_to_visit = u_nbrs - P[best_com]
+            # Requeue nbrs from other coms if not already in queue
+            # Add to end of queue (revisit after currently queued nodes)
+            nodes_to_revisit = u_nbrs - P[best_com]
+            dict_deque.update(dict.fromkeys(nodes_to_revisit))
 
-            for v in nodes_to_visit:
-                assert (v not in dict_deque) == (v not in node_queue)
-                if v not in node_queue:  # this looks O(|node+queue|). maybe continue?
-                    node_queue.appendleft(v)
-            dict_deque.update(dict.fromkeys(nodes_to_visit))
-
-    P = [p for p in P if p]
-
-    return P
+    # remove empty sets from P
+    return [p for p in P if p]
 
 
-@line_profiler.profile
-def _refine_partition(
-    G,
-    P,
-    delta_func,
-    seed,
-    theta,
-):
-
-    P_refined = []
-
-    for C in P:
-        # each community C in the partition P
-        # is split into a set of smaller communities
-        # resulting in a refined partition
-
-        C_refined = _merge_node_subset(
-            G,
-            C,
-            delta_func,
-            seed,
-            theta,
-        )
-        P_refined.append(C_refined)
-
-    return P_refined
-
-
-@line_profiler.profile
-def _merge_node_subset(
-    G,
-    C,
-    delta_func,
-    seed,
-    theta,
-):
-    node2com = {u: i for i, u in enumerate(C)}
+def _merge_node_subset(C, delta_func, seed, theta):
     C_refined = [{u} for u in C]
     # R contains well-connected nodes within C
-    R = {u for u in C if delta_func(u, C - {u}) > 0}
+    R = {u: i for i, u in enumerate(C) if delta_func(u, C - {u}) > 0}
 
-    for u in R:
-        # merge nodes that are in a singleton community {u}
+    # T[i] > 0 means community i is well connected to others
+    # Definition of T in line 37 of pseudocode in paper (supplemental mat.)
+    # uses condition for "cpm" matric: E(C, S-C) >= gamma * |C| * (|S| - |C|)
+    # where |X| is the node_weight of the set X of nodes.
+    # We generalize to any metric by using condition T(i) > 0
+    T = {i: delta_func(u, C - {u}) for i, u in enumerate(C)}
+
+    for u, comm_i in R.items():
+        # Only process nodes that are still in a singleton community {u}
         # - Find candidate communities for u to merge with
         # - Select one randomly based on relative delta for each community
         #   Note: not choosing the best one
-        comm = node2com[u]
-        if len(C_refined[comm]) != 1:
+        if len(C_refined[comm_i]) != 1:
             continue
+
         cand_comms = []
         cand_comm_deltas = []
-
         # Note: delta for removing u from current comm is 0 (singleton comm)
         for i, new_comm in enumerate(C_refined):
-            if comm == i:
+            # Main condition is T[i] > 0. also not empty and not same community
+            if comm_i == i or not new_comm or T[i] <= 0:
                 continue
 
-            # this application of delta_func relates to the
-            # definition of T in line :37 from pseudocode in paper
-            # condition is: E(C, S-C) >= gamma * |C| * (|S| - |C|)
-            # where |X| is the node_weight of the set X of nodes.
-            if delta_func(new_comm, C - new_comm) > 0:
-                Q_delta = delta_func(u, new_comm)
-                if Q_delta > 0:
-                    cand_comms.append(i)
-                    cand_comm_deltas.append(Q_delta)
+            Q_delta = delta_func(u, new_comm)
+            if Q_delta > 0:
+                cand_comms.append(i)
+                cand_comm_deltas.append(Q_delta)
 
         # select one candidate community at random
         if cand_comms:
@@ -660,11 +670,15 @@ def _merge_node_subset(
             #       math.exp((Q_delta - max_Q_delta)/theta)
             max_delta = max(cand_comm_deltas)
             cand_wts = [math.exp((x - max_delta) / theta) for x in cand_comm_deltas]
-            new_comm = seed.choices(cand_comms, weights=cand_wts)[0]
+            new_comm_i = seed.choices(cand_comms, weights=cand_wts)[0]
 
-            C_refined[comm].remove(u)
-            C_refined[new_comm].add(u)
-            node2com[u] = new_comm
+            C_refined[comm_i].remove(u)
+            T[comm_i] = 0
+            new_comm = C_refined[new_comm_i]
+            new_comm.add(u)
+            # Note: delta_func here has a set as 1st arg:
+            #       returns delta when combining the two sets.
+            T[new_comm_i] = delta_func(new_comm, C - new_comm)
 
     return [c for c in C_refined if c]
 
@@ -672,51 +686,76 @@ def _merge_node_subset(
 def _create_aggregate_graph(G, P_refined, node_attributes):
     """Return a new graph based on P_refined. Each community becomes a node.
 
-    node_attributes is a list of attribute names required for this metric.
-    Sum each node attribute when aggregating a community into a new node.
+    Note: `node_attributes` is changed in place by this function!
 
     P_refined is a list of lists of community sets. The outer list indicates
     communities in the new graph which comes from P. Each inner list holds
     the refined sets of nodes each of which becomes a new node. So P_refined
     contains P as the outer list and its refinement as the inner lists which
     hold the refined community sets that make up the new graph's nodes.
+
+    node_attributes is a dict keyed by each attribute name to be aggregated
+    which depends on the metric being used.
+    The value is a dict for that attribute keyed by node to the attribute value.
+    Aggregate means sum within a G community into a new node in H.
+    After this function the incoming dict values are replaced by aggregated dicts.
     """
+    G_original_nodes = G.nodes(data="nodes")
+
     nodes_G2H = {}
     H = G.__class__()
     H_node2com = {}
     H_node_id = 0
-    for H_comm, refined_sets in enumerate(P_refined):
-        for refined_comm in refined_sets:
+    H_node_attributes = {attr_name: {} for attr_name in node_attributes}
+    for H_comm_id, refined_comms in enumerate(P_refined):
+        for refined_comm in refined_comms:
             # each set from the refined_sets defines
             # a node in the new aggregated graph. Name it new_node_id.
-            H_node2com[H_node_id] = H_comm
+            H_node2com[H_node_id] = H_comm_id
             agg_vals = {attribute: 0 for attribute in node_attributes}
 
             # contains the original graph nodes defining this new community
             original_nodes = set()
 
-            # old_node is node from previous stage, not original graph
+            # G_node is node from previous stage, not original graph
             for G_node in refined_comm:
                 nodes_G2H[G_node] = H_node_id
 
                 # aggregate node attributes
-                ######## store G.nodes[*]["nodes"] in a dict?
-                original_nodes.update(G.nodes[G_node]["nodes"])
-                for node_attribute in node_attributes:
-                    agg_vals[node_attribute] += G.nodes[G_node][node_attribute]
+                original_nodes.update(G_original_nodes[G_node])
+                for attr_name, attr_dict in node_attributes.items():
+                    agg_vals[attr_name] += attr_dict[G_node]
 
-            H.add_node(H_node_id, nodes=original_nodes, **agg_vals)
+            H.add_node(H_node_id, nodes=original_nodes)
+            for attr_name in node_attributes:
+                H_node_attributes[attr_name][H_node_id] = agg_vals[attr_name]
             H_node_id += 1
+    # load H_node_attr into node_attributes dict (overwrites G data)
+    # This is a hack to morph node info in main function so delta_func can use it
+    # We could store this info as graph node data, but that is slower and fatter.
+    for attr_name in node_attributes:
+        node_attributes[attr_name] = H_node_attributes[attr_name]
 
-    H_adj = H._adj
-    for u, v, uv_weight in G.edges(data="weight", default=1):
+    # Handle edge_wts and in_edge_wts
+    is_directed = H.is_directed()
+    H_edge_wts = {H_node: {} for H_node in H}
+    if is_directed:
+        H_in_edge_wts = {H_node: {} for H_node in H}
+    for u, nbrs in G.graph["edge_wts"].items():
         H_u = nodes_G2H[u]
-        H_v = nodes_G2H[v]
-        if H_u != H_v:
-            H_unbrs = H_adj[H_u]
-            if H_v in H_unbrs:
-                H_unbrs[H_v]["weight"] += uv_weight
-            else:
-                H.add_edge(H_u, H_v, weight=uv_weight)
-
+        H_unbrs = H_edge_wts[H_u]
+        for v, uv_weight in nbrs.items():
+            H_v = nodes_G2H[v]
+            if H_u != H_v:
+                if H_v in H_unbrs:
+                    H_unbrs[H_v] += uv_weight
+                    if is_directed:
+                        H_in_edge_wts[H_v][H_u] += uv_weight
+                else:
+                    H_unbrs[H_v] = uv_weight
+                    if is_directed:
+                        H_in_edge_wts[H_v][H_u] = uv_weight
+    H.graph["edge_wts"] = H_edge_wts
+    if is_directed:
+        H.graph["in_edge_wts"] = H_in_edge_wts
     return H, H_node2com

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -260,7 +260,7 @@ def leiden_partitions(
         # same nodes & class as G
         graph = nx.empty_graph(G, create_using=G.__class__)
         if weight is None:
-            graph.add_edges_from(G.edges())
+            graph.add_weighted_edges_from((*e, 1) for e in G.edges())
         else:
             graph.add_weighted_edges_from(G.edges(data=weight, default=1))
     # node attr "nodes" holds the original nodes represented by this current node
@@ -285,15 +285,24 @@ def leiden_partitions(
 
             def delta(nodes_to_add, community):
                 comm_size = sum(graph.nodes[u]["node_weight"] for u in community)
-                nodes_size = sum(graph.nodes[u]["node_weight"] for u in nodes_to_add)
-                if len(nodes_to_add) < len(community):
-                    a, c = nodes_to_add, community
+                if isinstance(nodes_to_add, set):
+                    nodes_size = sum(
+                        graph.nodes[u]["node_weight"] for u in nodes_to_add
+                    )
+                    if len(nodes_to_add) < len(community):
+                        a, c = nodes_to_add, community
+                    else:
+                        a, c = community, nodes_to_add
+                    edges = graph.in_edges(a, data="weight", default=1)
+                    E_in = sum(wt for _, v, wt in edges if v in c)
+                    edges = graph.out_edges(a, data="weight", default=1)
+                    E_out = sum(wt for _, v, wt in edges if v in c)
                 else:
-                    a, c = community, nodes_to_add
-                edges = graph.in_edges(a, data="weight", default=1)
-                E_in = sum(wt for _, v, wt in edges if v in c)
-                edges = graph.out_edges(a, data="weight", default=1)
-                E_out = sum(wt for _, v, wt in edges if v in c)
+                    nodes_size = graph.nodes[nodes_to_add]["node_weight"]
+                    nbrs = graph._adj[nodes_to_add].items()
+                    E_in = sum(d["weight"] for nbr, d in nbrs if nbr in community)
+                    nbrs = graph._pred[nodes_to_add].items()
+                    E_out = sum(d["weight"] for nbr, d in nbrs if nbr in community)
 
                 return E_in + E_out - gamma * comm_size * nodes_size
 
@@ -304,14 +313,20 @@ def leiden_partitions(
             @line_profiler.profile
             def delta(nodes_to_add, community):
                 comm_size = sum(graph.nodes[u]["node_weight"] for u in community)
-                nodes_size = sum(graph.nodes[u]["node_weight"] for u in nodes_to_add)
-
-                if len(nodes_to_add) < len(community):
-                    a, c = nodes_to_add, community
+                if isinstance(nodes_to_add, set):
+                    nodes_size = sum(
+                        graph.nodes[u]["node_weight"] for u in nodes_to_add
+                    )
+                    if len(nodes_to_add) < len(community):
+                        a, c = nodes_to_add, community
+                    else:
+                        a, c = community, nodes_to_add
+                    edges = graph.edges(a, data="weight", default=1)
+                    E = sum(wt for _, nbr, wt in edges if nbr in c)
                 else:
-                    a, c = community, nodes_to_add
-                edges = graph.edges(a, data="weight", default=1)
-                E = sum(wt for _, v, wt in edges if v in c)
+                    nodes_size = graph.nodes[nodes_to_add]["node_weight"]
+                    nbrs = graph._adj[nodes_to_add].items()
+                    E = sum(d["weight"] for nbr, d in nbrs if nbr in community)
 
                 return E - gamma * comm_size * nodes_size
 
@@ -338,22 +353,33 @@ def leiden_partitions(
             gamma = 2 * resolution
 
             def delta(nodes_to_add, community):
-                if len(nodes_to_add) < len(community):
-                    a, c = nodes_to_add, community
+                if isinstance(nodes_to_add, set):
+                    if len(nodes_to_add) < len(community):
+                        a, c = nodes_to_add, community
+                    else:
+                        a, c = community, nodes_to_add
+
+                    a_in = sum(in_degrees[u] for u in a)
+                    a_out = sum(out_degrees[u] for u in a)
+                    c_in = sum(in_degrees[u] for u in c)
+                    c_out = sum(out_degrees[u] for u in c)
+
+                    edges = graph.in_edges(a, data="weight", default=1)
+                    E_in = sum(wt for _, v, wt in edges if v in c)
+                    edges = graph.out_edges(a, data="weight", default=1)
+                    E_out = sum(wt for _, v, wt in edges if v in c)
                 else:
-                    a, c = community, nodes_to_add
+                    a_in = in_degrees[nodes_to_add]
+                    a_out = out_degrees[nodes_to_add]
+                    c_in = sum(in_degrees[u] for u in community)
+                    c_out = sum(out_degrees[u] for u in community)
 
-                a_in = sum(in_degrees[u] for u in a)
-                a_out = sum(out_degrees[u] for u in a)
-                c_in = sum(in_degrees[u] for u in c)
-                c_out = sum(out_degrees[u] for u in c)
+                    nbrs = graph._succ[nodes_to_add].items()
+                    E_in = sum(d["weight"] for nbr, d in nbrs if nbr in community)
+                    nbrs = graph._pred[nodes_to_add].items()
+                    E_out = sum(d["weight"] for nbr, d in nbrs if nbr in community)
 
-                edges = graph.in_edges(a, data="weight", default=1)
-                E_to = sum(wt for _, v, wt in edges if v in c)
-                edges = graph.out_edges(a, data="weight", default=1)
-                E_from = sum(wt for _, v, wt in edges if v in c)
-
-                return E_to + E_from - gamma * (a_in * c_out + a_out * c_in)
+                return E_in + E_out - gamma * (a_in * c_out + a_out * c_in)
 
         else:
             # Setup for undirected modularity
@@ -367,14 +393,17 @@ def leiden_partitions(
             gamma = 2 * resolution
 
             def delta(nodes_to_add, community):
-                nodes_size = sum(graph.nodes[u]["degree"] for u in nodes_to_add)
                 comm_size = sum(graph.nodes[u]["degree"] for u in community)
-                E_D = sum(
-                    wt
-                    for u, v, wt in graph.edges(nodes_to_add, data="weight", default=1)
-                    if v in community
-                )
-                return E_D - gamma * nodes_size * comm_size
+                if isinstance(nodes_to_add, set):
+                    nodes_size = sum(graph.nodes[u]["degree"] for u in nodes_to_add)
+                    edges = graph.edges(nodes_to_add, data="weight", default=1)
+                    E = sum(wt for _, v, wt in edges if v in community)
+                else:
+                    nodes_size = graph.nodes[nodes_to_add]["degree"]
+                    nbrs = graph._adj[nodes_to_add].items()
+                    E = sum(d["weight"] for nbr, d in nbrs if nbr in community)
+
+                return E - gamma * nodes_size * comm_size
 
     elif metric == "barber_modularity":
         # Setup for undirected bipartite barber modularity (not yet fully implemented)
@@ -425,15 +454,19 @@ def leiden_partitions(
             data["weight"] *= 1 / m
 
         def delta(nodes_to_add, community):
-            nodes_red = sum(graph.nodes[u]["red_degree"] for u in nodes_to_add)
-            nodes_blue = sum(graph.nodes[u]["blue_degree"] for u in nodes_to_add)
             comm_red = sum(graph.nodes[u]["red_degree"] for u in community)
             comm_blue = sum(graph.nodes[u]["blue_degree"] for u in community)
-            E = sum(
-                wt
-                for _, v, wt in graph.edges(nodes_to_add, data="weight", default=1)
-                if v in community
-            )
+            if isinstance(nodes_to_add, set):
+                nodes_red = sum(graph.nodes[u]["red_degree"] for u in nodes_to_add)
+                nodes_blue = sum(graph.nodes[u]["blue_degree"] for u in nodes_to_add)
+                edges = graph.edges(nodes_to_add, data="weight", default=1)
+                E = sum(wt for _, v, wt in edges if v in community)
+            else:
+                nodes_red = graph.nodes[nodes_to_add]["red_degree"]
+                nodes_blue = graph.nodes[nodes_to_add]["blue_degree"]
+                nbrs = graph._adj[nodes_to_add].items()
+                E = sum(d["weight"] for nbr, d in nbrs if nbr in community)
+
             return E - resolution * (nodes_red * comm_blue + nodes_blue * comm_red)
 
         raise nx.NetworkXError("barber_modularity not implemented for leiden")
@@ -509,7 +542,7 @@ def _move_nodes_fast(graph, node2com, delta_func, seed):
 
         # this value is the overall change in quality that occurs
         # when node u is removed from its current community
-        q_rem = delta_func({u}, P[old_com] - {u})
+        q_rem = delta_func(u, P[old_com] - {u})
 
         # for each node in the queue, we measure the change in quality
         # from moving that node to each other community, keeping track of
@@ -518,7 +551,7 @@ def _move_nodes_fast(graph, node2com, delta_func, seed):
             if new_com != old_com:
                 # this quantity is the overall change in quality that
                 # occurs when the node u is added to the new community
-                q_add = delta_func({u}, P[new_com])
+                q_add = delta_func(u, P[new_com])
 
                 # the overall change in quality therefore from moving
                 # node u from old_com to new_com is as follows
@@ -590,11 +623,11 @@ def _merge_node_subset(
     C_refined = [{u} for u in C]
     # first, the sufficiently well-connected nodes within S
     # are identified and added to the set R.
-    R = {u for u in C if delta_func({u}, C - {u}) > 0}
+    R = {u for u in C if delta_func(u, C - {u}) > 0}
 
     for u in R:
         comm = node2com[u]
-        if C_refined[comm] != {u}:
+        if len(C_refined[comm]) != 1:
             continue
         # if the community that u belongs to is the singleton {u}, then
         # we will proceed to merge it probabilistically with another
@@ -618,7 +651,7 @@ def _merge_node_subset(
 
         # this is the change in quality that occurs from removing node
         # u from its current community
-        q_rem = delta_func({u}, C_refined[comm] - {u})
+        q_rem = delta_func(u, C_refined[comm] - {u})
         for i, new_comm in enumerate(C_refined):
             if comm == i:
                 # we only want to consider moving u to a different
@@ -634,7 +667,7 @@ def _merge_node_subset(
             if delta_func(new_comm, C - new_comm) > 0:
                 # the change in quality that occurs from moving node u
                 # into the new community
-                q_add = delta_func({u}, new_comm)
+                q_add = delta_func(u, new_comm)
 
                 # the overall quality delta is therefore the sum
                 # of the change in quality from removing u from its

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -238,65 +238,49 @@ def leiden_partitions(
     # For one node, the change from moving node u from A to B is:
     # q_delta = delta_func(u, B) - delta_func(u, A-{u})
 
-    orig_G = G  # make copy of original G to allow mutations
-    is_directed = orig_G.is_directed()
-    if orig_G.is_multigraph():
+    is_directed = G.is_directed()
+    edge_wts = {u: {} for u in G}
+    if G.is_multigraph():
         # Convert Multi(Di)Graph to (Di)Graph by summing edges
-        G = nx.DiGraph() if is_directed else nx.Graph()
-        G.add_nodes_from(orig_G)
-        G.add_edges_from(orig_G.edges())
         if weight is None:
             edge_wts = {
-                u: {v: len(kd) for v, kd in nbrs.items()}
-                for u, nbrs in orig_G._adj.items()
+                u: {v: len(kd) for v, kd in nbrs.items() if u != v}
+                for u, nbrs in G._adj.items()
             }
-            if is_directed:
-                in_edge_wts = {
-                    u: {v: len(kd) for v, kd in nbrs.items()}
-                    for u, nbrs in orig_G._pred.items()
-                }
         else:
             edge_wts = {
                 u: {
                     v: sum(dd.get(weight, 1) for dd in kd.values())
                     for v, kd in nbrs.items()
+                    if u != v
                 }
-                for u, nbrs in orig_G._adj.items()
+                for u, nbrs in G._adj.items()
             }
-            if is_directed:
-                in_edge_wts = {
-                    u: {
-                        v: sum(dd.get(weight, 1) for dd in kd.values())
-                        for v, kd in nbrs.items()
-                    }
-                    for u, nbrs in orig_G._pred.items()
-                }
     else:
-        # same nodes & class as orig_G
-        G = nx.empty_graph(orig_G, create_using=orig_G.__class__)
-        G.add_edges_from(orig_G.edges)
         if weight is None:
-            edge_wts = {u: {v: 1 for v in nbrs} for u, nbrs in orig_G._adj.items()}
-            if is_directed:
-                in_edge_wts = {
-                    u: {v: 1 for v in nbrs} for u, nbrs in orig_G._pred.items()
-                }
+            edge_wts = {u: {v: 1 for v in nbrs if u != v} for u, nbrs in G._adj.items()}
         else:
             edge_wts = {
-                u: {v: dd.get(weight, 1) for v, dd in nbrs.items()}
-                for u, nbrs in orig_G._adj.items()
+                u: {v: dd.get(weight, 1) for v, dd in nbrs.items() if u != v}
+                for u, nbrs in G._adj.items()
             }
-            if is_directed:
-                in_edge_wts = {
-                    u: {v: dd.get(weight, 1) for v, dd in nbrs.items()}
-                    for u, nbrs in orig_G._pred.items()
-                }
+
+    orig_G = G  # make copy of original G to allow mutations
+    G = nx.DiGraph() if is_directed else nx.Graph()
+    G.add_nodes_from(orig_G)
+    G.add_weighted_edges_from(
+        (u, v, wt) for u, nbrs in edge_wts.items() for v, wt in nbrs.items()
+    )
     G.graph["edge_wts"] = edge_wts
+
     if is_directed:
+        in_edge_wts = {u: {} for u in G}
+        for u, nbrs in edge_wts.items():
+            for v, wt in nbrs.items():
+                in_edge_wts[v][u] = wt
         G.graph["in_edge_wts"] = in_edge_wts
 
     # node attr "nodes" holds the original nodes represented by this current node
-    # initialize to point to itself
     nx.set_node_attributes(G, {n: {n} for n in orig_G}, "nodes")
 
     if metric == "cpm":
@@ -736,11 +720,9 @@ def _create_aggregate_graph(G, P_refined, node_attributes):
     for attr_name in node_attributes:
         node_attributes[attr_name] = H_node_attributes[attr_name]
 
-    # Handle edge_wts and in_edge_wts
+    # Handle edge_wts, edges and in_edge_wts
     is_directed = H.is_directed()
     H_edge_wts = {H_node: {} for H_node in H}
-    if is_directed:
-        H_in_edge_wts = {H_node: {} for H_node in H}
     for u, nbrs in G.graph["edge_wts"].items():
         H_u = nodes_G2H[u]
         H_unbrs = H_edge_wts[H_u]
@@ -749,14 +731,18 @@ def _create_aggregate_graph(G, P_refined, node_attributes):
             if H_u != H_v:
                 if H_v in H_unbrs:
                     H_unbrs[H_v] += uv_weight
-                    if is_directed:
-                        H_in_edge_wts[H_v][H_u] += uv_weight
                 else:
-                    H.add_edge(H_u, H_v)
                     H_unbrs[H_v] = uv_weight
-                    if is_directed:
-                        H_in_edge_wts[H_v][H_u] = uv_weight
+    H.add_weighted_edges_from(
+        (u, v, wt) for u, nbrs in H_edge_wts.items() for v, wt in nbrs.items()
+    )
     H.graph["edge_wts"] = H_edge_wts
+
     if is_directed:
+        H_in_edge_wts = {u: {} for u in H}
+        for u, nbrs in H_edge_wts.items():
+            for v, wt in nbrs.items():
+                H_in_edge_wts[v][u] = wt
         H.graph["in_edge_wts"] = H_in_edge_wts
+
     return H, H_node2com

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -365,12 +365,12 @@ def leiden_partitions(
 
         if is_directed:
             # Setup for directed modularity
-            m = sum(wt for u, v, wt in G.edges(data="weight"))
-            gamma = resolution / m
-
             in_degrees = dict(G.in_degree(weight="weight"))
             out_degrees = dict(G.out_degree(weight="weight"))
             node_attributes = {"in_degree": in_degrees, "out_degree": out_degrees}
+
+            m = sum(out_degrees.values())
+            gamma = resolution / m
 
             # Note: delta_func uses objects in defining namespace:
             # - gamma
@@ -406,15 +406,19 @@ def leiden_partitions(
                         C_out = sum(out_degrees[u] for u in community)
                         E = sum(wt for v, wt in edge_wts[u].items() if v in community)
 
+                # Note: this function returns (m * modularity_delta) to avoid
+                # extra division by m. The choice of best change is not affected.
+                # Usual formula would be:
+                # E / m - (resolution/ m**2) * (A_in * C_out + A_out * C_in)
                 return E - gamma * (A_in * C_out + A_out * C_in)
 
         else:
             # Setup for undirected modularity
-            m = sum(wt for u, v, wt in G.edges(data="weight"))
-            gamma = resolution / m
-
-            degrees = {u: sum(nbrs.values()) for u, nbrs in edge_wts.items()}
+            degrees = dict(G.degree(weight="weight"))
             node_attributes = {"degree": degrees}
+
+            two_m = sum(degrees.values())
+            gamma = resolution / two_m
 
             # Note: delta_func uses objects in defining namespace:
             # - gamma
@@ -443,6 +447,10 @@ def leiden_partitions(
                         comm_size = sum(degrees[u] for u in community)
                         E = sum(wt for v, wt in edge_wts[u].items() if v in community)
 
+                # Note: this function returns (m * modularity_delta) to avoid
+                # extra division by m. The choice of best change is not affected.
+                # Usual formula would be:
+                # E / m - (resolution * 2/ (2*m)**2) * nodes_size * comm_size
                 return E - gamma * nodes_size * comm_size
 
     elif metric == "barber_modularity":
@@ -467,9 +475,10 @@ def leiden_partitions(
         blue_nodes = {u for u, c in G.nodes(data="bipartite") if c == 1}
         # TODO add check for this being a bipartite graph
 
-        red_degrees = {u: sum(edge_wts[u].values()) for u in red_nodes}
+        degrees = dict(G.degree(weight="weight"))
+        red_degrees = {u: degrees[u] for u in red_nodes}
         red_degrees.update((u, 0) for u in blue_nodes)
-        blue_degrees = {u: sum(edge_wts[u].values()) for u in blue_nodes}
+        blue_degrees = {u: degrees[u] for u in blue_nodes}
         blue_degrees.update((u, 0) for u in red_nodes)
 
         node_attributes = {"red_degree": red_degrees, "blue_degree": blue_degrees}
@@ -700,7 +709,7 @@ def _create_aggregate_graph(G, P_refined, node_attributes):
                 for attr_name, attr_dict in node_attributes.items():
                     agg_vals[attr_name] += attr_dict[G_node]
 
-            H.add_node(H_node_id, nodes=original_nodes)
+            H.add_node(H_node_id, nodes=original_nodes, **agg_vals)
             for attr_name in node_attributes:
                 H_node_attributes[attr_name][H_node_id] = agg_vals[attr_name]
             H_node_id += 1

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -238,40 +238,25 @@ def leiden_partitions(
     # For one node, the change from moving node u from A to B is:
     # q_delta = delta_func(u, B) - delta_func(u, A-{u})
 
-    is_directed = G.is_directed()
-    edge_wts = {u: {} for u in G}
-    if G.is_multigraph():
-        # Convert Multi(Di)Graph to (Di)Graph by summing edges
-        if weight is None:
-            edge_wts = {
-                u: {v: len(kd) for v, kd in nbrs.items() if u != v}
-                for u, nbrs in G._adj.items()
-            }
-        else:
-            edge_wts = {
-                u: {
-                    v: sum(dd.get(weight, 1) for dd in kd.values())
-                    for v, kd in nbrs.items()
-                    if u != v
-                }
-                for u, nbrs in G._adj.items()
-            }
-    else:
-        if weight is None:
-            edge_wts = {u: {v: 1 for v in nbrs if u != v} for u, nbrs in G._adj.items()}
-        else:
-            edge_wts = {
-                u: {v: dd.get(weight, 1) for v, dd in nbrs.items() if u != v}
-                for u, nbrs in G._adj.items()
-            }
-
     orig_G = G  # make copy of original G to allow mutations
+    is_directed = orig_G.is_directed()
     G = nx.DiGraph() if is_directed else nx.Graph()
     G.add_nodes_from(orig_G)
-    G.add_weighted_edges_from(
-        (u, v, wt) for u, nbrs in edge_wts.items() for v, wt in nbrs.items()
-    )
-    G.graph["edge_wts"] = edge_wts
+    # Add edges (including selfloops)
+    if orig_G.is_multigraph():
+        for u, v, wt in orig_G.edges(data=weight, default=1):
+            if G.has_edge(u, v):
+                G[u][v]["weight"] += wt
+            else:
+                G.add_edge(u, v, weight=wt)
+    else:
+        G.add_weighted_edges_from(orig_G.edges(data=weight, default=1))
+
+    # Compute edge_wts as dict-of-dicts (ignoring selfloops)
+    edge_wts = {
+        u: {v: dd["weight"] for v, dd in nbrs.items() if u != v}
+        for u, nbrs in G._adj.items()
+    }
 
     if is_directed:
         # in edge wts used for E in delta_func (the wt sum between specific nodes)
@@ -281,10 +266,13 @@ def leiden_partitions(
         for v, nbrs in G._pred.items():
             v_wts = edge_wts[v]
             for u, dd in nbrs.items():
+                if u == v:
+                    continue
                 if u in v_wts:
                     v_wts[u] += dd["weight"]
                 else:
                     v_wts[u] = dd["weight"]
+    G.graph["edge_wts"] = edge_wts
 
     # node attr "nodes" holds the original nodes represented by this current node
     nx.set_node_attributes(G, {n: {n} for n in orig_G}, "nodes")
@@ -357,13 +345,13 @@ def leiden_partitions(
                 else:
                     u = nodes_to_add
                     nodes_size = node_weights[u]
-                    if len(community) > 1:
-                        comm_size = sum(node_weights[v] for v in community)
-                        E = sum(wt for v, wt in edge_wts[u].items() if v in community)
-                    else:
+                    if len(community) == 1:
                         v = next(iter(community))
                         comm_size = node_weights[v]
                         E = edge_wts[u].get(v, 0)
+                    else:
+                        comm_size = sum(node_weights[v] for v in community)
+                        E = sum(wt for v, wt in edge_wts[u].items() if v in community)
 
                 return E - gamma * comm_size * nodes_size
 
@@ -377,9 +365,8 @@ def leiden_partitions(
 
         if is_directed:
             # Setup for directed modularity
-            m = sum(wt for u, nbrs in edge_wts.items() for v, wt in nbrs.items())
-            # Note: m is twice the sum of all edge weights here. Hence 2/m
-            gamma = 2 * resolution / m
+            m = sum(wt for u, v, wt in G.edges(data="weight"))
+            gamma = resolution / m
 
             in_degrees = dict(G.in_degree(weight="weight"))
             out_degrees = dict(G.out_degree(weight="weight"))
@@ -423,9 +410,8 @@ def leiden_partitions(
 
         else:
             # Setup for undirected modularity
-            m = sum(wt for u, nbrs in edge_wts.items() for v, wt in nbrs.items())
-            # Note: m is twice the sum of all edge weights. Hence 2/m
-            gamma = 2 * resolution / m
+            m = sum(wt for u, v, wt in G.edges(data="weight"))
+            gamma = resolution / m
 
             degrees = {u: sum(nbrs.values()) for u, nbrs in edge_wts.items()}
             node_attributes = {"degree": degrees}
@@ -724,30 +710,29 @@ def _create_aggregate_graph(G, P_refined, node_attributes):
     for attr_name in node_attributes:
         node_attributes[attr_name] = H_node_attributes[attr_name]
 
-    # Handle edge_wts and edges
-    is_directed = H.is_directed()
-    H_edge_wts = {H_node: {} for H_node in H}
-    for u, nbrs in G.adjacency():
+    # Add edges (including selfloops)
+    for u, v, wt in G.edges(data="weight"):
         H_u = nodes_G2H[u]
-        H_unbrs = H_edge_wts[H_u]
-        for v, dd in nbrs.items():
-            H_v = nodes_G2H[v]
-            if H_u != H_v:
-                if H_v in H_unbrs:
-                    H_unbrs[H_v] += dd["weight"]
-                else:
-                    H_unbrs[H_v] = dd["weight"]
-    H.add_weighted_edges_from(
-        (u, v, wt) for u, nbrs in H_edge_wts.items() for v, wt in nbrs.items()
-    )
-    H.graph["edge_wts"] = H_edge_wts
-
-    if is_directed:
+        H_v = nodes_G2H[v]
+        if H.has_edge(H_u, H_v):
+            H[H_u][H_v]["weight"] += wt
+        else:
+            H.add_edge(H_u, H_v, weight=wt)
+    # Compute edge_wts as dict-of-dicts (ignoring selfloops)
+    H_edge_wts = {
+        u: {v: dd["weight"] for v, dd in nbrs.items() if u != v}
+        for u, nbrs in H._adj.items()
+    }
+    if H.is_directed():
         for v, nbrs in H._pred.items():
             v_wts = H_edge_wts[v]
             for u, dd in nbrs.items():
+                if u == v:
+                    continue
                 if u in v_wts:
                     v_wts[u] += dd["weight"]
                 else:
                     v_wts[u] = dd["weight"]
+    H.graph["edge_wts"] = H_edge_wts
+
     return H, H_node2com

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -274,13 +274,17 @@ def leiden_partitions(
     G.graph["edge_wts"] = edge_wts
 
     if is_directed:
-        for u, nbrs in edge_wts.items():
-            for v, wt in nbrs.items():
-                v_wts = edge_wts[v]
+        # in edge wts used for E in delta_func (the wt sum between specific nodes)
+        # we store it outside the graph for speedy lookup and not for other tasks.
+        # Eg computing m = sum(G edge wts) is multiplied by 2 if you use edge_wts.
+        # Be Careful using edge_wts in directed case.
+        for v, nbrs in G._pred.items():
+            v_wts = edge_wts[v]
+            for u, dd in nbrs.items():
                 if u in v_wts:
-                    v_wts[u] += wt
+                    v_wts[u] += dd["weight"]
                 else:
-                    v_wts[u] = wt
+                    v_wts[u] = dd["weight"]
 
     # node attr "nodes" holds the original nodes represented by this current node
     nx.set_node_attributes(G, {n: {n} for n in orig_G}, "nodes")
@@ -374,6 +378,7 @@ def leiden_partitions(
         if is_directed:
             # Setup for directed modularity
             m = sum(wt for u, nbrs in edge_wts.items() for v, wt in nbrs.items())
+            # Note: m is twice the sum of all edge weights here. Hence 2/m
             gamma = 2 * resolution / m
 
             in_degrees = dict(G.in_degree(weight="weight"))
@@ -419,6 +424,7 @@ def leiden_partitions(
         else:
             # Setup for undirected modularity
             m = sum(wt for u, nbrs in edge_wts.items() for v, wt in nbrs.items())
+            # Note: m is twice the sum of all edge weights. Hence 2/m
             gamma = 2 * resolution / m
 
             degrees = {u: sum(nbrs.values()) for u, nbrs in edge_wts.items()}
@@ -469,12 +475,7 @@ def leiden_partitions(
             return
 
         metric_function = barber_modularity
-
-        # scale edge weights by total so m == 1 and can be removed from formulas
-        m = sum(wt for u, nbrs in edge_wts.items() for v, wt in nbrs.items())
-        for u, nbrs in edge_wts.items():
-            for v, wt in nbrs.items():
-                edge_wts[u][v] /= m
+        # TODO check these formulas for how m should appear. written when m=1.
 
         red_nodes = {u for u, c in G.nodes(data="bipartite") if c == 0}
         blue_nodes = {u for u, c in G.nodes(data="bipartite") if c == 1}
@@ -742,11 +743,11 @@ def _create_aggregate_graph(G, P_refined, node_attributes):
     H.graph["edge_wts"] = H_edge_wts
 
     if is_directed:
-        for u, nbrs in H_edge_wts.items():
-            for v, wt in nbrs.items():
-                v_wts = H_edge_wts[v]
+        for v, nbrs in H._pred.items():
+            v_wts = H_edge_wts[v]
+            for u, dd in nbrs.items():
                 if u in v_wts:
-                    v_wts[u] += wt
+                    v_wts[u] += dd["weight"]
                 else:
-                    v_wts[u] = wt
+                    v_wts[u] = dd["weight"]
     return H, H_node2com

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -532,7 +532,7 @@ def leiden_partitions(
         P = _move_nodes_fast(G, node2com, delta_func, seed=seed)
 
         # Refine the communities using _merge_node_subset (name from paper)
-        P_refined = [_merge_node_subset(C, delta_func, seed, theta) for C in P]
+        P_refined = [_merge_node_subset(G, C, delta_func, seed, theta) for C in P]
         P_refined_flat = [comm for p in P_refined for comm in p]
 
         # Stop when overall change is close to zero.
@@ -613,7 +613,7 @@ def _move_nodes_fast(G, node2com, delta_func, seed):
     return [p for p in P if p]
 
 
-def _merge_node_subset(C, delta_func, seed, theta):
+def _merge_node_subset(G, C, delta_func, seed, theta):
     # T[i] > 0 means community i is well connected to others
     # Definition of T in line 37 of pseudocode in paper (supplemental mat.)
     # uses condition for "cpm" metric: E(C, S-C) >= gamma * |C| * (|S| - |C|)
@@ -632,13 +632,14 @@ def _merge_node_subset(C, delta_func, seed, theta):
         #   Note: not choosing the best one
         if len(C_refined[comm_i]) != 1:
             continue
+        unbrs = set(nx.all_neighbors(G, u))
 
         cand_comms = []
         cand_comm_deltas = []
         # Note: delta for removing u from current comm is 0 (singleton comm)
         for i, new_comm in enumerate(C_refined):
-            # Main condition is T[i] > 0. also not empty and not same community
-            if comm_i == i or not new_comm or T[i] <= 0:
+            # Main conditions: unbrs in new_comm and T[i] > 0. Also not old comm.
+            if not (new_comm & unbrs) or comm_i == i or T[i] <= 0:
                 continue
 
             Q_delta = delta_func(u, new_comm)

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -1,6 +1,4 @@
-"""Functions for detecting communities based on Leiden Community Detection
-algorithm.
-"""
+"""Detecting communities based on the Leiden Community Detection algorithm"""
 
 import functools
 import itertools
@@ -229,38 +227,43 @@ def leiden_partitions(
         yield partition
         return
 
+    # Initialization steps while copying G to graph
+    # - edge weights set as "weight" in graph, summed if G.is_multigraph()
+    # - node attributes initialized based on metric impact on node_weights aggregated
+    # - define the metric function based on metric
+    # - define the corresponding delta function
+    # - set node_attributes to names of node attrs summed when merging based on metric
+
+    # delta function gives change in metric when merging two communities.
+    # The change due to splitting a set U from C is negating e.g. -delta(U, C-U)
+    # For one node, the change from moving node u from A to B is:
+    # q_delta = delta({u}, B) - delta({u}, A-{u})
+
     is_directed = G.is_directed()
     if G.is_multigraph():
-        # this is the same as how louvain handles multigraph inputs
-        graph = _convert_multigraph(G, weight, is_directed)
-    else:
-        # if the weight parameter is defined then we use this value for
-        # edge weights within the algorithm, defaulting to 1 where the
-        # attribute does not exist
-        # else if weight is None then all edges are given a weight of 1
-        if weight:
-            graph = G.__class__()
-            graph.add_nodes_from(G)
-            graph.add_weighted_edges_from(G.edges(data=weight, default=1))
+        # Convert Multi(Di)Graph to (Di)Graph by summing edges
+        graph = nx.DiGraph() if is_directed else nx.Graph()
+        graph.add_nodes_from(G)
+        if weight is None:
+            graph.add_weighted_edges_from(
+                (u, v, len(kd)) for u, nbrs in G._adj.items() for v, kd in nbrs.items()
+            )
         else:
-            graph = G.__class__()
-            graph.add_nodes_from(G)
+            graph.add_weighted_edges_from(
+                (u, v, sum(dd.get(weight, 1) for dd in kd.values()))
+                for u, nbrs in G._adj.items()
+                for v, kd in nbrs.items()
+            )
+    else:
+        # same nodes & class as G
+        graph = nx.empty_graph(G, create_using=G.__class__)
+        if weight is None:
             graph.add_edges_from(G.edges())
-            nx.set_edge_attributes(graph, 1, name="weight")
-
-    # The following setup stage depends on the choice of quality
-    # function. In particular, this stage must set three things:
-    # 1) set the function metric
-    # 2) set the corresponding quality_delta function
-    # 3) set the specific attributes required to compute the
-    #    metric and quality_delta
-
-    # the quality_delta function computes the partial quality delta contributed by
-    # adding nodes_to_add to community.
-    # Corresponding value from removing U from C is computed by taking
-    # the negative  -1 * quality_delta(U, C-U)
-    # to compute the overall quality delta from moving node u from A to B we have
-    # q_delta = quality_delta({u}, B) - quality_delta({u}, A-{u})
+        else:
+            graph.add_weighted_edges_from(G.edges(data=weight, default=1))
+    # node attr "nodes" holds the original nodes represented by this current node
+    # initialize to point to itself
+    nx.set_node_attributes(graph, {n: {n} for n in G}, "nodes")
 
     if metric == "cpm":
         # Setup for constant potts model
@@ -278,50 +281,44 @@ def leiden_partitions(
             # Setup for directed constant potts model
             gamma = 2 * resolution
 
-            def quality_delta(nodes_to_add, community):
+            def delta(nodes_to_add, community):
                 comm_size = sum(graph.nodes[u]["node_weight"] for u in community)
                 nodes_size = sum(graph.nodes[u]["node_weight"] for u in nodes_to_add)
-                E_in = sum(
-                    wt
-                    for _, v, wt in graph.edges(nodes_to_add, data="weight")
-                    if v in community
-                )
-                E_out = sum(
-                    wt
-                    for _, v, wt in graph.edges(community, data="weight")
-                    if v in nodes_to_add
-                )
+                if len(nodes_to_add) < len(community):
+                    a, c = nodes_to_add, community
+                else:
+                    a, c = community, nodes_to_add
+                edges = graph.in_edges(a, data="weight", default=1)
+                E_in = sum(wt for _, v, wt in edges if v in c)
+                edges = graph.out_edges(a, data="weight", default=1)
+                E_out = sum(wt for _, v, wt in edges if v in c)
+
                 return E_in + E_out - gamma * comm_size * nodes_size
+
         else:
             # Setup for undirected constant potts model
             gamma = resolution
 
-            def quality_delta(nodes_to_add, community):
+            def delta(nodes_to_add, community):
                 comm_size = sum(graph.nodes[u]["node_weight"] for u in community)
                 nodes_size = sum(graph.nodes[u]["node_weight"] for u in nodes_to_add)
-                E = sum(
-                    wt
-                    for _, v, wt in graph.edges(nodes_to_add, data="weight")
-                    if v in community
-                )
+
+                if len(nodes_to_add) < len(community):
+                    a, c = nodes_to_add, community
+                else:
+                    a, c = community, nodes_to_add
+                edges = graph.edges(a, data="weight", default=1)
+                E = sum(wt for _, v, wt in edges if v in c)
+
                 return E - gamma * comm_size * nodes_size
 
     elif metric == "modularity":
         # Setup for (unipartite) modularity
-
-        # the modualrity function throws an zero division error
-        # if the graph consists of only a single node.
-        # if leiden aggregates the graph to a single node then
-        # we just need to retun a value that ensure the algorithm
-        # stops
-        def guarded_modularity(G, P):
-
-            try:
-                return modularity(G, P, resolution=resolution)
-            except ZeroDivisionError:
-                return float("inf")
-
-        metric = guarded_modularity
+        metric = functools.partial(
+            modularity,
+            resolution=resolution,
+            weight="weight",
+        )
         if is_directed:
             # Setup for directed modularity
             node_attributes = ["in_degree", "out_degree"]
@@ -330,35 +327,30 @@ def leiden_partitions(
 
             m = sum(wt for u, wt in in_degrees) + sum(wt for u, wt in out_degrees)
             for u, v, data in graph.edges(data=True):
-                data["weight"] *= 1 / m
+                data["weight"] = data.get("weight", 1) / m
 
-            nx.set_node_attributes(
-                graph, {u: in_deg / m for u, in_deg in in_degrees}, "in_degree"
-            )
-            nx.set_node_attributes(
-                graph, {u: out_deg / m for u, out_deg in out_degrees}, "out_degree"
-            )
+            nx.set_node_attributes(graph, dict(in_degrees), "in_degree")
+            nx.set_node_attributes(graph, dict(out_degrees), "out_degree")
 
             gamma = 2 * resolution
 
-            def quality_delta(nodes_to_add, community):
-                nodes_in = sum(graph.nodes[u]["in_degree"] for u in nodes_to_add)
-                nodes_out = sum(graph.nodes[u]["out_degree"] for u in nodes_to_add)
-                comm_in = sum(graph.nodes[u]["in_degree"] for u in community)
-                comm_out = sum(graph.nodes[u]["out_degree"] for u in community)
-                E_to = sum(
-                    wt
-                    for _, v, wt in graph.edges(nodes_to_add, data="weight")
-                    if v in community
-                )
-                E_from = sum(
-                    wt
-                    for _, v, wt in graph.edges(community, data="weight")
-                    if v in nodes_to_add
-                )
-                return (E_to + E_from) - gamma * (
-                    nodes_in * comm_out + nodes_out * comm_in
-                )
+            def delta(nodes_to_add, community):
+                if len(nodes_to_add) < len(community):
+                    a, c = nodes_to_add, community
+                else:
+                    a, c = community, nodes_to_add
+
+                a_in = sum(in_degrees[u] for u in a)
+                a_out = sum(out_degrees[u] for u in a)
+                c_in = sum(in_degrees[u] for u in c)
+                c_out = sum(out_degrees[u] for u in c)
+
+                edges = graph.in_edges(a, data="weight", default=1)
+                E_to = sum(wt for _, v, wt in edges if v in c)
+                edges = graph.out_edges(a, data="weight", default=1)
+                E_from = sum(wt for _, v, wt in edges if v in c)
+
+                return E_to + E_from - gamma * (a_in * c_out + a_out * c_in)
 
         else:
             # Setup for undirected modularity
@@ -367,16 +359,16 @@ def leiden_partitions(
 
             m = sum(deg for u, deg in degrees) / 2
             for u, v, data in graph.edges(data=True):
-                data["weight"] *= 1 / m
+                data["weight"] = data.get(weight, 1) / m
             nx.set_node_attributes(graph, {u: deg / m for u, deg in degrees}, "degree")
             gamma = 2 * resolution
 
-            def quality_delta(nodes_to_add, community):
+            def delta(nodes_to_add, community):
                 nodes_size = sum(graph.nodes[u]["degree"] for u in nodes_to_add)
                 comm_size = sum(graph.nodes[u]["degree"] for u in community)
                 E_D = sum(
                     wt
-                    for u, v, wt in graph.edges(nodes_to_add, data="weight")
+                    for u, v, wt in graph.edges(nodes_to_add, data="weight", default=1)
                     if v in community
                 )
                 return E_D - gamma * nodes_size * comm_size
@@ -429,14 +421,14 @@ def leiden_partitions(
         for u, v, data in graph.edges(data=True):
             data["weight"] *= 1 / m
 
-        def quality_delta(nodes_to_add, community):
+        def delta(nodes_to_add, community):
             nodes_red = sum(graph.nodes[u]["red_degree"] for u in nodes_to_add)
             nodes_blue = sum(graph.nodes[u]["blue_degree"] for u in nodes_to_add)
             comm_red = sum(graph.nodes[u]["red_degree"] for u in community)
             comm_blue = sum(graph.nodes[u]["blue_degree"] for u in community)
             E = sum(
                 wt
-                for _, v, wt in graph.edges(nodes_to_add, data="weight")
+                for _, v, wt in graph.edges(nodes_to_add, data="weight", default=1)
                 if v in community
             )
             return E - resolution * (nodes_red * comm_blue + nodes_blue * comm_red)
@@ -460,14 +452,14 @@ def leiden_partitions(
         # leiden initialises nodes into communities based on the
         # unrefined partition of the previous stage. The dict
         # refinement_mapping specifies how these initial communities
-        # are to be set
-        P = _move_nodes_fast(graph, refinement_mapping, quality_delta, seed=seed)
+        # are to be set. If None, use singleton communities.
+        P = _move_nodes_fast(graph, refinement_mapping, delta, seed=seed)
 
-        P_refined = _refine_partition(graph, P, quality_delta, seed=seed, theta=theta)
+        P_refined = _refine_partition(graph, P, delta, seed=seed, theta=theta)
 
         P_refined_flat = [comm for P_ref in P_refined for comm in P_ref]
 
-        # Stop when overall change in quality is close to zero.
+        # Stop when overall change is close to zero.
         Q_new = metric(graph, P_refined_flat)
         improvement_made = (Q_new - Q) > 0.0000001
         Q = Q_new
@@ -480,36 +472,31 @@ def leiden_partitions(
         # the node attribute 'nodes', which is set during _create_aggregate_graph(...)
         # Each node in graph represents a community in the original graph
         # and the node holds this information in the attribute 'nodes'.
+        # We yield a copy to protect the graph data structure for later iterations.
         yield [set(graph.nodes[u]["nodes"]).copy() for u in graph]
 
     return
 
 
-def _move_nodes_fast(G, refinement_mapping, quality_delta_func, seed):
-
-    # Unlike louvain, instead of beginning each iteration with the singleton
-    # partition, each iteration uses the (unrefined) partition from the previous
-    # step as the starting communities when moving nodes.
-    # This section of code initilises nodes into those communities.
-    # if no partition is passed from the previous step (i.e. during the
-    # first iteration) then this is skipped and the singleton partition is used.
-    if refinement_mapping:
-        P = [set() for _ in range(len(refinement_mapping.values()))]
-        node2com = {}
-        for i, u in enumerate(G):
-            P[refinement_mapping[i]].add(u)
-            node2com[u] = refinement_mapping[i]
+def _move_nodes_fast(graph, partition, delta_func, seed):
+    # use refinement_mapping as beginning partition. If None, use singletons
+    if partition is None:
+        P = [{u} for u in graph]
+        node2com = {u: i for i, u in enumerate(graph)}
     else:
-        P = [{u} for u in G]
-        node2com = {u: i for i, u in enumerate(G)}
+        P = [set() for _ in partition]
+        node2com = {}
+        for i, u in enumerate(graph):
+            P[partition[i]].add(u)
+            node2com[u] = partition[i]
 
-    rand_nodes = list(G.nodes)
+    rand_nodes = list(graph.nodes)
     seed.shuffle(rand_nodes)
     node_queue = deque(rand_nodes)
 
     while node_queue:
         u = node_queue.pop()
-        neighbor_coms = {node2com[v] for v in nx.all_neighbors(G, u)}
+        neighbor_coms = {node2com[v] for v in nx.all_neighbors(graph, u)}
 
         best_delta = 0
         old_com = node2com[u]
@@ -517,7 +504,7 @@ def _move_nodes_fast(G, refinement_mapping, quality_delta_func, seed):
 
         # this value is the overall change in quality that occurs
         # when node u is removed from its current community
-        q_rem = quality_delta_func({u}, P[old_com] - {u})
+        q_rem = delta_func({u}, P[old_com] - {u})
 
         # for each node in the queue, we measure the change in quality
         # from moving that node to each other community, keeping track of
@@ -526,7 +513,7 @@ def _move_nodes_fast(G, refinement_mapping, quality_delta_func, seed):
             if new_com != old_com:
                 # this quantity is the overall change in quality that
                 # occurs when the node u is added to the new community
-                q_add = quality_delta_func({u}, P[new_com])
+                q_add = delta_func({u}, P[new_com])
 
                 # the overall change in quality therefore from moving
                 # node u from old_com to new_com is as follows
@@ -542,7 +529,7 @@ def _move_nodes_fast(G, refinement_mapping, quality_delta_func, seed):
             P[old_com].remove(u)
             P[best_com].add(u)
 
-            neighbours = set(G.adj[u])
+            neighbours = set(graph._adj[u])
             nodes_to_visit = neighbours - P[best_com]
 
             for v in nodes_to_visit:
@@ -557,7 +544,7 @@ def _move_nodes_fast(G, refinement_mapping, quality_delta_func, seed):
 def _refine_partition(
     G,
     P,
-    quality_delta_func,
+    delta_func,
     seed,
     theta,
 ):
@@ -572,7 +559,7 @@ def _refine_partition(
         C_refined = _merge_node_subset(
             G,
             C,
-            quality_delta_func,
+            delta_func,
             seed,
             theta,
         )
@@ -585,7 +572,7 @@ def _refine_partition(
 def _merge_node_subset(
     G,
     C,
-    quality_delta_func,
+    delta_func,
     seed,
     theta,
 ):
@@ -594,7 +581,7 @@ def _merge_node_subset(
     C_refined = [{u} for u in C]
     # first, the sufficiently well-connected nodes within S
     # are identified and added to the set R.
-    R = {u for u in C if quality_delta_func({u}, C - {u}) > 0}
+    R = {u for u in C if delta_func({u}, C - {u}) > 0}
 
     for u in R:
         comm = node2com[u]
@@ -607,7 +594,7 @@ def _merge_node_subset(
         # first we identify candidate communities to merge u into
         # and then the final community is randomly selected from these
         # according to a probability distribution which is partly
-        # defined by the relative quality_delta (bigger increase in
+        # defined by the relative delta (bigger increase in
         # quality makes choosing that community more likely, but
         # the algorithm does not greedily choose the greatest increase)
 
@@ -622,7 +609,7 @@ def _merge_node_subset(
 
         # this is the change in quality that occurs from removing node
         # u from its current community
-        q_rem = quality_delta_func({u}, C_refined[comm] - {u})
+        q_rem = delta_func({u}, C_refined[comm] - {u})
         for i, new_comm in enumerate(C_refined):
             if comm == i:
                 # we only want to consider moving u to a different
@@ -633,12 +620,12 @@ def _merge_node_subset(
             # is within S. This is what is means for the resulting
             # partition to be a refinement of S.
 
-            # this application of quality_delta_func relates to the
+            # this application of delta_func relates to the
             # definition of T in line :37 from pseudocode in paper
-            if quality_delta_func(new_comm, C - new_comm) > 0:
+            if delta_func(new_comm, C - new_comm) > 0:
                 # the change in quality the occurs from moving node u
                 # into the new community
-                q_add = quality_delta_func({u}, C_refined[i])
+                q_add = delta_func({u}, C_refined[i])
 
                 # the overall quality delta is therefore the sum
                 # of the change in quality from removing u from its
@@ -682,68 +669,68 @@ def _merge_node_subset(
     return C_refined
 
 
-def _create_aggregate_graph(G, refined_communities_list, node_attributes):
-    """
-    Generate a new graph based on the partitions of a given graph
+def _create_aggregate_graph(G, P_refined, node_attributes):
+    """Return a new graph based on P_refined. Each community becomes a node.
 
-    node_attributes is a list of attributes that are required for the
-    given choice of quality metric. When aggregating a community (set
-    of nodes) into a new node of the aggregated graph, the value for
-    each attribute is the sum of the constituent nodes.
-    """
+    node_attributes is a list of attribute names required for this metric.
+    Sum each node attribute when aggregating a community into a new node.
 
+    P_refined is a list of lists of community sets. The outer list indicates
+    communities in the new graph which comes from P. Each inner list holds
+    the refined sets of nodes each of which becomes a new node. So P_refined
+    contains P as the outer list and its refinement as the inner lists which
+    holds the refined community sets that make up the new graph's nodes.
+    """
     H = G.__class__()
     old2new = {}
-
-    refinement_mapping = {}
+    new_node2com = {}
     new_node_id = 0
-    for partition_index, community in enumerate(refined_communities_list):
-        for refined_community in community:
-            # each refined_community from the refined_partiton defines
-            # a node in the new aggregated graph
-
-            refinement_mapping[new_node_id] = partition_index
-
+    for new_comm, refined_sets in enumerate(P_refined):
+        for refined_comm in refined_sets:
+            # each set from the refined_sets defines
+            # a node in the new aggregated graph. Name it new_node_id.
+            new_node2com[new_node_id] = new_comm
             agg_vals = {attribute: 0 for attribute in node_attributes}
 
-            # will contain the nodes defining a community
-            # in the original graph
+            # contains the original graph nodes defining this new community
             original_nodes = set()
 
-            # old_node is node from the previous iteration
-            # i.e. aggregated graph from the previous
-            # stage, not the original graph
-            for old_node in refined_community:
+            # old_node is node from previous stage, not original graph
+            for old_node in refined_comm:
+                old2new[old_node] = new_node_id
+
+                # aggregate node attributes
+                original_nodes.update(G.nodes[old_node]["nodes"])
                 for node_attribute in node_attributes:
                     agg_vals[node_attribute] += G.nodes[old_node][node_attribute]
 
-                old2new[old_node] = new_node_id
-                original_nodes.update(G.nodes[old_node].get("nodes", {old_node}))
-
             H.add_node(new_node_id, nodes=original_nodes, **agg_vals)
-
             new_node_id += 1
 
-    for u, v, uv_weight in G.edges(data="weight"):
+    H_adj = H._adj
+    for u, v, uv_weight in G.edges(data="weight", default=1):
         new_u = old2new[u]
         new_v = old2new[v]
         if new_u != new_v:
-            if H.has_edge(new_u, new_v):
-                H.edges[(new_u, new_v)]["weight"] += uv_weight
+            new_unbrs = H_adj[new_u]
+            if new_v in new_unbrs:
+                new_unbrs[new_v]["weight"] += uv_weight
             else:
                 H.add_edge(new_u, new_v, weight=uv_weight)
 
-    return H, refinement_mapping
+    return H, new_node2com
 
 
 def _convert_multigraph(G, weight, is_directed):
     """Convert a Multigraph to normal Graph"""
+    H.empty_graph(G, create_using=(nx.DiGraph if is_directed else nx.Graph))
+    H.add_weighted_edges_from(G.edges(data=weight, default=1))
+    return H
     if is_directed:
         H = nx.DiGraph()
     else:
         H = nx.Graph()
 
-    H.add_nodes_from(G)
     for u, v, wt in G.edges(data=weight, default=1):
         if H.has_edge(u, v):
             H[u][v]["weight"] += wt

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -283,12 +283,14 @@ def leiden_partitions(
             # Setup for directed constant potts model
             gamma = 2 * resolution
 
+            @line_profiler.profile
             def delta(nodes_to_add, community):
                 comm_size = sum(graph.nodes[u]["node_weight"] for u in community)
                 if isinstance(nodes_to_add, set):
                     nodes_size = sum(
                         graph.nodes[u]["node_weight"] for u in nodes_to_add
                     )
+
                     if len(nodes_to_add) < len(community):
                         a, c = nodes_to_add, community
                     else:
@@ -299,9 +301,9 @@ def leiden_partitions(
                     E_out = sum(wt for _, v, wt in edges if v in c)
                 else:
                     nodes_size = graph.nodes[nodes_to_add]["node_weight"]
-                    nbrs = graph._adj[nodes_to_add].items()
-                    E_in = sum(d["weight"] for nbr, d in nbrs if nbr in community)
                     nbrs = graph._pred[nodes_to_add].items()
+                    E_in = sum(d["weight"] for nbr, d in nbrs if nbr in community)
+                    nbrs = graph._succ[nodes_to_add].items()
                     E_out = sum(d["weight"] for nbr, d in nbrs if nbr in community)
 
                 return E_in + E_out - gamma * comm_size * nodes_size
@@ -352,6 +354,7 @@ def leiden_partitions(
 
             gamma = 2 * resolution
 
+            @line_profiler.profile
             def delta(nodes_to_add, community):
                 if isinstance(nodes_to_add, set):
                     if len(nodes_to_add) < len(community):
@@ -374,9 +377,9 @@ def leiden_partitions(
                     c_in = sum(in_degrees[u] for u in community)
                     c_out = sum(out_degrees[u] for u in community)
 
-                    nbrs = graph._succ[nodes_to_add].items()
-                    E_in = sum(d["weight"] for nbr, d in nbrs if nbr in community)
                     nbrs = graph._pred[nodes_to_add].items()
+                    E_in = sum(d["weight"] for nbr, d in nbrs if nbr in community)
+                    nbrs = graph._succ[nodes_to_add].items()
                     E_out = sum(d["weight"] for nbr, d in nbrs if nbr in community)
 
                 return E_in + E_out - gamma * (a_in * c_out + a_out * c_in)
@@ -392,6 +395,7 @@ def leiden_partitions(
             nx.set_node_attributes(graph, {u: deg / m for u, deg in degrees}, "degree")
             gamma = 2 * resolution
 
+            @line_profiler.profile
             def delta(nodes_to_add, community):
                 comm_size = sum(graph.nodes[u]["degree"] for u in community)
                 if isinstance(nodes_to_add, set):
@@ -604,7 +608,6 @@ def _refine_partition(
             seed,
             theta,
         )
-        C_refined = list(filter(None, C_refined))
         P_refined.append(C_refined)
 
     return P_refined
@@ -618,97 +621,53 @@ def _merge_node_subset(
     seed,
     theta,
 ):
-
     node2com = {u: i for i, u in enumerate(C)}
     C_refined = [{u} for u in C]
-    # first, the sufficiently well-connected nodes within S
-    # are identified and added to the set R.
+    # R contains well-connected nodes within C
     R = {u for u in C if delta_func(u, C - {u}) > 0}
 
     for u in R:
+        # merge nodes that are in a singleton community {u}
+        # - Find candidate communities for u to merge with
+        # - Select one randomly based on relative delta for each community
+        #   Note: not choosing the best one
         comm = node2com[u]
         if len(C_refined[comm]) != 1:
             continue
-        # if the community that u belongs to is the singleton {u}, then
-        # we will proceed to merge it probabilistically with another
-        # community within C.
+        cand_comms = []
+        cand_comm_deltas = []
 
-        # first we identify candidate communities to merge u into
-        # and then the final community is randomly selected from these
-        # according to a probability distribution which is partly
-        # defined by the relative delta (bigger increase in
-        # quality makes choosing that community more likely, but
-        # the algorithm does not greedily choose the greatest increase)
-
-        # we therefore track both the communities and their respective
-        # probabilities in order to define the probabilty distribution
-        # to select the community that u will be moved into
-
-        # if u is not in a singleton partition then we move on to the
-        # next node.
-        candidate_comm = []
-        candidate_comm_q_delta = []
-
-        # this is the change in quality that occurs from removing node
-        # u from its current community
-        q_rem = delta_func(u, C_refined[comm] - {u})
+        # Note: delta for removing u from current comm is 0 (singleton comm)
         for i, new_comm in enumerate(C_refined):
             if comm == i:
-                # we only want to consider moving u to a different
-                # community, not its current community.
                 continue
-
-            # We only consider merging u into a community that
-            # is within S. This is what it means for the resulting
-            # partition to be a refinement of S.
 
             # this application of delta_func relates to the
             # definition of T in line :37 from pseudocode in paper
+            # condition is: E(C, S-C) >= gamma * |C| * (|S| - |C|)
+            # where |X| is the node_weight of the set X of nodes.
             if delta_func(new_comm, C - new_comm) > 0:
-                # the change in quality that occurs from moving node u
-                # into the new community
-                q_add = delta_func(u, new_comm)
-
-                # the overall quality delta is therefore the sum
-                # of the change in quality from removing u from its
-                # starting community, and the change of quality
-                # from adding it to the new community
-
-                Q_delta = q_add - q_rem
-
+                Q_delta = delta_func(u, new_comm)
                 if Q_delta > 0:
-                    candidate_comm.append(i)
-                    candidate_comm_q_delta.append(Q_delta)
+                    cand_comms.append(i)
+                    cand_comm_deltas.append(Q_delta)
 
-        # if there are candidate communities identified then
-        # one is selected at random, and u is added to that
-        # community
-        if candidate_comm:
-            # the probability distribution that the new community is drawn
-            # from is defined in terms of the quality delta associated
-            # with the move to each community.
-
-            # If moving u to community C results in a quality delta QC,
-            # the relative frequency with which C will be chosen is
-            # proportional to
-            #
-            #       math.exp(QC/theta)
-            #
-            # Since computing large exponentials can cause overflow
-            # errors, we use an equivalent form that computes normalised
-            # values with the same ratios
-            max_delta = max(candidate_comm_q_delta)
-            candidate_comm_prob = [
-                math.exp((x - max_delta) / theta) for x in candidate_comm_q_delta
-            ]
-
-            new_comm = seed.choices(candidate_comm, weights=candidate_comm_prob)[0]
+        # select one candidate community at random
+        if cand_comms:
+            # probability of each candidate comm determined by Q_delta
+            # Relative frequency is proportional to
+            #       math.exp(Q_delta/theta)
+            # Large exponentials can overflow so normalize to
+            #       math.exp((Q_delta - max_Q_delta)/theta)
+            max_delta = max(cand_comm_deltas)
+            cand_wts = [math.exp((x - max_delta) / theta) for x in cand_comm_deltas]
+            new_comm = seed.choices(cand_comms, weights=cand_wts)[0]
 
             C_refined[comm].remove(u)
             C_refined[new_comm].add(u)
             node2com[u] = new_comm
 
-    return C_refined
+    return [c for c in C_refined if c]
 
 
 def _create_aggregate_graph(G, P_refined, node_attributes):

--- a/networkx/algorithms/community/leiden.py
+++ b/networkx/algorithms/community/leiden.py
@@ -752,6 +752,7 @@ def _create_aggregate_graph(G, P_refined, node_attributes):
                     if is_directed:
                         H_in_edge_wts[H_v][H_u] += uv_weight
                 else:
+                    H.add_edge(H_u, H_v)
                     H_unbrs[H_v] = uv_weight
                     if is_directed:
                         H_in_edge_wts[H_v][H_u] = uv_weight

--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -241,11 +241,15 @@ def modularity(G, communities, weight="weight", resolution=1):
         out_degree = dict(G.out_degree(weight=weight))
         in_degree = dict(G.in_degree(weight=weight))
         m = sum(out_degree.values())
+        if m == 0:
+            return 0
         norm = 1 / m**2
     else:
         out_degree = in_degree = dict(G.degree(weight=weight))
         deg_sum = sum(out_degree.values())
         m = deg_sum / 2
+        if m == 0:
+            return 0
         norm = 1 / deg_sum**2
 
     def community_contribution(community):

--- a/networkx/algorithms/community/tests/test_leiden.py
+++ b/networkx/algorithms/community/tests/test_leiden.py
@@ -315,6 +315,54 @@ def test_comms_change_after_aggregation():
 
 
 @pytest.mark.parametrize("m", _metrics())
+def test_undirected_selfloops(m):
+    qmod = "modularity"
+    G = nx.karate_club_graph()
+    partition = comm.leiden_communities(G, metric=m, seed=1, weight=None)
+
+    G.add_weighted_edges_from([(i, i, i * 1000) for i in range(4)])
+    # large self-loop weight impacts partition
+    big_partition = comm.leiden_communities(G, metric=m, seed=1, weight="weight")
+    assert big_partition != partition
+
+    # small self-loop weights aren't enough to impact partition in this graph
+    small_partition = comm.leiden_communities(G, metric=m, seed=1, weight=None)
+    assert small_partition == partition
+
+
+def test_directed_selfloops():
+    qmod = "modularity"
+    G = nx.DiGraph()
+    G.add_nodes_from(range(11))
+    G_edges = [
+        (0, 2),
+        (0, 1),
+        (1, 0),
+        (2, 1),
+        (2, 0),
+        (3, 4),
+        (4, 3),
+        (7, 8),
+        (8, 7),
+        (9, 10),
+        (10, 9),
+    ]
+    G.add_edges_from(G_edges)
+    parts = [{0, 1, 2}, {3, 4}, {5}, {6}, {7, 8}, {9, 10}]
+    partition = comm.leiden_communities(G, metric=qmod, seed=2, weight=None)
+    assert parts == partition
+
+    G.add_weighted_edges_from([(i, i, i * 1000) for i in range(4)])
+    # large self-loop weight impacts partition
+    big_partition = comm.leiden_communities(G, metric=qmod, seed=2, weight="weight")
+    assert big_partition != partition
+
+    # small self-loop weights aren't enough to impact partition in this graph
+    small_partition = comm.leiden_communities(G, metric=qmod, seed=2, weight=None)
+    assert small_partition == partition
+
+
+@pytest.mark.parametrize("m", _metrics())
 def test_weights_matter(m):
     G = nx.path_graph(15)
     no_weights = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=42637))
@@ -357,3 +405,11 @@ def test_directed_weights_matter(m):
     big_weights = list(comm.leiden_partitions(G, metric=m, resolution=r, seed=s))
     part_with_3 = [i for i, c in enumerate(big_weights[-1]) if 3 in c][0]
     assert 4 in big_weights[-1][part_with_3]
+
+
+def test_edge_wts():
+    G = nx.DiGraph()
+    G.add_weighted_edges_from([(0, 1, 8), (1, 0, 1), (1, 2, 1)])
+
+    P = comm.leiden_communities(G, metric="modularity", resolution=2, seed=42)
+    assert {frozenset(c) for c in P} == {frozenset({0}), frozenset({1, 2})}

--- a/networkx/algorithms/community/tests/test_leiden.py
+++ b/networkx/algorithms/community/tests/test_leiden.py
@@ -142,22 +142,20 @@ def test_LFR_communities_across_algos():
     # Resolution differs to get 3 communities.
     # The LFR example constructs G to have 3 communities.
     # So comparison is really about the nodes in the 3 communities being the same
-    # That works for all except the Leiden modularity variant.
+    # That works for all with correct choices of seed
     C = nx.get_node_attributes(G, "community").values()
     LFR_comm = {frozenset(c) for c in C}  # remove duplicate entries
 
     C = comm.louvain_communities(G, resolution=0.5, seed=10)
     louvain_comm = {frozenset(c) for c in C}
 
-    C = comm.leiden_communities(G, metric="cpm", resolution=-0.02, seed=10)
+    C = comm.leiden_communities(G, metric="cpm", resolution=-0.001, seed=20)
     cpm_comm = {frozenset(c) for c in C}
 
-    C = comm.leiden_communities(G, metric="modularity", resolution=-30.0, seed=3)
+    C = comm.leiden_communities(G, metric="modularity", resolution=0.1, seed=157)
     mod_comm = {frozenset(c) for c in C}
 
-    msg = f"{len(louvain_comm)=}, {len(cpm_comm)=}, {len(mod_comm)=}, {len(LFR_comm)=}"
-    assert len(louvain_comm) == len(cpm_comm) == len(mod_comm) == len(LFR_comm), msg
-    assert louvain_comm == cpm_comm == LFR_comm  # mod_comm has 3 different comms
+    assert louvain_comm == cpm_comm == LFR_comm == mod_comm
 
 
 def test_barbell_communities_across_algos():
@@ -211,30 +209,30 @@ def test_mispelled_metric():
 
 def test_expected_stable_across_code_changes_cpm():
     G = nx.karate_club_graph()
-    P = comm.leiden_communities(G, resolution=0.2, seed=1)
+    P = comm.leiden_communities(G, resolution=0.2, seed=3)
     P_expected = [
         {0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21},
-        {4, 10},
-        {16, 5, 6},
+        {16, 4, 5, 6, 10},
         {9},
-        {18},
-        {8, 14, 15, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},
+        {8, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},
     ]
     assert {frozenset(C) for C in P} == {frozenset(C) for C in P_expected}
 
     G = nx.karate_club_graph()
-    P = comm.leiden_communities(G, weight=None, resolution=0.2, seed=1)
+    P = comm.leiden_communities(G, weight=None, resolution=0.2, seed=170)
     P_expected = [
         {11},
         {12},
-        {8, 30},
-        {4, 10, 16, 5, 6},
-        {24, 27},
-        {25, 26, 29, 23},
+        {0, 1, 2, 3, 7, 8, 13},
+        {17},
+        {19},
+        {30},
         {9},
-        {0, 1, 2, 3, 7, 13, 17, 19},
+        {16, 4, 5, 6, 10},
         {21},
-        {28, 31, 32, 33, 14, 15, 18, 20, 22},
+        {24, 25, 28, 31},
+        {26},
+        {32, 33, 14, 15, 18, 20, 22, 23, 27, 29},
     ]
     assert {frozenset(C) for C in P} == {frozenset(C) for C in P_expected}
 
@@ -242,24 +240,21 @@ def test_expected_stable_across_code_changes_cpm():
 def test_expected_stable_across_code_changes_qmod():
     qmod = "modularity"
     G = nx.karate_club_graph()
-    P = comm.leiden_communities(G, resolution=0.2, seed=10, metric=qmod)
+    P = comm.leiden_communities(G, resolution=0.2, seed=2, metric=qmod)
     P_expected = [
         {0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21},
-        {16, 5, 6},
-        {4, 10},
-        {23, 24, 25, 27, 28, 31},
-        {32, 33, 8, 9, 14, 15, 18, 20, 22, 26, 29, 30},
+        {16, 4, 5, 6, 10},
+        {32, 33, 8, 9, 14, 15, 18, 20, 22, 23, 26, 27, 29, 30},
+        {24, 25, 28, 31},
     ]
     assert {frozenset(C) for C in P} == {frozenset(C) for C in P_expected}
 
     G = nx.karate_club_graph()
-    P = comm.leiden_communities(G, weight=None, resolution=0.2, seed=10, metric=qmod)
+    P = comm.leiden_communities(G, weight=None, resolution=0.2, seed=8, metric=qmod)
     P_expected = [
-        {0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21},
-        {16, 5, 6},
-        {4, 10},
-        {8, 9, 14, 15, 18, 20, 22, 23, 26, 27, 29, 30, 32, 33},
-        {24, 25, 28, 31},
+        {0, 1, 2, 3, 7, 9, 11, 12, 13, 17, 19, 21},
+        {16, 4, 5, 6, 10},
+        {8, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},
     ]
     assert {frozenset(C) for C in P} == {frozenset(C) for C in P_expected}
 
@@ -302,3 +297,8 @@ def test_bipartite_graphs_modularity_directed():
     G = nx.bipartite.random_graph(10, 20, 0.2, directed=True, seed=11)
     with pytest.raises(nx.NetworkXError):
         comm.leiden_communities(G, metric="barber_modularity", resolution=0.2, seed=1)
+
+
+def test_neighbors_correct_after_aggregation():
+    result = list(comm.leiden_partitions(nx.path_graph(15), resolution=0.2, seed=1))
+    assert len(result[0]) != len(result[1])

--- a/networkx/algorithms/community/tests/test_leiden.py
+++ b/networkx/algorithms/community/tests/test_leiden.py
@@ -149,10 +149,10 @@ def test_LFR_communities_across_algos():
     C = comm.louvain_communities(G, resolution=0.5, seed=10)
     louvain_comm = {frozenset(c) for c in C}
 
-    C = comm.leiden_communities(G, metric="cpm", resolution=-0.001, seed=20)
+    C = comm.leiden_communities(G, metric="cpm", resolution=0.001, seed=45)
     cpm_comm = {frozenset(c) for c in C}
 
-    C = comm.leiden_communities(G, metric="modularity", resolution=0.1, seed=157)
+    C = comm.leiden_communities(G, metric="modularity", resolution=0.3, seed=36)
     mod_comm = {frozenset(c) for c in C}
 
     assert louvain_comm == cpm_comm == LFR_comm == mod_comm
@@ -283,6 +283,7 @@ def test_connected_communities_no_weights():
 @pytest.mark.parametrize("metric", _metrics())
 def test_directed_graphs_modularity(metric):
     G = nx.gn_graph(n=100, seed=11)
+    G.add_edges_from([(1, 2), (2, 1)])  # ensure one node-pair has both directions
     assert nx.is_directed(G)
     comm.leiden_communities(G, metric=metric, weight=None, resolution=0.2, seed=11)
 
@@ -299,6 +300,39 @@ def test_bipartite_graphs_modularity_directed():
         comm.leiden_communities(G, metric="barber_modularity", resolution=0.2, seed=1)
 
 
-def test_neighbors_correct_after_aggregation():
+def test_neighbors_change_after_aggregation():
     result = list(comm.leiden_partitions(nx.path_graph(15), resolution=0.2, seed=1))
     assert len(result[0]) != len(result[1])
+
+
+def test_weights_matter():
+    G = nx.path_graph(15)
+    no_weights = list(comm.leiden_partitions(G, resolution=2, seed=42637))
+
+    G.add_weighted_edges_from((u, v, (u + 1) * v) for u, v in G.edges())
+    with_weights = list(comm.leiden_partitions(G, resolution=2, seed=42637))
+    assert len(no_weights[0]) > len(with_weights[0])
+    assert len(no_weights[-1]) > len(with_weights[-1])
+
+    G.edges[(3, 4)]["weight"] = 10000
+    big_weights = list(comm.leiden_partitions(G, resolution=2, seed=42637))
+    part_with_3 = [i for i, c in enumerate(big_weights[-1]) if 3 in c][0]
+    assert 4 in big_weights[-1][part_with_3]
+
+
+def test_directed_weights_matter():
+    G = nx.path_graph(15)
+    G = nx.DiGraph(G.edges())
+    no_weights = list(comm.leiden_partitions(G, resolution=2, seed=42637))
+
+    G.add_weighted_edges_from((u, v, (u + 1) * v) for u, v in G.edges())
+    with_weights = list(comm.leiden_partitions(G, resolution=2, seed=42637))
+    assert len(no_weights[0]) > len(with_weights[0])
+    assert len(no_weights[-1]) > len(with_weights[-1])
+    part_with_3 = [i for i, c in enumerate(with_weights[-1]) if 3 in c][0]
+    assert 4 not in with_weights[-1][part_with_3]
+
+    G.edges[(3, 4)]["weight"] = 1000
+    big_weights = list(comm.leiden_partitions(G, resolution=2, seed=42637))
+    part_with_3 = [i for i, c in enumerate(big_weights[-1]) if 3 in c][0]
+    assert 4 in big_weights[-1][part_with_3]

--- a/networkx/algorithms/community/tests/test_leiden.py
+++ b/networkx/algorithms/community/tests/test_leiden.py
@@ -248,8 +248,7 @@ def test_expected_stable_across_code_changes_qmod():
     G = nx.karate_club_graph()
     P = comm.leiden_communities(G, weight=None, resolution=0.4, seed=100, metric=qmod)
     P_expected = [
-        {0, 1, 2, 3, 7, 9, 11, 12, 13, 17, 19, 21},
-        {16, 4, 5, 6, 10},
+        {0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 16, 17, 19, 21},
         {8, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},
     ]
     assert {frozenset(C) for C in P} == {frozenset(C) for C in P_expected}
@@ -363,23 +362,20 @@ def test_directed_selfloops():
 @pytest.mark.parametrize("m", _metrics())
 def test_weights_matter(m):
     G = nx.path_graph(15)
-    no_weights = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=42637))
+    no_wts = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=42637))
 
     G.add_weighted_edges_from((u, v, (u + 1) * v) for u, v in G.edges())
 
-    with_weights = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=40))
-
-    fewer_comms = len(no_weights[0]) > len(with_weights[0])
-    big_comms_bigger = len(no_weights[0][3]) < len(with_weights[0][3])
-    assert fewer_comms or big_comms_bigger
-    fewer_comms = len(no_weights[-1]) > len(with_weights[-1])
-    big_comms_bigger = len(no_weights[-1][3]) < len(with_weights[-1][3])
-    assert fewer_comms or big_comms_bigger
+    with_wts = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=40))
+    assert len(with_wts) > len(no_wts)
+    fewer_comms = len(no_wts[-1]) > len(with_wts[-1])
+    big_comms = max(len(C) for C in no_wts[-1]) < max(len(C) for C in with_wts[-1])
+    assert fewer_comms or big_comms
 
     G.edges[(3, 4)]["weight"] = 100
-    big_weights = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=40))
-    part_with_3 = [i for i, c in enumerate(big_weights[-1]) if 3 in c][0]
-    assert 4 in big_weights[-1][part_with_3]
+    big_wts = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=40))
+    part_with_3 = [i for i, c in enumerate(big_wts[-1]) if 3 in c][0]
+    assert 4 in big_wts[-1][part_with_3]
 
 
 @pytest.mark.parametrize("m", _metrics())
@@ -411,3 +407,54 @@ def test_edge_wts():
 
     P = comm.leiden_communities(G, metric="modularity", resolution=2, seed=42)
     assert {frozenset(c) for c in P} == {frozenset({0}), frozenset({1, 2})}
+
+
+def test_modularity_selfloops():
+    G = nx.Graph()
+    G.add_edge(0, 1, weight=1)
+    G.add_edge(0, 0, weight=2)
+
+    P = comm.leiden_communities(G, metric="modularity", resolution=2, seed=0)
+    assert {frozenset(c) for c in P} == {frozenset([0]), frozenset([1])}
+
+
+def test_modularity_twom_instead_of_m():
+    G = nx.Graph()
+    G.add_edge(0, 1, weight=1)
+
+    P = comm.leiden_communities(G, metric="modularity", resolution=1, seed=0)
+    assert P == [{0, 1}]
+
+
+def test_cpm_node_weights_on_G():
+    G = nx.Graph()
+    G.add_weighted_edges_from(
+        [
+            (0, 1, 1),
+            (1, 2, 2),
+            (2, 3, 4),
+            (3, 4, 4),
+            (4, 5, 2),
+            (5, 6, 3),
+            (6, 7, 1),
+            (7, 8, 2),
+            (8, 9, 2),
+            (0, 7, 2),
+            (0, 8, 1),
+            (1, 3, 2),
+            (1, 9, 1),
+            (2, 6, 2),
+            (2, 8, 4),
+            (3, 5, 3),
+            (4, 7, 1),
+            (4, 9, 2),
+            (6, 9, 4),
+            (7, 9, 4),
+        ]
+    )
+
+    Plist = list(comm.leiden_partitions(G, metric="cpm", resolution=0.8, seed=0))
+    P_expected = [{8, 2}, {1}, {9, 6, 7}, {3, 4, 5}, {0}]
+    assert len(Plist) == 2
+    assert {frozenset(c) for c in Plist[0]} == {frozenset(c) for c in P_expected}
+    assert {frozenset(c) for c in Plist[1]} == {frozenset(c) for c in P_expected}

--- a/networkx/algorithms/community/tests/test_leiden.py
+++ b/networkx/algorithms/community/tests/test_leiden.py
@@ -313,17 +313,17 @@ def test_comms_change_after_aggregation():
 
 @pytest.mark.parametrize("m", _metrics())
 def test_undirected_selfloops(m):
-    qmod = "modularity"
     G = nx.karate_club_graph()
-    partition = comm.leiden_communities(G, metric=m, seed=1, weight=None)
+    partition = comm.leiden_communities(G, metric=m, seed=1)
 
     G.add_weighted_edges_from([(i, i, i * 1000) for i in range(4)])
     # large self-loop weight impacts partition
-    big_partition = comm.leiden_communities(G, metric=m, seed=1, weight="weight")
+    big_partition = comm.leiden_communities(G, metric=m, seed=2)
     assert big_partition != partition
 
     # small self-loop weights aren't enough to impact partition in this graph
-    small_partition = comm.leiden_communities(G, metric=m, seed=1, weight=None)
+    G.add_weighted_edges_from([(i, i, 0.1) for i in range(4)])
+    small_partition = comm.leiden_communities(G, metric=m, seed=1)
     assert small_partition == partition
 
 
@@ -362,18 +362,18 @@ def test_directed_selfloops():
 @pytest.mark.parametrize("m", _metrics())
 def test_weights_matter(m):
     G = nx.path_graph(15)
-    no_wts = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=42637))
+    no_wts = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=5))
 
     G.add_weighted_edges_from((u, v, (u + 1) * v) for u, v in G.edges())
 
-    with_wts = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=40))
+    with_wts = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=5))
     assert len(with_wts) > len(no_wts)
     fewer_comms = len(no_wts[-1]) > len(with_wts[-1])
     big_comms = max(len(C) for C in no_wts[-1]) < max(len(C) for C in with_wts[-1])
     assert fewer_comms or big_comms
 
     G.edges[(3, 4)]["weight"] = 100
-    big_wts = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=40))
+    big_wts = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=5))
     part_with_3 = [i for i, c in enumerate(big_wts[-1]) if 3 in c][0]
     assert 4 in big_wts[-1][part_with_3]
 

--- a/networkx/algorithms/community/tests/test_leiden.py
+++ b/networkx/algorithms/community/tests/test_leiden.py
@@ -118,10 +118,7 @@ def test_resolution_kwarg_cpm(G):
     assert len(P1) < len(P2) < len(P3) < len(P4) < len(P5)
 
 
-@pytest.mark.slow
 def test_resolution_kwarg_mod(G):
-    # these work -- but kinda slow & modularity doesn't change smoothly
-    # TODO check the speed again after optimizing leiden modularity
     qmod = "modularity"
     # Only three sizes of partitions: 2, 21, 77. Changes at r=0 and r=6.83
     if G.is_multigraph():
@@ -169,7 +166,9 @@ def test_barbell_communities_across_algos():
 
     # seed doesn't seem to matter for this example. Resolution does.
     louvain_comm = comm.louvain_communities(G, resolution=1)
-    mod_comm = comm.leiden_communities(G, metric="modularity", resolution=0.3, seed=seed)
+    mod_comm = comm.leiden_communities(
+        G, metric="modularity", resolution=0.3, seed=seed
+    )
     cpm_comm = comm.leiden_communities(G, metric="cpm", resolution=0.3, seed=seed)
 
     assert {frozenset(C) for C in louvain_comm} == {frozenset(C) for C in mod_comm}

--- a/networkx/algorithms/community/tests/test_leiden.py
+++ b/networkx/algorithms/community/tests/test_leiden.py
@@ -87,8 +87,8 @@ def test_overall_increase(metric, Q_func, gamma):
 @pytest.mark.parametrize("metric", _metrics())
 def test_coverage_up_with_leiden_metrics(G, singletons, metric):
     # check that `partition_quality` coverage increases for all metrics
-    # even though they not optimizing coverage. Also that coverage > 45%
-    partition = comm.leiden_communities(G, metric=metric, resolution=0.05, seed=10)
+    # even though they are not optimizing coverage. Also that coverage > 45%
+    partition = comm.leiden_communities(G, metric=metric, resolution=0.01, seed=10)
     coverage = comm.partition_quality(G, partition)[0]  # 0th return is coverage
     assert coverage >= 0.45
     assert coverage > comm.partition_quality(G, singletons)[0]
@@ -133,11 +133,7 @@ def test_resolution_kwarg_mod(G):
         P1 = comm.leiden_communities(G, metric=qmod, resolution=0.0, seed=12)
         P2 = comm.leiden_communities(G, metric=qmod, resolution=1.0, seed=12)
         P3 = comm.leiden_communities(G, metric=qmod, resolution=7.0, seed=12)
-<<<<<<< HEAD
-=======
-        print(f"{len(P1)=} {len(P2)=} {len(P3)=}")
->>>>>>> d909e0c6f (first set of adjustments of leiden)
-        assert len(P1) < len(P2) < len(P3)
+        assert len(P1) < len(P2) < len(P3), f"{len(P1)=} {len(P2)=} {len(P3)=}"
 
 
 def test_LFR_communities_across_algos():
@@ -156,13 +152,14 @@ def test_LFR_communities_across_algos():
     C = comm.louvain_communities(G, resolution=0.5, seed=10)
     louvain_comm = {frozenset(c) for c in C}
 
-    C = comm.leiden_communities(G, metric="cpm", resolution=0.0001, seed=10)
+    C = comm.leiden_communities(G, metric="cpm", resolution=-0.02, seed=10)
     cpm_comm = {frozenset(c) for c in C}
 
-    C = comm.leiden_communities(G, metric="modularity", resolution=0.01, seed=3)
+    C = comm.leiden_communities(G, metric="modularity", resolution=-30.0, seed=3)
     mod_comm = {frozenset(c) for c in C}
 
-    assert len(louvain_comm) == len(cpm_comm) == len(mod_comm) == len(LFR_comm)
+    msg = f"{len(louvain_comm)=}, {len(cpm_comm)=}, {len(mod_comm)=}, {len(LFR_comm)=}"
+    assert len(louvain_comm) == len(cpm_comm) == len(mod_comm) == len(LFR_comm), msg
     assert louvain_comm == cpm_comm == LFR_comm  # mod_comm has 3 different comms
 
 
@@ -172,7 +169,7 @@ def test_barbell_communities_across_algos():
 
     # seed doesn't seem to matter for this example. Resolution does.
     louvain_comm = comm.louvain_communities(G, resolution=1)
-    mod_comm = comm.leiden_communities(G, metric="modularity", resolution=3, seed=seed)
+    mod_comm = comm.leiden_communities(G, metric="modularity", resolution=0.3, seed=seed)
     cpm_comm = comm.leiden_communities(G, metric="cpm", resolution=0.3, seed=seed)
 
     assert {frozenset(C) for C in louvain_comm} == {frozenset(C) for C in mod_comm}
@@ -218,9 +215,11 @@ def test_expected_stable_across_code_changes_cpm():
     P = comm.leiden_communities(G, resolution=0.2, seed=1)
     P_expected = [
         {0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21},
-        {16, 4, 5, 6, 10},
+        {4, 10},
+        {16, 5, 6},
         {9},
-        {8, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},
+        {18},
+        {8, 14, 15, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},
     ]
     assert {frozenset(C) for C in P} == {frozenset(C) for C in P_expected}
 
@@ -229,16 +228,14 @@ def test_expected_stable_across_code_changes_cpm():
     P_expected = [
         {11},
         {12},
-        {0, 1, 2, 3, 7, 8, 13},
-        {17},
-        {19},
-        {30},
+        {8, 30},
+        {4, 10, 16, 5, 6},
+        {24, 27},
+        {25, 26, 29, 23},
         {9},
-        {16, 4, 5, 6, 10},
+        {0, 1, 2, 3, 7, 13, 17, 19},
         {21},
-        {24, 25, 28, 31},
-        {26},
-        {32, 33, 14, 15, 18, 20, 22, 23, 27, 29},
+        {28, 31, 32, 33, 14, 15, 18, 20, 22},
     ]
     assert {frozenset(C) for C in P} == {frozenset(C) for C in P_expected}
 
@@ -246,21 +243,24 @@ def test_expected_stable_across_code_changes_cpm():
 def test_expected_stable_across_code_changes_qmod():
     qmod = "modularity"
     G = nx.karate_club_graph()
-    P = comm.leiden_communities(G, resolution=2, seed=10, metric=qmod)
+    P = comm.leiden_communities(G, resolution=0.2, seed=10, metric=qmod)
     P_expected = [
         {0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21},
-        {16, 4, 5, 6, 10},
-        {32, 33, 8, 9, 14, 15, 18, 20, 22, 23, 26, 27, 29, 30},
-        {24, 25, 28, 31},
+        {16, 5, 6},
+        {4, 10},
+        {23, 24, 25, 27, 28, 31},
+        {32, 33, 8, 9, 14, 15, 18, 20, 22, 26, 29, 30},
     ]
     assert {frozenset(C) for C in P} == {frozenset(C) for C in P_expected}
 
     G = nx.karate_club_graph()
-    P = comm.leiden_communities(G, weight=None, resolution=2, seed=10, metric=qmod)
+    P = comm.leiden_communities(G, weight=None, resolution=0.2, seed=10, metric=qmod)
     P_expected = [
-        {0, 1, 2, 3, 7, 9, 11, 12, 13, 17, 19, 21},
-        {16, 4, 5, 6, 10},
-        {8, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},
+        {0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21},
+        {16, 5, 6},
+        {4, 10},
+        {8, 9, 14, 15, 18, 20, 22, 23, 26, 27, 29, 30, 32, 33},
+        {24, 25, 28, 31},
     ]
     assert {frozenset(C) for C in P} == {frozenset(C) for C in P_expected}
 

--- a/networkx/algorithms/community/tests/test_leiden.py
+++ b/networkx/algorithms/community/tests/test_leiden.py
@@ -152,7 +152,7 @@ def test_LFR_communities_across_algos():
     C = comm.leiden_communities(G, metric="cpm", resolution=0.001, seed=45)
     cpm_comm = {frozenset(c) for c in C}
 
-    C = comm.leiden_communities(G, metric="modularity", resolution=0.3, seed=36)
+    C = comm.leiden_communities(G, metric="modularity", resolution=0.3, seed=24)
     mod_comm = {frozenset(c) for c in C}
 
     assert louvain_comm == cpm_comm == LFR_comm == mod_comm
@@ -240,7 +240,7 @@ def test_expected_stable_across_code_changes_cpm():
 def test_expected_stable_across_code_changes_qmod():
     qmod = "modularity"
     G = nx.karate_club_graph()
-    P = comm.leiden_communities(G, resolution=0.2, seed=2, metric=qmod)
+    P = comm.leiden_communities(G, resolution=0.2, seed=483, metric=qmod)
     P_expected = [
         {0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21},
         {16, 4, 5, 6, 10},
@@ -250,7 +250,7 @@ def test_expected_stable_across_code_changes_qmod():
     assert {frozenset(C) for C in P} == {frozenset(C) for C in P_expected}
 
     G = nx.karate_club_graph()
-    P = comm.leiden_communities(G, weight=None, resolution=0.2, seed=8, metric=qmod)
+    P = comm.leiden_communities(G, weight=None, resolution=0.2, seed=39, metric=qmod)
     P_expected = [
         {0, 1, 2, 3, 7, 9, 11, 12, 13, 17, 19, 21},
         {16, 4, 5, 6, 10},

--- a/networkx/algorithms/community/tests/test_leiden.py
+++ b/networkx/algorithms/community/tests/test_leiden.py
@@ -133,6 +133,10 @@ def test_resolution_kwarg_mod(G):
         P1 = comm.leiden_communities(G, metric=qmod, resolution=0.0, seed=12)
         P2 = comm.leiden_communities(G, metric=qmod, resolution=1.0, seed=12)
         P3 = comm.leiden_communities(G, metric=qmod, resolution=7.0, seed=12)
+<<<<<<< HEAD
+=======
+        print(f"{len(P1)=} {len(P2)=} {len(P3)=}")
+>>>>>>> d909e0c6f (first set of adjustments of leiden)
         assert len(P1) < len(P2) < len(P3)
 
 

--- a/networkx/algorithms/community/tests/test_leiden.py
+++ b/networkx/algorithms/community/tests/test_leiden.py
@@ -240,10 +240,8 @@ def test_expected_stable_across_code_changes_qmod():
     G = nx.karate_club_graph()
     P = comm.leiden_communities(G, resolution=0.2, seed=22, metric=qmod)
     P_expected = [
-        {0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21},
-        {16, 4, 5, 6, 10},
-        {32, 33, 8, 9, 14, 15, 18, 20, 22, 23, 26, 27, 29, 30},
-        {24, 25, 28, 31},
+        {0, 1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 16, 17, 19, 21},
+        {8, 9, 14, 15, 18, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33},
     ]
     assert {frozenset(C) for C in P} == {frozenset(C) for C in P_expected}
 

--- a/networkx/algorithms/community/tests/test_leiden.py
+++ b/networkx/algorithms/community/tests/test_leiden.py
@@ -305,7 +305,7 @@ def test_comms_change_after_aggregation():
 
     result = list(LP(PG, resolution=0.2, seed=1))
     assert len(result[0]) != len(result[1])
-    result = list(LP(DPG, resolution=0.2, seed=1))
+    result = list(LP(DPG, resolution=0.1, seed=1))
     assert len(result[0]) != len(result[1])
 
     result = list(LP(PG, metric="modularity", resolution=0.2, seed=1))
@@ -322,12 +322,15 @@ def test_weights_matter(m):
     G.add_weighted_edges_from((u, v, (u + 1) * v) for u, v in G.edges())
 
     with_weights = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=40))
+
     fewer_comms = len(no_weights[0]) > len(with_weights[0])
     big_comms_bigger = len(no_weights[0][3]) < len(with_weights[0][3])
     assert fewer_comms or big_comms_bigger
-    no_w, with_w = no_weights[-1], with_weights[-1]
-    assert (len(no_w) > len(with_w)) or (len(no_w[0]) < len(with_w[0]))
+    fewer_comms = len(no_weights[-1]) > len(with_weights[-1])
+    big_comms_bigger = len(no_weights[-1][3]) < len(with_weights[-1][3])
+    assert fewer_comms or big_comms_bigger
 
+    G.edges[(3, 4)]["weight"] = 100
     big_weights = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=40))
     part_with_3 = [i for i, c in enumerate(big_weights[-1]) if 3 in c][0]
     assert 4 in big_weights[-1][part_with_3]
@@ -342,12 +345,15 @@ def test_directed_weights_matter(m):
 
     G.add_weighted_edges_from((u, v, (u + 1) * v) for u, v in G.edges())
     with_weights = list(comm.leiden_partitions(G, metric=m, resolution=r, seed=s))
-    assert len(no_weights[0]) > len(with_weights[0])
-    assert len(no_weights[-1][-1]) < len(with_weights[-1][-1])
-    part_with_3 = [i for i, c in enumerate(with_weights[-1]) if 3 in c][0]
-    assert 4 not in with_weights[-1][part_with_3]
 
-    G.edges[(3, 4)]["weight"] = 1000
+    fewer_comms = len(no_weights[0]) > len(with_weights[0])
+    big_comms_bigger = len(no_weights[0][3]) < len(with_weights[0][3])
+    assert fewer_comms or big_comms_bigger
+    fewer_comms = len(no_weights[-1]) > len(with_weights[-1])
+    big_comms_bigger = len(no_weights[-1][3]) < len(with_weights[-1][3])
+    assert fewer_comms or big_comms_bigger
+
+    G.edges[(3, 4)]["weight"] = 100
     big_weights = list(comm.leiden_partitions(G, metric=m, resolution=r, seed=s))
     part_with_3 = [i for i, c in enumerate(big_weights[-1]) if 3 in c][0]
     assert 4 in big_weights[-1][part_with_3]

--- a/networkx/algorithms/community/tests/test_leiden.py
+++ b/networkx/algorithms/community/tests/test_leiden.py
@@ -122,10 +122,10 @@ def test_resolution_kwarg_mod(G):
     qmod = "modularity"
     # Only three sizes of partitions: 2, 21, 77. Changes at r=0 and r=6.83
     if G.is_multigraph():
-        P01 = comm.leiden_communities(G, metric=qmod, resolution=0.1, seed=12)
-        P1 = comm.leiden_communities(G, metric=qmod, resolution=1.0, seed=12)
+        P1 = comm.leiden_communities(G, metric=qmod, resolution=1, seed=12)
+        P2 = comm.leiden_communities(G, metric=qmod, resolution=2, seed=12)
         P10 = comm.leiden_communities(G, metric=qmod, resolution=10, seed=12)
-        assert len(P01) < len(P1) < len(P10)
+        assert len(P1) < len(P2) < len(P10)
     else:
         P1 = comm.leiden_communities(G, metric=qmod, resolution=0.0, seed=12)
         P2 = comm.leiden_communities(G, metric=qmod, resolution=1.0, seed=12)
@@ -164,9 +164,7 @@ def test_barbell_communities_across_algos():
 
     # seed doesn't seem to matter for this example. Resolution does.
     louvain_comm = comm.louvain_communities(G, resolution=1)
-    mod_comm = comm.leiden_communities(
-        G, metric="modularity", resolution=0.3, seed=seed
-    )
+    mod_comm = comm.leiden_communities(G, metric="modularity", resolution=1, seed=seed)
     cpm_comm = comm.leiden_communities(G, metric="cpm", resolution=0.3, seed=seed)
 
     assert {frozenset(C) for C in louvain_comm} == {frozenset(C) for C in mod_comm}
@@ -240,7 +238,7 @@ def test_expected_stable_across_code_changes_cpm():
 def test_expected_stable_across_code_changes_qmod():
     qmod = "modularity"
     G = nx.karate_club_graph()
-    P = comm.leiden_communities(G, resolution=0.2, seed=483, metric=qmod)
+    P = comm.leiden_communities(G, resolution=0.2, seed=22, metric=qmod)
     P_expected = [
         {0, 1, 2, 3, 7, 11, 12, 13, 17, 19, 21},
         {16, 4, 5, 6, 10},
@@ -250,7 +248,7 @@ def test_expected_stable_across_code_changes_qmod():
     assert {frozenset(C) for C in P} == {frozenset(C) for C in P_expected}
 
     G = nx.karate_club_graph()
-    P = comm.leiden_communities(G, weight=None, resolution=0.2, seed=39, metric=qmod)
+    P = comm.leiden_communities(G, weight=None, resolution=0.4, seed=100, metric=qmod)
     P_expected = [
         {0, 1, 2, 3, 7, 9, 11, 12, 13, 17, 19, 21},
         {16, 4, 5, 6, 10},
@@ -300,39 +298,56 @@ def test_bipartite_graphs_modularity_directed():
         comm.leiden_communities(G, metric="barber_modularity", resolution=0.2, seed=1)
 
 
-def test_neighbors_change_after_aggregation():
-    result = list(comm.leiden_partitions(nx.path_graph(15), resolution=0.2, seed=1))
+def test_comms_change_after_aggregation():
+    LP = comm.leiden_partitions
+    PG = nx.path_graph(15)
+    DPG = nx.DiGraph(PG.edges)
+
+    result = list(LP(PG, resolution=0.2, seed=1))
+    assert len(result[0]) != len(result[1])
+    result = list(LP(DPG, resolution=0.2, seed=1))
+    assert len(result[0]) != len(result[1])
+
+    result = list(LP(PG, metric="modularity", resolution=0.2, seed=1))
+    assert len(result[0]) != len(result[1])
+    result = list(LP(DPG, metric="modularity", resolution=0.02, seed=1))
     assert len(result[0]) != len(result[1])
 
 
-def test_weights_matter():
+@pytest.mark.parametrize("m", _metrics())
+def test_weights_matter(m):
     G = nx.path_graph(15)
-    no_weights = list(comm.leiden_partitions(G, resolution=2, seed=42637))
+    no_weights = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=42637))
 
     G.add_weighted_edges_from((u, v, (u + 1) * v) for u, v in G.edges())
-    with_weights = list(comm.leiden_partitions(G, resolution=2, seed=42637))
-    assert len(no_weights[0]) > len(with_weights[0])
-    assert len(no_weights[-1]) > len(with_weights[-1])
 
-    G.edges[(3, 4)]["weight"] = 10000
-    big_weights = list(comm.leiden_partitions(G, resolution=2, seed=42637))
+    with_weights = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=40))
+    fewer_comms = len(no_weights[0]) > len(with_weights[0])
+    big_comms_bigger = len(no_weights[0][3]) < len(with_weights[0][3])
+    assert fewer_comms or big_comms_bigger
+    no_w, with_w = no_weights[-1], with_weights[-1]
+    assert (len(no_w) > len(with_w)) or (len(no_w[0]) < len(with_w[0]))
+
+    big_weights = list(comm.leiden_partitions(G, metric=m, resolution=2, seed=40))
     part_with_3 = [i for i, c in enumerate(big_weights[-1]) if 3 in c][0]
     assert 4 in big_weights[-1][part_with_3]
 
 
-def test_directed_weights_matter():
-    G = nx.path_graph(15)
-    G = nx.DiGraph(G.edges())
-    no_weights = list(comm.leiden_partitions(G, resolution=2, seed=42637))
+@pytest.mark.parametrize("m", _metrics())
+def test_directed_weights_matter(m):
+    r = 2
+    s = 42637
+    G = nx.DiGraph(nx.path_graph(15).edges())
+    no_weights = list(comm.leiden_partitions(G, metric=m, resolution=r, seed=s))
 
     G.add_weighted_edges_from((u, v, (u + 1) * v) for u, v in G.edges())
-    with_weights = list(comm.leiden_partitions(G, resolution=2, seed=42637))
+    with_weights = list(comm.leiden_partitions(G, metric=m, resolution=r, seed=s))
     assert len(no_weights[0]) > len(with_weights[0])
-    assert len(no_weights[-1]) > len(with_weights[-1])
+    assert len(no_weights[-1][-1]) < len(with_weights[-1][-1])
     part_with_3 = [i for i, c in enumerate(with_weights[-1]) if 3 in c][0]
     assert 4 not in with_weights[-1][part_with_3]
 
     G.edges[(3, 4)]["weight"] = 1000
-    big_weights = list(comm.leiden_partitions(G, resolution=2, seed=42637))
+    big_weights = list(comm.leiden_partitions(G, metric=m, resolution=r, seed=s))
     part_with_3 = [i for i, c in enumerate(big_weights[-1]) if 3 in c][0]
     assert 4 in big_weights[-1][part_with_3]


### PR DESCRIPTION
This PR speeds up Leiden by over 10x. We can remove the slow mark on tests.

The main change is to store the node/edge data in separate dicts rather than on the graph. Each lookup like:  `G.nodes[node]["node_weight"]` involves a View creation and two dict lookups, while `node_weights[node]` is just one dict lookup. We are summing up these attributes across potential communities (subset of nodes of the G). And there are many many subsets to consider. I thought about caching the subsets sums, but decided the potential number of subsets is really really big, so the cache would blow up memory.

Changes outside leiden.py:
- **quality.py**:  Avoid divide by zero case
- **tests/test_leiden.py**:  tweak resolution values and precise subsets for tests that are checking for changes due to code, but for which we don't know a ground truth solution. For example, testing results across metrics often requires changing the resolution to match other metrics. And testing against specific community partitions that were obtained with the older code (not created based on knowledge of what it should be) is often fragile. 

Changes within leiden.py:
- tried to consolidate comments near top of a loop to explain the upcoming code, rather than splitting it our on each line. Also tried to use variable names that helped reduce need for some comments. Other variable names were shortened to reduce wrapping which extended loops across multiple pages.
- Unified names across functions: e.g. `G` and `orig_G` rather than a mix of `G` and `graph` throughout. Also `P_refined` and `P` and `C`. This sometimes makes the varnames differ from the paper's names. But these are better and close enough to allow comparison.
- while copying the input graph, put the edge weights into a dict-of-dict (DOD) structure, and the node attributes (which change based on which metric you use) into a dict for each attribute. This avoids lookup issues as described above -- but it also means when we aggregate graphs we can update the data separately from the graph manipulations. The DOD structure seems to provide most of the speedup of this PR. The [line_profiler] package was very helpful in focusing my efforts on the `delta_func` code (which computes the change in metric when moving a node to a new community). About 85% of the time was spent on these dict lookups and view creations. Avoiding them helped a lot.
- refactored `_refine_partition` and `_merge_node_subset` to avoid even needing the graph as input (though graph is used via the namespace of `delta_func()`). The main loop here was recomputing the `T` condition repeatedly in a loop that didn't change it's inputs. So I was able to move those calculations outside the loop for another large speedup.
- The `_create_aggregate_graph` function was rewritten to update the data attributes in the dicts rather than on the graph. It changes an input dict `node_attributes` rather than returning it. This allows us to use put those dicts into the namespace of the function where `delta_func` is defined so it can look them up easily.  There may be a faster/better way to do this tracking and updating the external info needed by `delta_func`, but this approach seems to work well. Suggestions welcome.
- I added comments to warn that reader of the various `delta_func()` functions that outside objects (like the DOD objects) are used inside the function. And I added comments near places where the newly created DOD objects for the aggregate graph are moved into the main function's namespace.

I think this is ready for review. :tada:
 