### PR TITLE
Add normalized_adjacency_matrix and normalized_adjacency_spectrum (closes #3834)

### DIFF
--- a/doc/reference/linalg.rst
+++ b/doc/reference/linalg.rst
@@ -13,6 +13,7 @@ Graph Matrix
    :toctree: generated/
 
    adjacency_matrix
+   normalized_adjacency_matrix
    incidence_matrix
 
 Laplacian Matrix
@@ -72,6 +73,7 @@ Spectrum
    :toctree: generated/
 
    adjacency_spectrum
+   normalized_adjacency_spectrum
    laplacian_spectrum
    bethe_hessian_spectrum
    normalized_laplacian_spectrum

--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -4,7 +4,7 @@ Adjacency matrix and incidence matrix of graphs.
 
 import networkx as nx
 
-__all__ = ["incidence_matrix", "adjacency_matrix"]
+__all__ = ["incidence_matrix", "adjacency_matrix", "normalized_adjacency_matrix"]
 
 
 @nx._dispatchable(edge_attrs="weight")
@@ -172,3 +172,94 @@ def adjacency_matrix(G, nodelist=None, dtype=None, weight="weight", *, format="c
     return nx.to_scipy_sparse_array(
         G, nodelist=nodelist, dtype=dtype, weight=weight, format=format
     )
+
+
+@nx._dispatchable(edge_attrs="weight")
+def normalized_adjacency_matrix(G, nodelist=None, weight="weight"):
+    r"""Returns the normalized adjacency matrix of `G`.
+
+    The normalized adjacency matrix is the matrix
+
+    .. math::
+
+        N = D^{-1/2} A D^{-1/2}
+
+    where `A` is the adjacency matrix of `G` and `D` is the diagonal matrix of
+    node degrees [1]_. The eigenvalues of `N` lie in the interval `[-1, 1]`.
+    It is related to the normalized Laplacian `\mathcal{L}` by
+    `N = I - \mathcal{L}` for graphs without isolated nodes.
+
+    Parameters
+    ----------
+    G : graph
+       A NetworkX graph
+
+    nodelist : list, optional
+       The rows and columns are ordered according to the nodes in `nodelist`.
+       If ``nodelist=None`` (the default), then the ordering is produced by
+       ``G.nodes()``.
+
+    weight : string or None, optional (default='weight')
+       The edge data key used to compute each value in the matrix.
+       If None, then each edge has weight 1.
+
+    Returns
+    -------
+    N : SciPy sparse array
+      The normalized adjacency matrix of `G`.
+
+    Notes
+    -----
+    For MultiGraph/MultiDiGraph, the edge weights are summed.
+    See :func:`to_numpy_array` for other options.
+
+    `D` is the diagonal matrix of the row sums of the adjacency matrix, i.e.
+    the out-degree for directed graphs. To use the in-degree instead, use
+    ``G.reverse(copy=False)``. Following the convention of
+    `normalized_laplacian_matrix`, an isolated node (zero degree) produces a
+    zero row and column rather than a division by zero.
+
+    For an unnormalized output, use `adjacency_matrix`.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> G = nx.path_graph(4)
+    >>> print(nx.normalized_adjacency_matrix(G).toarray())
+    [[0.         0.70710678 0.         0.        ]
+     [0.70710678 0.         0.5        0.        ]
+     [0.         0.5        0.         0.70710678]
+     [0.         0.         0.70710678 0.        ]]
+
+    The normalized adjacency and normalized Laplacian matrices satisfy
+    `N = I - \mathcal{L}`:
+
+    >>> N = nx.normalized_adjacency_matrix(G).toarray()
+    >>> L = nx.normalized_laplacian_matrix(G).toarray()
+    >>> np.allclose(N, np.eye(len(G)) - L)
+    True
+
+    See Also
+    --------
+    adjacency_matrix
+    normalized_adjacency_spectrum
+    normalized_laplacian_matrix
+
+    References
+    ----------
+    .. [1] Fan Chung-Graham, Spectral Graph Theory,
+       CBMS Regional Conference Series in Mathematics, Number 92, 1997.
+    """
+    import numpy as np
+    import scipy as sp
+
+    if nodelist is None:
+        nodelist = list(G)
+    A = nx.to_scipy_sparse_array(G, nodelist=nodelist, weight=weight, format="csr")
+    n, _ = A.shape
+    diags = A.sum(axis=1)
+    with np.errstate(divide="ignore"):
+        diags_sqrt = 1.0 / np.sqrt(diags)
+    diags_sqrt[np.isinf(diags_sqrt)] = 0
+    DH = sp.sparse.dia_array((diags_sqrt, 0), shape=(n, n)).tocsr()
+    return DH @ (A @ DH)

--- a/networkx/linalg/spectrum.py
+++ b/networkx/linalg/spectrum.py
@@ -7,6 +7,7 @@ import networkx as nx
 __all__ = [
     "laplacian_spectrum",
     "adjacency_spectrum",
+    "normalized_adjacency_spectrum",
     "modularity_spectrum",
     "normalized_laplacian_spectrum",
     "bethe_hessian_spectrum",
@@ -121,6 +122,42 @@ def adjacency_spectrum(G, weight="weight"):
     import scipy as sp
 
     return sp.linalg.eigvals(nx.adjacency_matrix(G, weight=weight).todense())
+
+
+@nx._dispatchable(edge_attrs="weight")
+def normalized_adjacency_spectrum(G, weight="weight"):
+    """Returns eigenvalues of the normalized adjacency matrix of G.
+
+    Parameters
+    ----------
+    G : graph
+       A NetworkX graph
+
+    weight : string or None, optional (default='weight')
+       The edge data key used to compute each value in the matrix.
+       If None, then each edge has weight 1.
+
+    Returns
+    -------
+    evals : NumPy array
+      Eigenvalues
+
+    Notes
+    -----
+    For MultiGraph/MultiDiGraph, the edge weights are summed.
+    See to_numpy_array for other options.
+
+    For an undirected graph the normalized adjacency matrix is symmetric and
+    its eigenvalues are real and lie in the interval ``[-1, 1]``.
+
+    See Also
+    --------
+    normalized_adjacency_matrix
+    adjacency_spectrum
+    """
+    import scipy as sp
+
+    return sp.linalg.eigvals(nx.normalized_adjacency_matrix(G, weight=weight).todense())
 
 
 @nx._dispatchable

--- a/networkx/linalg/tests/test_graphmatrix.py
+++ b/networkx/linalg/tests/test_graphmatrix.py
@@ -28,6 +28,70 @@ def test_adjacency_matrix_format(ary_format):
         assert np.array_equal(A, expected_array)
 
 
+def test_normalized_adjacency_matrix():
+    G = nx.path_graph(4)
+    s2 = 1 / np.sqrt(2)
+    # fmt: off
+    expected = np.array(
+        [[0,  s2, 0,   0 ],
+         [s2, 0,  0.5, 0 ],
+         [0,  0.5, 0,  s2],
+         [0,  0,  s2,  0 ]]
+    )
+    # fmt: on
+    N = nx.normalized_adjacency_matrix(G)
+    np.testing.assert_allclose(N.todense(), expected)
+
+    # The matrix is symmetric for undirected graphs.
+    np.testing.assert_allclose(N.todense(), N.todense().T)
+
+    # N = I - normalized_laplacian for graphs without isolated nodes.
+    L = nx.normalized_laplacian_matrix(G).todense()
+    np.testing.assert_allclose(N.todense(), np.eye(len(G)) - L, atol=1e-12)
+
+    # The eigenvalues lie in [-1, 1].
+    evals = np.linalg.eigvalsh(N.todense())
+    assert evals.min() >= -1 - 1e-9
+    assert evals.max() <= 1 + 1e-9
+
+
+def test_normalized_adjacency_matrix_nodelist():
+    G = nx.path_graph(4)
+    N1 = nx.normalized_adjacency_matrix(G).todense()
+    # Reversing the node order permutes both rows and columns.
+    N2 = nx.normalized_adjacency_matrix(G, nodelist=[3, 2, 1, 0]).todense()
+    np.testing.assert_allclose(N1, N2[::-1, ::-1])
+
+
+def test_normalized_adjacency_matrix_isolated_node():
+    G = nx.Graph()
+    G.add_node(0)
+    G.add_edge(1, 2)
+    N = nx.normalized_adjacency_matrix(G, nodelist=[0, 1, 2]).todense()
+    # An isolated node yields a zero row/column, not a division by zero.
+    assert np.all(np.isfinite(N))
+    np.testing.assert_allclose(N[0], 0)
+    np.testing.assert_allclose(N[:, 0], 0)
+
+
+def test_normalized_adjacency_matrix_weighted():
+    G = nx.Graph()
+    G.add_edge(0, 1, weight=4)
+    G.add_edge(1, 2, weight=4)
+    # A uniform edge weight cancels in the normalization.
+    Nw = nx.normalized_adjacency_matrix(G).todense()
+    Nu = nx.normalized_adjacency_matrix(G, weight=None).todense()
+    np.testing.assert_allclose(Nw, Nu)
+
+
+def test_normalized_adjacency_matrix_directed():
+    DiG = nx.DiGraph([(0, 1), (1, 2), (2, 0)])
+    # Every node has out-degree 1, so D^{-1/2} A D^{-1/2} == A.
+    N = nx.normalized_adjacency_matrix(DiG).todense()
+    A = nx.adjacency_matrix(DiG).todense()
+    np.testing.assert_allclose(N, A)
+
+
 def test_incidence_matrix_simple():
     deg = [3, 2, 2, 1, 0]
     G = nx.havel_hakimi_graph(deg)

--- a/networkx/linalg/tests/test_spectrum.py
+++ b/networkx/linalg/tests/test_spectrum.py
@@ -49,6 +49,16 @@ class TestSpectrum:
         e = sorted(nx.adjacency_spectrum(self.P))
         np.testing.assert_almost_equal(e, evals)
 
+    def test_normalized_adjacency_spectrum(self):
+        "Normalized adjacency eigenvalues"
+        evals = np.array([-1, 0, 1])
+        e = sorted(nx.normalized_adjacency_spectrum(self.P).real)
+        np.testing.assert_almost_equal(e, evals)
+        # A uniform edge weight does not change the normalized spectrum.
+        e0 = sorted(nx.normalized_adjacency_spectrum(self.WG, weight=None).real)
+        ew = sorted(nx.normalized_adjacency_spectrum(self.WG).real)
+        np.testing.assert_almost_equal(e0, ew)
+
     def test_modularity_spectrum(self):
         "Modularity eigenvalues"
         evals = np.array([-1.5, 0.0, 0.0])


### PR DESCRIPTION
## What

Adds two functions to `networkx.linalg`, closing #3834:

- **`normalized_adjacency_matrix(G, nodelist=None, weight="weight")`** (in `graphmatrix.py`) — the normalized adjacency matrix

  $$N = D^{-1/2} A D^{-1/2}$$

  where `A` is the adjacency matrix and `D` the diagonal degree matrix.
- **`normalized_adjacency_spectrum(G, weight="weight")`** (in `spectrum.py`) — its eigenvalues.

These mirror the existing `normalized_laplacian_matrix` / `adjacency_spectrum` API (same signatures, dispatch decorator, weight handling, and isolated-node convention — a zero-degree node gives a zero row/column rather than dividing by zero).

## Why

The normalized adjacency matrix is a standard object in spectral graph theory (Chung, *Spectral Graph Theory*). Its eigenvalues lie in `[-1, 1]`, and it satisfies `N = I - \mathcal{L}` with the normalized Laplacian — but until now networkx had `normalized_laplacian_matrix`/`normalized_laplacian_spectrum` with no adjacency counterpart. Requested in #3834.

## Details
- Added to the respective `__all__`s and to `doc/reference/linalg.rst`.
- Docstrings include runnable examples (the `N = I - \mathcal{L}` identity is shown as a doctest).
- Works for directed graphs (uses out-degree, via the general `eigvals` for the spectrum) and weighted/multigraphs (edge weights summed), consistent with the sibling functions.

## Testing
- New unit tests in `linalg/tests/test_graphmatrix.py` (exact values, symmetry, `N = I - \mathcal{L}`, eigenvalue range, `nodelist` permutation, isolated nodes, weighting, directed) and `test_spectrum.py`.
- `pytest networkx/linalg/` → **124 passed**; doctests pass; `ruff format`/`ruff check` clean.
