### PR TITLE
ENH(link_analysis): warn when pagerank convergence threshold is vacuous (N * tol >= 2)

### DIFF
--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -1,6 +1,7 @@
 """PageRank analysis of graph structure."""
 
 import networkx as nx
+import warnings
 
 __all__ = ["pagerank", "google_matrix"]
 
@@ -130,6 +131,18 @@ def _pagerank_python(
     # Create a copy in (right) stochastic form
     W = nx.stochastic_graph(D, weight=weight)
     N = W.number_of_nodes()
+    if N * tol >= 2.0:
+        warnings.warn(
+            f"pagerank convergence threshold N * tol = {N * tol:.2g} >= 2 "
+            f"(the maximum possible L1 distance between probability vectors). "
+            f"The convergence check is vacuous in this regime; the function "
+            f"will always return after the first power iteration regardless of "
+            f"actual convergence. Pass tol < 2 / N for a meaningful check "
+            f"(with N={N}, that means tol < {2 / N:.2g}).",
+        RuntimeWarning,
+        stacklevel=2,
+        )
+
 
     # Choose fixed starting vector if not given
     if nstart is None:
@@ -455,6 +468,18 @@ def _pagerank_scipy(
     N = len(G)
     if N == 0:
         return {}
+
+    if N * tol >= 2.0:
+        warnings.warn(
+            f"pagerank convergence threshold N * tol = {N * tol:.2g} >= 2 "
+            f"(the maximum possible L1 distance between probability vectors). "
+            f"The convergence check is vacuous in this regime; the function "
+            f"will always return after the first power iteration regardless of "
+            f"actual convergence. Pass tol < 2 / N for a meaningful check "
+            f"(with N={N}, that means tol < {2 / N:.2g}).",
+        RuntimeWarning,
+        stacklevel=2,
+        )
 
     nodelist = list(G)
     A = nx.to_scipy_sparse_array(G, nodelist=nodelist, weight=weight, dtype=float)


### PR DESCRIPTION
## Summary

Closes #8651.

Adds a `RuntimeWarning` in both `_pagerank_python` and `_pagerank_scipy` for the regime where `N * tol >= 2`. In this regime the convergence check (`err < N * tol`) is provably vacuous — the L1 distance between any two probability vectors is bounded by 2, so the condition is always `True` and the algorithm terminates after the first power iteration regardless of actual convergence.

## Math

Both implementations converge when:
```
err = sum(|x[n] - xlast[n]|)  # L1 distance
err < N * tol
```
Since `x` and `xlast` are probability vectors (non-negative, sum to 1), their L1 distance is bounded by 2. So `N * tol >= 2` makes the threshold permanently satisfied from iteration 1.

With the default `tol=1e-6`, this kicks in at `N >= 2_000_000` — a real threshold for modern PageRank workloads on web-crawl/social/citation graphs.

## Changes

- `networkx/algorithms/link_analysis/pagerank_alg.py`: add `import warnings` at module level; add the vacuous-threshold check in both `_pagerank_python` and `_pagerank_scipy` before the power-iteration loop.

## Example

```python
import networkx as nx
import warnings

G = nx.DiGraph()
G.add_nodes_from(range(1000))
G.add_edge(0, 1)

with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter("always")
    nx.pagerank(G, tol=3e-3)  # N*tol = 3.0 >= 2
    assert len(w) == 1
    assert issubclass(w[0].category, RuntimeWarning)
    assert "vacuous" in str(w[0].message).lower()
```

Follows the approach proposed in #8651 and approved by @dschult.