### PR TITLE
Raise NetworkXError on truncated graph6/sparse6 data

### DIFF
--- a/networkx/readwrite/graph6.py
+++ b/networkx/readwrite/graph6.py
@@ -388,10 +388,22 @@ def data_to_n(data):
     integer sequence.
 
     Return (value, rest of seq.)"""
+    if len(data) == 0:
+        raise nx.NetworkXError(
+            "failed to parse graph6 or sparse6 data: empty byte sequence"
+        )
     if data[0] <= 62:
         return data[0], data[1:]
+    if len(data) < 4:
+        raise nx.NetworkXError(
+            "failed to parse graph6 or sparse6 data: truncated byte sequence"
+        )
     if data[1] <= 62:
         return (data[1] << 12) + (data[2] << 6) + data[3], data[4:]
+    if len(data) < 8:
+        raise nx.NetworkXError(
+            "failed to parse graph6 or sparse6 data: truncated byte sequence"
+        )
     return (
         (data[2] << 30)
         + (data[3] << 24)

--- a/networkx/readwrite/tests/test_graph6.py
+++ b/networkx/readwrite/tests/test_graph6.py
@@ -51,6 +51,13 @@ class TestFromGraph6Bytes:
         with pytest.raises(ValueError):
             nx.from_graph6_bytes(b"C.")
 
+    def test_from_graph6_bytes_rejects_truncated(self):
+        # empty or truncated data must raise NetworkXError rather than an
+        # IndexError, matching the documented behavior for unparseable input
+        for data in [b"", b"~", b"~~"]:
+            with pytest.raises(nx.NetworkXError):
+                nx.from_graph6_bytes(data)
+
 
 class TestReadGraph6:
     def test_read_many_graph6(self):


### PR DESCRIPTION
## Summary

`nx.from_graph6_bytes` is documented to raise `NetworkXError` when its input cannot be parsed as graph6, but empty or truncated input raises an undocumented `IndexError` instead:

```python
>>> nx.from_graph6_bytes(b"")
IndexError: list index out of range
>>> nx.from_graph6_bytes(b"~")
IndexError: list index out of range
```

`nx.read_graph6` is affected the same way, since it parses each line of a file through `from_graph6_bytes`, so a truncated or corrupt `.g6` file raises `IndexError` rather than the documented error. The sparse6 readers share the same helper and have the same issue.

## Cause

`data_to_n` reads `data[0]` through `data[7]` depending on the encoding width without checking the sequence length first, and `from_graph6_bytes` validates each byte's value range but not the overall length.

## Fix

Add length guards to the shared `data_to_n` helper so empty or truncated input raises `NetworkXError`. Valid input is unchanged.

## Tests

Added `test_from_graph6_bytes_rejects_truncated`; the graph6 and sparse6 test suites pass.
