### PR TITLE
Pydot: handle nodes that are keywords

### DIFF
--- a/networkx/drawing/nx_pydot.py
+++ b/networkx/drawing/nx_pydot.py
@@ -227,7 +227,7 @@ def to_pydot(N):
 
     for n, nodedata in N.nodes(data=True):
         str_nodedata = {str(k): str(v) for k, v in nodedata.items()}
-        n = str(n)
+        n = pydot.quote_id_if_necessary(str(n))
         p = pydot.Node(n, **str_nodedata)
         P.add_node(p)
 

--- a/networkx/drawing/tests/test_pydot.py
+++ b/networkx/drawing/tests/test_pydot.py
@@ -156,3 +156,23 @@ def test_pydot_numerical_name():
     assert 1 in graph_layout
     assert "A" in graph_layout
     assert "B" in graph_layout
+
+
+def test_pydot_reserved_node_name():
+    # https://github.com/pydot/pydot/issues/553
+    G = nx.Graph()
+    G.add_edge("NODE", "EDGE")
+
+    with StringIO() as f:
+        nx.drawing.nx_pydot.write_dot(G, f)
+        contents = f.getvalue()
+
+    assert (
+        contents
+        == """strict graph {
+"NODE";
+"EDGE";
+"NODE" -- "EDGE";
+}
+"""
+    )


### PR DESCRIPTION
Related issue: https://github.com/pydot/pydot/issues/553

While using `write_dot` on a graph that uses dot keywords (such as `EDGE` and `NODE`) as node names, invalid dot graphs can be generated such as

```
digraph my_graph {
NODE;
EDGE;
"NODE" -> "EDGE";
}
```

After discussing with the pydot maintainer, it seems the fix is on `networkx`' side. This PR uses the `quote_id_if_necessary` to handle those cases.

The same case does not apply to edges, only node; for edges, pydot already correctly quotes things there, but in the case of nodes, a `NODE` entry (case insensitive) is assumed to define the default layout of all nodes. If however that `NODE` (or `EDGE`) does not define any properties, it will result in a bare `NODE;` in the output which is syntactically invalid.