### PR TITLE
Fix incorrect parameter names in docstrings

### DIFF
--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -724,7 +724,7 @@ def held_karp_ascent(G, weight="weight"):
 
         Parameters
         ----------
-        k_xy : set
+        k : set
             The set of 1-arborescences which have the minimum rate of increase
             in the direction of ascent
 

--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -226,9 +226,6 @@ def mixing_dict(xy, normalized=False):
     xy : list or container of two-tuples
        Pairs of (x,y) items.
 
-    attribute : string
-       Node attribute key
-
     normalized : bool (default=False)
        Return counts if False or probabilities if True.
 

--- a/networkx/algorithms/summarization.py
+++ b/networkx/algorithms/summarization.py
@@ -371,9 +371,6 @@ def _snap_split(groups, neighbor_info, group_lookup, group_id):
     neighbor_info: dict
         A data structure indicating the number of edges a node has with the
         groups in the current summarization of each edge type
-    edge_types: dict
-        dictionary of edges in the graph and their corresponding attributes recognized
-        in the summarization
     group_lookup: dict
         dictionary of nodes and their current corresponding group ID
     group_id: object


### PR DESCRIPTION
Several docstrings documented parameter names that don't match the actual function signatures. This corrects them so the documented parameters line up with the code.

- `mixing_dict` (`assortativity/mixing.py`): removed the phantom `attribute` parameter, which isn't in the signature `mixing_dict(xy, normalized=False)`.
- `_snap_split` (`summarization.py`): removed the phantom `edge_types` parameter; the signature is `_snap_split(groups, neighbor_info, group_lookup, group_id)` (`edge_types` is only a local loop variable).
- `find_epsilon` (helper in `approximation/traveling_salesman.py`): renamed the documented `k_xy` to the actual parameter `k`.

Documentation-only change; no behavior change.