### PR TITLE
Fix UnboundLocalError in threshold.triangle_sequence for leading-"i" creation sequences

### DIFF
--- a/networkx/algorithms/tests/test_threshold.py
+++ b/networkx/algorithms/tests/test_threshold.py
@@ -242,6 +242,23 @@ class TestGeneratorThreshold:
         assert nxt.eigenvalues("dddiii") == [0, 0, 0, 0, 3, 3]
         assert nxt.eigenvalues("dddiiid") == [0, 1, 1, 1, 4, 4, 7]
 
+    def test_triangle_cluster_sequence_leading_isolated(self):
+        # Regression: triangle_sequence()/cluster_sequence() referenced
+        # `prevsym` before assignment and raised UnboundLocalError when the
+        # creation sequence began with an isolated ("i") node, even though
+        # threshold_graph() builds a valid graph from such a sequence and the
+        # sibling routines (triangles, degree_sequence, ...) handle it fine.
+        for cs in ["idd", "iidd", "iddid", "iiddid"]:
+            G = nxt.threshold_graph(cs)
+
+            ts = nxt.triangle_sequence(cs)
+            assert ts == list(nx.triangles(G).values())
+            assert sum(ts) // 3 == nxt.triangles(cs)
+
+            c1 = nxt.cluster_sequence(cs)
+            c2 = list(nx.clustering(G).values())
+            assert sum(abs(c - d) for c, d in zip(c1, c2)) == pytest.approx(0, abs=1e-7)
+
     def test_tg_creation_routines(self):
         s = nxt.left_d_threshold_sequence(5, 7)
         s = nxt.right_d_threshold_sequence(5, 7)

--- a/networkx/algorithms/threshold.py
+++ b/networkx/algorithms/threshold.py
@@ -468,6 +468,7 @@ def triangle_sequence(creation_sequence):
     dcur = (dr - 1) * (dr - 2) // 2  # number of triangles through a node of clique dr
     irun = 0  # number of i's in the last run
     drun = 0  # number of d's in the last run
+    prevsym = "i"  # no preceding d-run to flush before the first symbol
     for i, sym in enumerate(cs):
         if sym == "d":
             drun += 1


### PR DESCRIPTION
## Summary

`networkx.algorithms.threshold.triangle_sequence()` raises
`UnboundLocalError` whenever the creation sequence begins with an isolated
node (`"i"`). `cluster_sequence()` is affected too, since it delegates to
`triangle_sequence()`.

```python
>>> import networkx.algorithms.threshold as nxt
>>> nxt.triangle_sequence(["i", "d", "d"])
UnboundLocalError: cannot access local variable 'prevsym' where it is not associated with a value
>>> nxt.cluster_sequence(["i", "d", "d"])
UnboundLocalError: cannot access local variable 'prevsym' where it is not associated with a value
```

## Root cause

The loop reads `prevsym` in its body but only assigns it at the *end* of
each iteration:

```python
for i, sym in enumerate(cs):
    if sym == "d":
        ...
    else:  # cs[i]="i":
        if prevsym == "d":      # <-- read on the first iteration
            ...
    ...
    prevsym = sym               # <-- only assigned here
```

On the first iteration `prevsym` has never been assigned, so an `"i"`-first
sequence hits the `else` branch and the bare read raises.

This is a genuine inconsistency, not merely "garbage in": `threshold_graph()`
builds a perfectly valid graph from an `"i"`-first sequence, and every sibling
routine already handles it —

```python
>>> cs = ["i", "d", "d", "i", "d"]
>>> nxt.triangles(cs)            # 4.0
>>> nxt.degree_sequence(cs)      # [3, 3, 3, 1, 4]
>>> nxt.density(cs)              # 0.7
>>> nxt.degree_correlation(cs)   # -0.555...
>>> nxt.triangle_sequence(cs)    # UnboundLocalError   <-- only these two
>>> nxt.cluster_sequence(cs)     # UnboundLocalError
```

## Fix

The `if prevsym == "d"` branch exists to flush the state accumulated across a
run of `"d"`s the first time an `"i"` follows them. Before the first symbol
there is no preceding d-run to flush, so the correct initial value is
`prevsym = "i"` (one line):

```python
    irun = 0  # number of i's in the last run
    drun = 0  # number of d's in the last run
    prevsym = "i"  # no preceding d-run to flush before the first symbol
    for i, sym in enumerate(cs):
```

## Correctness (not just "doesn't crash")

With the fix, `triangle_sequence()` / `cluster_sequence()` output matches
NetworkX's own independent computation on the graph `threshold_graph()`
builds from the same sequence:

| creation seq | `triangle_sequence` | `nx.triangles(threshold_graph(cs))` |
| --- | --- | --- |
| `idd` | `[1, 1, 1]` | `[1, 1, 1]` |
| `iidd` | `[1, 1, 2, 2]` | `[1, 1, 2, 2]` |
| `iddid` | `[3, 3, 3, 0, 3]` | `[3, 3, 3, 0, 3]` |
| `iiddid` | `[3, 3, 5, 5, 0, 5]` | `[3, 3, 5, 5, 0, 5]` |

Output for `"d"`-first sequences is byte-identical to before (the existing
`test_fast_versions_properties_threshold_graphs` still passes unchanged).

## Test

Adds `test_triangle_cluster_sequence_leading_isolated`, mirroring the style of
the existing `test_fast_versions_properties_threshold_graphs` (validate
against `nx.triangles` / `nx.clustering`). Proven to guard the bug:

- Stash the one-line source fix, keep the test -> **FAILS** with
  `UnboundLocalError: ... 'prevsym' ...` at `threshold.py:476`.
- Restore the fix -> **PASSES**.

Full module: `19 passed, 1 skipped` (was `18 passed, 1 skipped`).
`ruff check` and `ruff format --check` clean on both changed files. Diff is
`+18 / -0` (1 source line, 17 test lines).
