### PR TITLE
Fix k_components losing or truncating k-components

### DIFF
--- a/networkx/algorithms/approximation/tests/test_kcomponents.py
+++ b/networkx/algorithms/approximation/tests/test_kcomponents.py
@@ -146,6 +146,45 @@ def test_karate_0():
     _check_connectivity(G)
 
 
+def test_two_icosahedra_with_connector_nodes():
+    # Regression test mirroring the exact algorithm's test for the
+    # _generate_partition bug: two icosahedra (5-connected) joined through
+    # three connector nodes, plus a fourth node that makes the graph
+    # 4-connected. The approximation uses a different procedure and was
+    # never affected, but it recovers the exact solution on this graph and
+    # should keep doing so.
+    A = nx.icosahedral_graph()
+    B = nx.relabel_nodes(nx.icosahedral_graph(), {i: i + 12 for i in range(12)})
+    G = nx.union(A, B)
+    G.add_edges_from([(24, 0), (24, 1), (24, 2), (24, 12), (24, 13)])
+    G.add_edges_from([(25, 3), (25, 4), (25, 5), (25, 14), (25, 15)])
+    G.add_edges_from([(26, 6), (26, 7), (26, 8), (26, 16), (26, 17)])
+    G.add_edges_from([(27, 9), (27, 10), (27, 20), (27, 21)])
+    result = k_components(G)
+    assert sorted(sorted(c) for c in result[5]) == [
+        sorted(range(12)),
+        sorted(range(12, 24)),
+    ]
+    # The whole graph is 4-connected, so it is the single k-component at
+    # every level from 1 to 4.
+    for k in range(1, 5):
+        assert sorted(sorted(c) for c in result[k]) == [sorted(range(28))]
+
+
+def test_highly_connected_gnp_graph():
+    # Regression test mirroring the exact algorithm's test for the
+    # _reconstruct_k_components bug: a 7-connected graph in which the whole
+    # graph is the only k-component at every level up to 7. The
+    # approximation reconstructs each level independently and was never
+    # affected, but it recovers the exact solution on this graph and should
+    # keep doing so.
+    G = nx.gnp_random_graph(16, 0.6, seed=22070)
+    nodes = sorted(G)
+    result = k_components(G)
+    for k in range(1, 8):
+        assert sorted(sorted(c) for c in result[k]) == [nodes]
+
+
 def test_karate_1():
     karate_k_num = {
         0: 4,

--- a/networkx/algorithms/connectivity/kcomponents.py
+++ b/networkx/algorithms/connectivity/kcomponents.py
@@ -179,18 +179,60 @@ def _consolidate(sets, k):
 
 
 def _generate_partition(G, cuts, k):
-    def has_nbrs_in_partition(G, node, partition):
-        return any(n in partition for n in G[node])
+    """Generate parts of G induced by its minimum-size node cutsets.
 
-    components = []
-    n_in_cuts = {n for cut in cuts for n in cut}
-    nodes = {n for n, d in G.degree() if d > k} - n_in_cuts
-    H = G.subgraph(nodes)
-    for cc in map(set, nx.connected_components(H)):
-        component = cc | {n for n in n_in_cuts if has_nbrs_in_partition(G, n, cc)}
-        if len(component) < G.order():
-            components.append(component)
-    yield from _consolidate(components, k + 1)
+    Following Moody and White (appendix A, step 3), cutsets are applied
+    one at a time: removing a cutset splits the current set of nodes into
+    two or more connected components, and each component plus the cutset
+    that induced it becomes a new candidate part. Every j-component of
+    ``G`` with ``j > k`` is preserved intact in at least one generated
+    part, because removing ``k < j`` nodes cannot disconnect it.
+
+    Applying cutsets one at a time is necessary for correctness: removing
+    the union of all cutsets in a single pass can drop cutset nodes whose
+    neighbors all belong to other cutsets, silently losing k-components.
+    """
+    order = G.order()
+    cuts = [set(cut) for cut in cuts]
+    parts = []
+    seen = set()
+    stack = [set(G)]
+    while stack:
+        nodes = stack.pop()
+        for cut in cuts:
+            if not cut < nodes:
+                continue
+            components = list(nx.connected_components(G.subgraph(nodes - cut)))
+            if len(components) > 1:
+                for component in components:
+                    # Nodes of the cutset belong to both sides of the induced
+                    # cut, but only if they have a neighbor in the component:
+                    # a cutset node from a j-component (j > k) always has at
+                    # least two neighbors in the component, while attaching a
+                    # neighborless cutset node would disconnect the part.
+                    child = frozenset(
+                        component
+                        | {n for n in cut if any(v in component for v in G[n])}
+                    )
+                    if child not in seen:
+                        seen.add(child)
+                        stack.append(set(child))
+                break
+        else:
+            # No cutset splits this part any further.
+            if len(nodes) < order:
+                parts.append(nodes)
+    # Merging parts that share at least k+1 nodes reduces the number of
+    # subproblems that the loop in k_components examines. This is a
+    # performance heuristic, not needed for correctness: no j-component
+    # with j > k can span two parts. If merging rebuilds the whole graph,
+    # fall back to the raw parts so the caller always recurses on
+    # strictly smaller graphs.
+    consolidated = list(_consolidate(parts, k + 1))
+    if any(len(part) == order for part in consolidated):
+        yield from parts
+    else:
+        yield from consolidated
 
 
 def _reconstruct_k_components(k_comps):
@@ -202,8 +244,15 @@ def _reconstruct_k_components(k_comps):
         elif k not in k_comps:
             result[k] = list(_consolidate(result[k + 1], k))
         else:
-            nodes_at_k = set.union(*k_comps[k])
-            to_add = [c for c in result[k + 1] if any(n not in nodes_at_k for n in c)]
+            # Propagate a component from level k+1 down to level k unless it
+            # is already contained in a single component recorded at level k.
+            # Checking against the union of all components recorded at k is
+            # not enough: a (k+1)-level component can span several k-level
+            # candidates without being a subset of any of them, and skipping
+            # it would replace a genuine k-component by its fragments.
+            to_add = [
+                c for c in result[k + 1] if not any(c <= comp for comp in k_comps[k])
+            ]
             if to_add:
                 result[k] = list(_consolidate(k_comps[k] + to_add, k))
             else:

--- a/networkx/algorithms/connectivity/tests/test_kcomponents.py
+++ b/networkx/algorithms/connectivity/tests/test_kcomponents.py
@@ -127,6 +127,47 @@ def test_torrents_and_ferraro_graph():
     assert all(len(c) == 5 for c in result[4])
 
 
+def test_generate_partition_does_not_drop_cutset_nodes():
+    # Two icosahedra (5-connected) joined through three connector nodes,
+    # plus a fourth node that makes the graph 4-connected. The minimum
+    # 3-cutsets of the icosahedron-plus-connectors subproblem are the three
+    # connector neighborhoods, and some of their nodes have all their
+    # neighbors inside other cutsets. _generate_partition used to remove the
+    # union of all cutsets in a single pass, dropping those nodes and losing
+    # one of the two 5-components.
+    A = nx.icosahedral_graph()
+    B = nx.relabel_nodes(nx.icosahedral_graph(), {i: i + 12 for i in range(12)})
+    G = nx.union(A, B)
+    G.add_edges_from([(24, 0), (24, 1), (24, 2), (24, 12), (24, 13)])
+    G.add_edges_from([(25, 3), (25, 4), (25, 5), (25, 14), (25, 15)])
+    G.add_edges_from([(26, 6), (26, 7), (26, 8), (26, 16), (26, 17)])
+    G.add_edges_from([(27, 9), (27, 10), (27, 20), (27, 21)])
+    assert nx.node_connectivity(G) == 4
+    result = nx.k_components(G)
+    assert sorted(sorted(c) for c in result[5]) == [
+        sorted(range(12)),
+        sorted(range(12, 24)),
+    ]
+    # The whole graph is 4-connected, so it is the single k-component at
+    # every level from 1 to 4.
+    for k in range(1, 5):
+        assert sorted(sorted(c) for c in result[k]) == [sorted(range(28))]
+
+
+def test_reconstruction_does_not_replace_component_by_fragments():
+    # A 7-connected graph: the whole graph is the only k-component at every
+    # level up to 7. The recursive cuts record lower-connectivity fragments
+    # whose union happens to cover all nodes; _reconstruct_k_components used
+    # to skip propagating the whole-graph component down to those levels,
+    # replacing a genuine k-component by its fragments.
+    G = nx.gnp_random_graph(16, 0.6, seed=22070)
+    assert nx.node_connectivity(G) == 7
+    nodes = sorted(G)
+    result = nx.k_components(G)
+    for k in range(1, 8):
+        assert sorted(sorted(c) for c in result[k]) == [nodes]
+
+
 @pytest.mark.parametrize(
     ("n", "p"), [(10, 0.6), pytest.param(50, 0.2, marks=pytest.mark.slow)]
 )


### PR DESCRIPTION
`nx.k_components` can return wrong results: it can miss a k-component entirely, report a strict subset of one, or replace a genuine k-component by lower-connectivity fragments. Differential fuzzing against the fixed implementation hits a divergence in roughly 1 in 60 random G(n, p) graphs (n = 12-20, p = 0.2-0.6), so this is not a corner case. Two independent root causes, both fixed here. The approximation in `networkx/algorithms/approximation/kcomponents.py` shares no code with these helpers and computes each level independently; it is not affected (verified on both regression graphs).

## Bug 1: `_generate_partition` drops cutset nodes

When partitioning a graph by its minimum node cutsets, the helper removed the **union of all cutsets** in a single pass and re-attached each cutset node only to the resulting components it has a direct neighbor in. A cutset node whose neighbors all belong to *other* cutsets is attached to nothing and silently vanishes, so the recursion never examines the intact subgraph and the k-component containing that node is lost or truncated.

Reproducer (first regression test): two icosahedra A and B (5-connected, so each is a 5-component) joined through three connector nodes, plus one node that makes the whole graph 4-connected. In the recursion, the subproblem `A + connectors` has minimum 3-cutsets `{0, 1, 2}`, `{3, 4, 5}` and `{6, 7, 8}` (the connector neighborhoods). Removing all nine nodes at once leaves cutset nodes 1 and 6 with no surviving neighbors: the "partition" is a single 10-node part and A is never seen intact. Result: `k_components` reports only one of the two 5-components.

The fix applies cutsets **one at a time**, which is what Moody and White describe (appendix A, step 3): removing a single cutset splits the current part into connected components; each component plus its adjacent cutset nodes becomes a new part; remaining cutsets are applied recursively inside each part (iteratively, with an explicit stack). This is correct by Menger's theorem: a j-component with j > k cannot be disconnected by removing k < j nodes, so it survives intact inside one part at every step. 

## Bug 2: `_reconstruct_k_components` lets fragments replace a component

The recursive-cut loop records candidate components whenever connectivity rises above the parent level, which admits non-maximal fragments of a higher-k component. `_reconstruct_k_components` is supposed to clean this up when propagating components down the levels, but its filter

```python
nodes_at_k = set.union(*k_comps[k])
to_add = [c for c in result[k + 1] if any(n not in nodes_at_k for n in c)]
```

skips a component from level k+1 whenever the *union* of the level-k candidates covers its nodes, even when no single candidate contains it.

Reproducer (second regression test): a 7-connected G(16, 0.6) graph whose whole node set is the unique k-component for every k <= 7. The recursion records 5-connected fragments whose union covers all 16 nodes, and the whole-graph component silently disappears from level 5 downward, replaced by its fragments. The fix tests containment in a single component: `not any(c <= comp for comp in k_comps[k])`.

On current main this second bug is masked by the first one: the dropped nodes keep fragment unions from covering everything, which is why both fixes land together.

## Tests

Two regression tests are added to the connectivity test suite, one per root cause. The same two graphs are also added as tests to the approximation test suite (`networkx/algorithms/approximation/tests/test_kcomponents.py`): the approximation shares no code with the fixed helpers and is not affected by either bug, and it recovers the exact results on both graphs -- these tests pin that behavior down.

## Performance note

Correctness costs some speed on mid-size inputs, because the old code's dropped nodes and degree-filtered parts made subproblems artificially small: `powerlaw_cluster_graph(500, 5, 0.3)` goes from 15.6s to 28.1s and n=1000 from 74s to 171s on the same machine. The test-suite fixtures show no slowdown. Reintroducing degree-based part shrinking with a connectivity-safe re-attachment is possible follow-up work.

**AI disclaimer**: Once I detected the problem, Claude helped a lot by writing and running the fuzzing that pin pointed the exact cause of the problem. Also it designed the two icosahedra example in the tests and provided a draft of the implementation. I reviewed carefully, did some corrections, and validated all the examples, code and tests.