### PR TITLE
Warn when PageRank convergence check is ineffective

### DIFF
--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -1,4 +1,5 @@
 """PageRank analysis of graph structure."""
+import warnings
 
 import networkx as nx
 
@@ -153,6 +154,15 @@ def _pagerank_python(
         s = sum(dangling.values())
         dangling_weights = {k: v / s for k, v in dangling.items()}
     dangling_nodes = [n for n in W if W.out_degree(n, weight=weight) == 0.0]
+
+    if N * tol >= 2:
+        warnings.warn(
+            "PageRank convergence check is ineffective when "
+            f"len(G) * tol >= 2 (here {N} * {tol} = {N * tol}); "
+            f"use tol < 2 / {N} to ensure meaningful convergence.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
     # power iteration: make up to max_iter iterations
     for _ in range(max_iter):
@@ -486,6 +496,15 @@ def _pagerank_scipy(
         # Convert the dangling dictionary into an array in nodelist order
         dangling_weights = np.array([dangling.get(n, 0) for n in nodelist], dtype=float)
         dangling_weights /= dangling_weights.sum()
+
+    if N * tol >= 2:
+        warnings.warn(
+            "PageRank convergence check is ineffective when "
+            f"len(G) * tol >= 2 (here {N} * {tol} = {N * tol}); "
+            f"use tol < 2 / {N} to ensure meaningful convergence.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
     # power iteration: make up to max_iter iterations
     for _ in range(max_iter):

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -45,6 +45,12 @@ def pagerank(
       Error tolerance used to check convergence in power method solver.
       The iteration will stop after a tolerance of ``len(G) * tol`` is reached.
 
+      .. note::
+
+         For large graphs, choose the tolerance carefully. If ``len(G) * tol >= 2``,
+         the power iteration may appear to converge after a single step regardless
+         of the actual accuracy.
+
     nstart : dictionary, optional
       Starting value of PageRank iteration for each node.
 
@@ -79,15 +85,6 @@ def pagerank(
     number of iterations exceed `max_iter`, a
     :exc:`~networkx.exception.PowerIterationFailedConvergence` exception
     is raised.
-
-    .. note::
-
-       For large graphs, choose the tolerance carefully. If
-       ``len(G) * tol >= 2``, the convergence check can become
-       trivially satisfied because the L1 difference between two
-       probability distributions is at most 2. In that case, the
-       power iteration may appear to converge after a single step
-       regardless of the actual accuracy.
 
     The PageRank algorithm was designed for directed graphs but this
     algorithm does not check if the input graph is directed and will

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -1,7 +1,5 @@
 """PageRank analysis of graph structure."""
 
-import warnings
-
 import networkx as nx
 
 __all__ = ["pagerank", "google_matrix"]
@@ -82,6 +80,15 @@ def pagerank(
     :exc:`~networkx.exception.PowerIterationFailedConvergence` exception
     is raised.
 
+    .. note::
+
+       For large graphs, choose the tolerance carefully. If
+       ``len(G) * tol >= 2``, the convergence check can become
+       trivially satisfied because the L1 difference between two
+       probability distributions is at most 2. In that case, the
+       power iteration may appear to converge after a single step
+       regardless of the actual accuracy.
+
     The PageRank algorithm was designed for directed graphs but this
     algorithm does not check if the input graph is directed and will
     execute on undirected graphs by converting each edge in the
@@ -155,15 +162,6 @@ def _pagerank_python(
         s = sum(dangling.values())
         dangling_weights = {k: v / s for k, v in dangling.items()}
     dangling_nodes = [n for n in W if W.out_degree(n, weight=weight) == 0.0]
-
-    if N * tol >= 2:
-        warnings.warn(
-            "PageRank convergence check is ineffective when "
-            f"len(G) * tol >= 2 (here {N} * {tol} = {N * tol}); "
-            f"use tol < 2 / {N} to ensure meaningful convergence.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
 
     # power iteration: make up to max_iter iterations
     for _ in range(max_iter):
@@ -497,15 +495,6 @@ def _pagerank_scipy(
         # Convert the dangling dictionary into an array in nodelist order
         dangling_weights = np.array([dangling.get(n, 0) for n in nodelist], dtype=float)
         dangling_weights /= dangling_weights.sum()
-
-    if N * tol >= 2:
-        warnings.warn(
-            "PageRank convergence check is ineffective when "
-            f"len(G) * tol >= 2 (here {N} * {tol} = {N * tol}); "
-            f"use tol < 2 / {N} to ensure meaningful convergence.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
 
     # power iteration: make up to max_iter iterations
     for _ in range(max_iter):

--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -1,4 +1,5 @@
 """PageRank analysis of graph structure."""
+
 import warnings
 
 import networkx as nx

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -231,13 +231,12 @@ def test_pagerank_scipy_warns_ineffective_tolerance():
 
 def test_pagerank_no_warn_effective_tolerance():
     """pagerank with N*tol<2 should not warn."""
+    import warnings
+
     G = nx.path_graph(3, create_using=nx.DiGraph)
     tol = 1e-6  # 3 * 1e-6 << 2
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
         _pagerank_python(G, tol=tol, max_iter=200)
-    runtime_warnings = [
-        w for w in record if issubclass(w.category, RuntimeWarning)
-    ]
-    assert not any(
-        "ineffective" in str(w.message) for w in runtime_warnings
-    )
+    runtime_warnings = [w for w in record if issubclass(w.category, RuntimeWarning)]
+    assert not any("ineffective" in str(w.message) for w in runtime_warnings)

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -211,32 +211,3 @@ class TestPageRankScipy(TestPageRank):
     def test_empty_scipy(self):
         G = nx.Graph()
         assert _pagerank_scipy(G) == {}
-
-
-def test_pagerank_python_warns_ineffective_tolerance():
-    """pagerank with N*tol>=2 should warn about ineffective convergence."""
-    G = nx.path_graph(3, create_using=nx.DiGraph)
-    tol = 1.0  # 3 * 1.0 = 3 >= 2
-    with pytest.warns(RuntimeWarning, match="ineffective"):
-        _pagerank_python(G, tol=tol, max_iter=5)
-
-
-def test_pagerank_scipy_warns_ineffective_tolerance():
-    """_pagerank_scipy with N*tol>=2 warns; lower tolerance does not."""
-    G = nx.path_graph(3, create_using=nx.DiGraph)
-    tol = 1.0
-    with pytest.warns(RuntimeWarning, match="ineffective"):
-        _pagerank_scipy(G, tol=tol, max_iter=5)
-
-
-def test_pagerank_no_warn_effective_tolerance():
-    """pagerank with N*tol<2 should not warn."""
-    import warnings
-
-    G = nx.path_graph(3, create_using=nx.DiGraph)
-    tol = 1e-6  # 3 * 1e-6 << 2
-    with warnings.catch_warnings(record=True) as record:
-        warnings.simplefilter("always")
-        _pagerank_python(G, tol=tol, max_iter=200)
-    runtime_warnings = [w for w in record if issubclass(w.category, RuntimeWarning)]
-    assert not any("ineffective" in str(w.message) for w in runtime_warnings)

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -211,3 +211,33 @@ class TestPageRankScipy(TestPageRank):
     def test_empty_scipy(self):
         G = nx.Graph()
         assert _pagerank_scipy(G) == {}
+
+
+def test_pagerank_python_warns_ineffective_tolerance():
+    """pagerank with N*tol>=2 should warn about ineffective convergence."""
+    G = nx.path_graph(3, create_using=nx.DiGraph)
+    tol = 1.0  # 3 * 1.0 = 3 >= 2
+    with pytest.warns(RuntimeWarning, match="ineffective"):
+        _pagerank_python(G, tol=tol, max_iter=5)
+
+
+def test_pagerank_scipy_warns_ineffective_tolerance():
+    """_pagerank_scipy with N*tol>=2 warns; lower tolerance does not."""
+    G = nx.path_graph(3, create_using=nx.DiGraph)
+    tol = 1.0
+    with pytest.warns(RuntimeWarning, match="ineffective"):
+        _pagerank_scipy(G, tol=tol, max_iter=5)
+
+
+def test_pagerank_no_warn_effective_tolerance():
+    """pagerank with N*tol<2 should not warn."""
+    G = nx.path_graph(3, create_using=nx.DiGraph)
+    tol = 1e-6  # 3 * 1e-6 << 2
+    with pytest.warns(None) as record:
+        _pagerank_python(G, tol=tol, max_iter=200)
+    runtime_warnings = [
+        w for w in record if issubclass(w.category, RuntimeWarning)
+    ]
+    assert not any(
+        "ineffective" in str(w.message) for w in runtime_warnings
+    )


### PR DESCRIPTION
A small RuntimeWarning for PageRank when `len(G) * tol >= 2`, where the L1 convergence threshold can no longer meaningfully gate iteration.

The change does not alter PageRank results or tolerance semantics; it only surfaces the ineffective-threshold case and adds regression coverage.
