### PR TITLE
warn when pagerank tol makes the convergence check vacuous

### DIFF
--- a/networkx/algorithms/link_analysis/pagerank_alg.py
+++ b/networkx/algorithms/link_analysis/pagerank_alg.py
@@ -1,8 +1,27 @@
 """PageRank analysis of graph structure."""
 
+import warnings
+
 import networkx as nx
 
 __all__ = ["pagerank", "google_matrix"]
+
+
+def _warn_if_tol_vacuous(N, tol):
+    # Both x and xlast are probability vectors, so their L1 distance is at most
+    # 2. That means the convergence check ``err < N * tol`` can never fail once
+    # ``N * tol >= 2``: pagerank then returns after a single iteration without
+    # actually testing convergence. Warn and point at a usable tolerance.
+    if N > 0 and N * tol >= 2:
+        warnings.warn(
+            f"N * tol = {N * tol:g} >= 2 for this graph of {N} nodes, which "
+            "exceeds the largest possible L1 distance (2) between successive "
+            "iterates. The convergence check `err < N * tol` is therefore always "
+            "satisfied and pagerank returns after one iteration without testing "
+            f"convergence. Use a smaller tol (e.g. tol < {2 / N:g}).",
+            RuntimeWarning,
+            stacklevel=3,
+        )
 
 
 @nx._dispatchable(edge_attrs="weight")
@@ -44,6 +63,9 @@ def pagerank(
     tol : float, optional
       Error tolerance used to check convergence in power method solver.
       The iteration will stop after a tolerance of ``len(G) * tol`` is reached.
+      Note that the L1 error between successive iterates is at most 2, so pick
+      ``tol`` small enough that ``len(G) * tol < 2``; otherwise the check is
+      always satisfied and a ``RuntimeWarning`` is raised.
 
     nstart : dictionary, optional
       Starting value of PageRank iteration for each node.
@@ -153,6 +175,8 @@ def _pagerank_python(
         s = sum(dangling.values())
         dangling_weights = {k: v / s for k, v in dangling.items()}
     dangling_nodes = [n for n in W if W.out_degree(n, weight=weight) == 0.0]
+
+    _warn_if_tol_vacuous(N, tol)
 
     # power iteration: make up to max_iter iterations
     for _ in range(max_iter):
@@ -393,6 +417,9 @@ def _pagerank_scipy(
     tol : float, optional
       Error tolerance used to check convergence in power method solver.
       The iteration will stop after a tolerance of ``len(G) * tol`` is reached.
+      Note that the L1 error between successive iterates is at most 2, so pick
+      ``tol`` small enough that ``len(G) * tol < 2``; otherwise the check is
+      always satisfied and a ``RuntimeWarning`` is raised.
 
     nstart : dictionary, optional
       Starting value of PageRank iteration for each node.
@@ -486,6 +513,8 @@ def _pagerank_scipy(
         # Convert the dangling dictionary into an array in nodelist order
         dangling_weights = np.array([dangling.get(n, 0) for n in nodelist], dtype=float)
         dangling_weights /= dangling_weights.sum()
+
+    _warn_if_tol_vacuous(N, tol)
 
     # power iteration: make up to max_iter iterations
     for _ in range(max_iter):

--- a/networkx/algorithms/link_analysis/tests/test_pagerank.py
+++ b/networkx/algorithms/link_analysis/tests/test_pagerank.py
@@ -1,4 +1,5 @@
 import random
+import warnings
 
 import pytest
 
@@ -75,6 +76,21 @@ class TestPageRank:
     def test_pagerank_max_iter(self, alg):
         with pytest.raises(nx.PowerIterationFailedConvergence):
             alg(self.G, max_iter=0)
+
+    @pytest.mark.parametrize("alg", (nx.pagerank, _pagerank_python, _pagerank_scipy))
+    def test_pagerank_vacuous_tol_warns(self, alg):
+        # N * tol >= 2 exceeds the max possible L1 error (2), so the convergence
+        # check can never fail. See gh-8651.
+        G = nx.path_graph(4, create_using=nx.DiGraph)
+        with pytest.warns(RuntimeWarning, match="N . tol"):
+            alg(G, tol=0.6)
+
+    @pytest.mark.parametrize("alg", (nx.pagerank, _pagerank_python, _pagerank_scipy))
+    def test_pagerank_reasonable_tol_no_warn(self, alg):
+        G = nx.path_graph(4, create_using=nx.DiGraph)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            alg(G, tol=1.0e-8)
 
     def test_numpy_pagerank(self):
         G = self.G


### PR DESCRIPTION
follows up on #8651. dschult suggested warning when the tolerance is mathematically forced to stop after the first iteration, this does that.

when N*tol >= 2 the convergence check `err < N*tol` can never fail, because the L1 distance between two probability vectors is at most 2. so pagerank returns after a single iteration without actually testing convergence, and gives no hint that anything is off (with the default tol=1e-6 this hits any graph with N >= 2,000,000).

this adds a RuntimeWarning in both `_pagerank_python` and `_pagerank_scipy` that points at a usable tol, plus a note in the tol docstring.

kept it a warning and not an error so anyone who really wants those values still gets them, and added the docstring note so the guidance is there even when warnings are filtered (re @rossbar's point about warnings getting ignored).

tests: added checks that the warning fires in the vacuous regime and does not fire for a normal tol, across pagerank/_pagerank_python/_pagerank_scipy. the full link_analysis suite passes locally.

disclosure: used an AI assistant to help with this, I reviewed it and am accountable for the change.