### PR TITLE
Optimize _triangles_and_degree_iter by caching neighbor sets

### DIFF
--- a/networkx/algorithms/cluster.py
+++ b/networkx/algorithms/cluster.py
@@ -108,10 +108,14 @@ def _triangles_and_degree_iter(G, nodes=None):
         nodes_nbrs = G.adj.items()
     else:
         nodes_nbrs = ((n, G[n]) for n in G.nbunch_iter(nodes))
-
+    # Precompute each node's neighbor set once, instead of rebuilding
+    # ``set(G[w])`` for every neighbor ``w`` on every iteration. A node's
+    # neighbor set is otherwise reconstructed roughly ``degree`` times over
+    # the full computation; caching it removes that redundant work.
+    neighbor_sets = {n: set(nbrs) - {n} for n, nbrs in G.adj.items()}
     for v, v_nbrs in nodes_nbrs:
-        vs = set(v_nbrs) - {v}
-        gen_degree = Counter(len(vs & (set(G[w]) - {w})) for w in vs)
+        vs = neighbor_sets[v]
+        gen_degree = Counter(len(vs & neighbor_sets[w]) for w in vs)
         ntriangles = sum(k * val for k, val in gen_degree.items())
         yield (v, len(vs), ntriangles, gen_degree)
 


### PR DESCRIPTION
Fixes #8742

What this does
This optimizes the internal helper _triangles_and_degree_iter in networkx/algorithms/cluster.py, which is the main path used by clustering() for undirected, unweighted graphs.

Problem
Profiling nx.clustering() on a 2000-node random graph with cProfile showed almost all time spent inside _triangles_and_degree_iter. The hot line rebuilds set(G[w]) for every neighbor w on every iteration. Since a node appears as a neighbor of each of its own neighbors, its neighbor set was reconstructed roughly degree-many times over the full computation, even though it never changes.

Fix
Precompute each node's neighbor set once into a dictionary before the loop, then reuse it. Same algorithm, same output; only the redundant set construction is removed.

Benchmarks (single-core, best of several runs, identical output verified)
Random sparse 1k: 2.56x, Random sparse 3k: 3.62x, Random dense 1.5k: 3.82x, Scale-free 3k: 3.73x, Small-world 3k: 2.16x, Complete 200: 2.37x. Denser graphs benefit more since neighbor sets are reused more often.

Testing
Existing networkx/algorithms/tests/test_cluster.py passes (56 passed). No public API change; output is identical.

Trade-off
This trades a small amount of memory (all neighbor sets held at once, O(n + m)) for removing repeated set allocation. I also prototyped a multiprocessing variant, but it only helps on large dense graphs and is much slower on small ones due to process overhead, so it is not included here.