### PR TITLE
DOC: fix lattice_reference niter default (5, not 1)

### DIFF
--- a/networkx/algorithms/smallworld.py
+++ b/networkx/algorithms/smallworld.py
@@ -131,7 +131,7 @@ def lattice_reference(G, niter=5, D=None, connectivity=True, seed=None):
     G : graph
         An undirected graph.
 
-    niter : integer (optional, default=1)
+    niter : integer (optional, default=5)
         An edge is rewired approximately niter times.
 
     D : numpy.array (optional, default=None)


### PR DESCRIPTION
The `lattice_reference` docstring documents `niter` as having
`default=1`, but the function signature is `niter=5`:

    def lattice_reference(G, niter=5, D=None, connectivity=True, seed=None):
        ...
        niter : integer (optional, default=1)   # <- wrong

The Parameters block looks copied from the sibling `random_reference`,
which genuinely does default to `niter=1`; the value was never updated
here. This corrects the documented default to 5 to match the actual
behavior. Docs-only, no code/behavior change.

Disclosure: I used an AI tool to help spot this docstring/signature
mismatch. I verified the fix manually — confirmed the signature default
is 5, confirmed the sibling `random_reference` is the niter=1 case the
text was copied from, and reviewed the one-line change.