### PR TITLE
Fix ISMAGS returning no isomorphisms for edgeless subgraph with edge_match

### DIFF
--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -575,6 +575,16 @@ class ISMAGS:
             g_partition = [set(g_things)]
             return sg_partition, g_partition, 1
 
+        # If the subgraph has no things to match (e.g. an edgeless subgraph),
+        # the matcher imposes no constraint, so coloring is vacuous. Mirror the
+        # ``thing_matcher is None`` case above. Otherwise ``make_partition``
+        # below returns an empty subgraph partition (sN == 0), the alignment
+        # loop matches nothing, and the lone empty leftover part is reported as
+        # an unmatched color -- which makes ``find_isomorphisms`` wrongly return
+        # no results when every graph edge should match (see gh-8738).
+        if not sg_things:
+            return [set(sg_things)], [set(g_things)], 1
+
         # Use thing_matcher to create a partition
         # Note: isinstance(G.edges(), OutEdgeDataView) is only true for multi(di)graph
         sg_multiedge = isinstance(sg_things, nx.classes.reportviews.OutEdgeDataView)

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -748,3 +748,26 @@ def test_weightkey(graph_class):
     g2 = graph_class()
     g2.add_edge("C", "D")
     assert nx.is_isomorphic(g1, g2, edge_match=em)
+
+
+@pytest.mark.parametrize("graph_class", graph_classes)
+def test_edgeless_subgraph_edge_match(graph_class):
+    # gh-8738: a non-trivial edge_match on a subgraph with no edges used to
+    # return no isomorphisms, while edge_match=None found them. Since the
+    # subgraph has no edges, edge matching is vacuous and both must agree.
+    graph = graph_class()
+    graph.add_edges_from([(0, 1), (1, 2)])
+    subgraph = graph_class()
+    subgraph.add_node(0)
+
+    def always_true(*args):
+        return True
+
+    without = iso.ISMAGS(graph, subgraph, edge_match=None)
+    with_match = iso.ISMAGS(graph, subgraph, edge_match=always_true)
+
+    expected = sorted(map(str, without.find_isomorphisms()))
+    found = sorted(map(str, with_match.find_isomorphisms()))
+    assert found == expected
+    # every node of the graph is a valid mapping for the single subgraph node
+    assert len(found) == len(graph)


### PR DESCRIPTION
### Summary

When a subgraph has **no edges**, `ISMAGS(..., edge_match=<non-None>)` incorrectly returns **no** isomorphisms, even though the same query with `edge_match=None` finds them. Since an edgeless subgraph cannot impose any edge constraint, an `edge_match` that accepts everything should behave identically to `edge_match=None`.

This addresses the `edge_match` part of #8738 (@dschult's diagnosis: handle the `sN == 0` case explicitly instead of relying on `itertools.product`).

### Reproducer

```python
import networkx as nx
from networkx.algorithms.isomorphism import ISMAGS

g = nx.Graph([(0, 1)])
sg = nx.Graph()
sg.add_node(0)

list(ISMAGS(g, sg, edge_match=None).find_isomorphisms())
# [{0: 0}, {1: 0}]

list(ISMAGS(g, sg, edge_match=lambda *a: True).find_isomorphisms())
# []   <-- bug: fewer results than edge_match=None
```

### Root cause

In `create_aligned_partitions`, a non-`None` matcher on an empty subgraph edge set makes `make_partition` return an empty subgraph partition (`sN == 0`). The alignment loop matches nothing, so the single empty "leftover" part is reported as an *unmatched edge color*. The guard in `find_isomorphisms`:

```python
elif len(self._sge_partition) > self.N_edge_colors:
    return
```

then trips (`1 > 0`) and yields nothing. With `edge_match=None`, the dedicated branch returns `N_edge_colors = 1`, so the guard passes and results are found.

### Fix

Handle the empty-subgraph case explicitly by mirroring the existing `thing_matcher is None` branch — edge coloring is vacuous when the subgraph has no edges.

### Tests

Adds `test_edgeless_subgraph_edge_match`, parametrized over `Graph`, `DiGraph`, `MultiGraph`, and `MultiDiGraph`. It fails on `main` (all four classes) and passes with this change. Full `test_ismags.py` suite passes (95 passed); `ruff check` and `ruff format --check` are clean.

### Notes

This PR intentionally scopes to the `edge_match`/edgeless-subgraph behavior only. The `node_match` default-length (`zip`) footgun and the node-attribute matching case also reported in #8738 are separate and not addressed here.