### PR TITLE
building sphinx-gallery examples in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,13 @@ jobs:
             pip list
 
       - run:
+          name: Show CPU info
+          command: |
+            source venv/bin/activate
+            echo "nproc: $(nproc)"
+            python -c "import os; from joblib import cpu_count; print('os cpu_count:', os.cpu_count()); print('joblib cpu_count:', cpu_count())"
+
+      - run:
           name: Build docs
           command: |
             # NOTE: bad interaction w/ blas multithreading on circleci

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -53,6 +53,7 @@ sphinx_gallery_conf = {
     "matplotlib_animations": True,
     "plot_gallery": "True",
     "reference_url": {"sphinx_gallery": None},
+    "parallel": -1,
 }
 
 rst_epilog = """


### PR DESCRIPTION
<!--
Please use pre-commit to lint your code.
For more details check out step 1 and 4 of
https://networkx.org/documentation/latest/developer/contribute.html
-->
ref. https://sphinx-gallery.github.io/stable/configuration.html#build-examples-in-parallel

Not getting any significant speedups!

From circleci logs:
- CPU info:

```
nproc: 36
os cpu_count: 36
joblib cpu_count: 2
```

- sphinx gallery reports using parallel=-1: `generating gallery (with parallel=-1)...`
- One possible explanation for the lack of significant speedup is that most gallery examples are too short-lived, so the overhead of process creation and job scheduling dominates any gains from parallel speedups.
<details>
<summary>computation time summary: (from the logs)</summary>

```
    - ../examples/3d_drawing/plot_facebook_3d.py:                                   24.80 sec   0.0 MB
    - ../examples/3d_drawing/plot_3d_animation_walk.py:                             15.82 sec   0.0 MB
    - ../examples/3d_drawing/plot_3d_animation_basic.py:                            15.18 sec   0.0 MB
    - ../examples/algorithms/plot_parallel_betweenness.py:                          11.47 sec   0.0 MB
    - ../examples/geospatial/plot_points.py:                                        10.58 sec   0.0 MB
    - ../examples/geospatial/plot_lines.py:                                         10.42 sec   0.0 MB
    - ../examples/geospatial/plot_delaunay.py:                                       9.67 sec   0.0 MB
    - ../examples/algorithms/plot_image_segmentation_spectral_graph_partition.py:    6.11 sec   0.0 MB
    - ../examples/geospatial/plot_osmnx.py:                                          4.27 sec   0.0 MB
    - ../examples/graphviz_layout/plot_atlas.py:                                     3.74 sec   0.0 MB
    - ../examples/geospatial/plot_polygons.py:                                       2.89 sec   0.0 MB
    - ../examples/algorithms/plot_betweenness_centrality.py:                         2.66 sec   0.0 MB
    - ../examples/graphviz_layout/plot_giant_component.py:                           1.06 sec   0.0 MB
    - ../examples/drawing/plot_spring_layout.py:                                     0.96 sec   0.0 MB
    - ../examples/drawing/plot_multigraphs.py:                                       0.87 sec   0.0 MB
    - ../examples/drawing/plot_eigenvalues.py:                                       0.81 sec   0.0 MB
    - ../examples/drawing/plot_chess_masters.py:                                     0.78 sec   0.0 MB
    - ../examples/algorithms/plot_girvan_newman.py:                                  0.74 sec   0.0 MB
    - ../examples/graph/plot_triad_types.py:                                         0.63 sec   0.0 MB
    - ../examples/external/plot_iplotx.py:                                           0.62 sec   0.0 MB
    - ../examples/graph/plot_words.py:                                               0.61 sec   0.0 MB
    - ../examples/external/plot_igraph.py:                                           0.60 sec   0.0 MB
    - ../examples/algorithms/plot_subgraphs.py:                                      0.54 sec   0.0 MB
    - ../examples/external/plot_hiveplotlib.py:                                      0.53 sec   0.0 MB
    - ../examples/graph/plot_visibility_graph.py:                                    0.40 sec   0.0 MB
    - ../examples/algorithms/plot_blockmodel.py:                                     0.40 sec   0.0 MB
    - ../examples/graphviz_layout/plot_lanl_routes.py:                               0.39 sec   0.0 MB
    - ../examples/graph/plot_morse_trie.py:                                          0.35 sec   0.0 MB
    - ../examples/graph/plot_football.py:                                            0.35 sec   0.0 MB
    - ../examples/drawing/plot_tsp.py:                                               0.32 sec   0.0 MB
    - ../examples/graph/plot_roget.py:                                               0.31 sec   0.0 MB
    - ../examples/drawing/plot_degree.py:                                            0.28 sec   0.0 MB
    - ../examples/algorithms/plot_rcm.py:                                            0.25 sec   0.0 MB
    - ../examples/drawing/plot_four_grids.py:                                        0.24 sec   0.0 MB
    - ../examples/algorithms/plot_dedensification.py:                                0.24 sec   0.0 MB
    - ../examples/algorithms/plot_lca.py:                                            0.24 sec   0.0 MB
    - ../examples/basic/plot_basic_directed.py:                                      0.22 sec   0.0 MB
    - ../examples/algorithms/plot_beam_search.py:                                    0.21 sec   0.0 MB
    - ../examples/basic/plot_properties.py:                                          0.21 sec   0.0 MB
    - ../examples/drawing/plot_directed.py:                                          0.21 sec   0.0 MB
    - ../examples/graphviz_layout/plot_decomposition.py:                             0.19 sec   0.0 MB
    - ../examples/drawing/plot_custom_node_icons.py:                                 0.19 sec   0.0 MB
    - ../examples/3d_drawing/plot_basic.py:                                          0.18 sec   0.0 MB
    - ../examples/algorithms/plot_metric_closure.py:                                 0.18 sec   0.0 MB
    - ../examples/algorithms/plot_snap.py:                                           0.15 sec   0.0 MB
    - ../examples/drawing/plot_sampson.py:                                           0.14 sec   0.0 MB
    - ../examples/graph/plot_napoleon_russian_campaign.py:                           0.13 sec   0.0 MB
    - ../examples/drawing/plot_spectral_grid.py:                                     0.13 sec   0.0 MB
    - ../examples/drawing/plot_labels_and_colors.py:                                 0.12 sec   0.0 MB
    - ../examples/graphviz_layout/plot_circular_tree.py:                             0.12 sec   0.0 MB
    - ../examples/algorithms/plot_shortest_path.py:                                  0.12 sec   0.0 MB
    - ../examples/algorithms/plot_circuits.py:                                       0.12 sec   0.0 MB
    - ../examples/graph/plot_mst.py:                                                 0.11 sec   0.0 MB
    - ../examples/drawing/plot_rainbow_coloring.py:                                  0.11 sec   0.0 MB
    - ../examples/graph/plot_dag_layout.py:                                          0.11 sec   0.0 MB
```

</details>

```
/home/circleci/project/venv/lib/python3.12/site-packages/joblib/externals/loky/process_executor.py:782: UserWarning: A worker stopped while some jobs were given to the executor. This can be caused by a too short worker timeout or by a memory leak.
  warnings.warn(
```

closing this PR for now.