### PR TITLE
Raise on mismatched attr/default lengths in isomorphism match helpers

### DIFF
--- a/networkx/algorithms/isomorphism/matchhelpers.py
+++ b/networkx/algorithms/isomorphism/matchhelpers.py
@@ -62,6 +62,11 @@ Returns
 match : function
     The customized, categorical `node_match` function.
 
+Raises
+------
+ValueError
+    If `attr` is a list and `default` does not have the same length as `attr`.
+
 Examples
 --------
 >>> import networkx.algorithms.isomorphism as iso
@@ -78,7 +83,7 @@ def categorical_node_match(attr, default):
             return data1.get(attr, default) == data2.get(attr, default)
 
     else:
-        attrs = list(zip(attr, default))  # Python 3
+        attrs = list(zip(attr, default, strict=True))
 
         def match(data1, data2):
             return all(data1.get(attr, d) == data2.get(attr, d) for attr, d in attrs)
@@ -98,7 +103,7 @@ def categorical_multiedge_match(attr, default):
             return values1 == values2
 
     else:
-        attrs = list(zip(attr, default))  # Python 3
+        attrs = list(zip(attr, default, strict=True))
 
         def match(datasets1, datasets2):
             values1 = set()
@@ -147,6 +152,11 @@ Returns
 match : function
     The customized, numerical `node_match` function.
 
+Raises
+------
+ValueError
+    If `attr` is a list and `default` does not have the same length as `attr`.
+
 Examples
 --------
 >>> import networkx.algorithms.isomorphism as iso
@@ -168,7 +178,7 @@ def numerical_node_match(attr, default, rtol=1.0000000000000001e-05, atol=1e-08)
             )
 
     else:
-        attrs = list(zip(attr, default))  # Python 3
+        attrs = list(zip(attr, default, strict=True))
 
         def match(data1, data2):
             values1 = [data1.get(attr, d) for attr, d in attrs]
@@ -190,7 +200,7 @@ def numerical_multiedge_match(attr, default, rtol=1.0000000000000001e-05, atol=1
             return allclose(values1, values2, rtol=rtol, atol=atol)
 
     else:
-        attrs = list(zip(attr, default))  # Python 3
+        attrs = list(zip(attr, default, strict=True))
 
         def match(datasets1, datasets2):
             values1 = []
@@ -244,6 +254,12 @@ Returns
 match : function
     The customized, generic `node_match` function.
 
+Raises
+------
+ValueError
+    If `attr` is a list and `default` or `op` do not have the same length
+    as `attr`.
+
 Examples
 --------
 >>> from operator import eq
@@ -263,7 +279,7 @@ def generic_node_match(attr, default, op):
             return op(data1.get(attr, default), data2.get(attr, default))
 
     else:
-        attrs = list(zip(attr, default, op))  # Python 3
+        attrs = list(zip(attr, default, op, strict=True))
 
         def match(data1, data2):
             for attr, d, operator in attrs:
@@ -321,7 +337,7 @@ def generic_multiedge_match(attr, default, op):
         attr = [attr]
         default = [default]
         op = [op]
-    attrs = list(zip(attr, default))  # Python 3
+    attrs = list(zip(attr, default, strict=True))
 
     def match(datasets1, datasets2):
         values1 = []

--- a/networkx/algorithms/isomorphism/tests/test_match_helpers.py
+++ b/networkx/algorithms/isomorphism/tests/test_match_helpers.py
@@ -1,5 +1,7 @@
 from operator import eq
 
+import pytest
+
 import networkx as nx
 from networkx.algorithms import isomorphism as iso
 
@@ -8,6 +10,59 @@ def test_categorical_node_match():
     nm = iso.categorical_node_match(["x", "y", "z"], [None] * 3)
     assert nm({"x": 1, "y": 2, "z": 3}, {"x": 1, "y": 2, "z": 3})
     assert not nm({"x": 1, "y": 2, "z": 2}, {"x": 1, "y": 2, "z": 1})
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        iso.categorical_node_match,
+        iso.categorical_edge_match,
+        iso.categorical_multiedge_match,
+        iso.numerical_node_match,
+        iso.numerical_edge_match,
+        iso.numerical_multiedge_match,
+    ],
+)
+def test_match_helper_mismatched_default_length_raises(factory):
+    # gh-8738: a `default` list shorter than `attr` used to be silently
+    # truncated by zip(), so the extra attributes were never compared (the
+    # match function then ignored them). It must raise instead.
+    with pytest.raises(ValueError):
+        factory(["a", "b"], [None])
+    with pytest.raises(ValueError):
+        factory(["a"], [None, None])
+    # the reported footgun: an empty default list
+    with pytest.raises(ValueError):
+        factory(["a"], [None] * 0)
+    # matching lengths still build a working matcher
+    match = factory(["a", "b"], [None, None])
+    assert callable(match)
+
+
+@pytest.mark.parametrize("factory", [iso.generic_node_match, iso.generic_edge_match])
+def test_generic_match_helper_mismatched_length_raises(factory):
+    # gh-8738: mismatched attr/default/op lengths must raise, not truncate.
+    with pytest.raises(ValueError):
+        factory(["a", "b"], [None], [eq, eq])  # default too short
+    with pytest.raises(ValueError):
+        factory(["a", "b"], [None, None], [eq])  # op too short
+    match = factory(["a", "b"], [None, None], [eq, eq])
+    assert callable(match)
+
+
+def test_generic_multiedge_match_mismatched_length_raises():
+    # gh-8738
+    with pytest.raises(ValueError):
+        iso.generic_multiedge_match(["a", "b"], [None], [eq, eq])
+    match = iso.generic_multiedge_match(["a", "b"], [None, None], [eq, eq])
+    assert callable(match)
+
+
+def test_categorical_node_match_string_form_unaffected():
+    # The single-attribute (str) form takes no list and must keep working.
+    nm = iso.categorical_node_match("size", 1)
+    assert nm({"size": 1}, {"size": 1})
+    assert not nm({"size": 1}, {"size": 2})
 
 
 class TestGenericMultiEdgeMatch:


### PR DESCRIPTION
### Summary

The isomorphism match-helper factories (`categorical_*`, `numerical_*`, `generic_*` for node/edge/multiedge) accept parallel lists of `attr` and `default` (plus `op` for the generic helpers) and pair them with `zip()`. When the lists have **different lengths**, `zip()` silently stops at the shorter one, so the extra attributes are never compared and the returned match function quietly **ignores** them:

```python
>>> import networkx.algorithms.isomorphism as iso
>>> nm = iso.categorical_node_match(["attr1"], [])  # default list too short
>>> nm({"attr1": 0}, {"attr1": 1})
True   # attr1 silently ignored -> everything "matches"
```

This is the root cause of the `node_match` behavior reported in #8738, where a `categorical_node_match(['attr1'], [None]*0)` was silently ignored during an ISMAGS query.

### Fix

Pass `strict=True` to every `zip()` that pairs these parallel lists, so a length mismatch raises `ValueError` at construction time instead of silently dropping attributes. This matches @dschult's suggested long-term fix in #8738:

> The long term fix is to change our call of `zip` to include `strict=True` so that it raises if either list is depleted before the other.

`zip(strict=True)` requires Python >= 3.10; NetworkX requires >= 3.12, so it is always available.

Covered call sites (the `*_edge_match` variants share code via `copyfunc`, so they are fixed too):
- `categorical_node_match` / `categorical_edge_match` / `categorical_multiedge_match`
- `numerical_node_match` / `numerical_edge_match` / `numerical_multiedge_match`
- `generic_node_match` / `generic_edge_match` (also validates `op` length) / `generic_multiedge_match`

The single-string `attr` form (e.g. `categorical_node_match("size", 1)`) takes no list and is unchanged.

### Docs & tests

- Documents the new `ValueError` in the shared `categorical`/`numerical`/`generic` docstrings.
- Adds parametrized tests across all affected factories asserting `ValueError` on mismatched lengths, that matching lengths still build a working matcher, and that the string form is unaffected. New tests fail on `main` and pass with this change.
- Full `networkx/algorithms/isomorphism/tests/` suite passes (1309 passed, 960 xfailed); `ruff check` and `ruff format --check` are clean.

### Notes

This is the `node_match`/default-length part of #8738. The `edge_match` on an edgeless subgraph (also in #8738) is addressed separately in #8745. The deeper node-attribute matching case (ISMAGS returning `[]` for a valid single-node match) is not addressed here.