### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/networkx/algorithms/graph_hashing.py
+++ b/networkx/algorithms/graph_hashing.py
@@ -121,7 +121,7 @@ def weisfeiler_lehman_graph_hash(
     Raises
     ------
     ValueError
-        If `iterations` is not a positve number.
+        If `iterations` is not a positive number.
 
     Examples
     --------
@@ -323,7 +323,7 @@ def weisfeiler_lehman_subgraph_hashes(
     Raises
     ------
     ValueError
-        If `iterations` is not a positve number.
+        If `iterations` is not a positive number.
 
     Examples
     --------

--- a/networkx/drawing/nx_pylab.py
+++ b/networkx/drawing/nx_pylab.py
@@ -430,17 +430,17 @@ def display(
         Visible nodes missing this attribute will use the final node_color value.
 
     edge_visible : string or bool, default "visible"
-        A string nameing the edge attribute which stores if an edge should be drawn.
+        A string naming the edge attribute which stores if an edge should be drawn.
         If `True`, all edges will be drawn while if `False` no edges will be visible.
         If incomplete, edges missing this attribute will be shown by default. Values
         of this attribute are expected to be booleans.
 
     edge_width : string or int, default "width"
-        A string nameing the edge attribute which stores the width of each edge.
+        A string naming the edge attribute which stores the width of each edge.
         Visible edges without this attribute will use a default width of 1.0.
 
     edge_color : string or color, default "color"
-        A string nameing the edge attribute which stores of color of each edge.
+        A string naming the edge attribute which stores of color of each edge.
         Visible edges without this attribute will be drawn black. Each color can be
         a string or rgb (or rgba) tuple of floats from 0.0 to 1.0.
 
@@ -502,7 +502,7 @@ def display(
         will use a default value of 0.
 
     edge_target_margin : string or int, default "target_margin"
-        A string naming the edge attribute which stores the minimumm margin (gap) between
+        A string naming the edge attribute which stores the minimum margin (gap) between
         the target node and the end of the edge. Visible edges without this attribute
         will use a default value of 0.
 
@@ -617,7 +617,7 @@ def display(
         attr = kwargs.get(param_name, attr)
 
         if default is None:
-            # raise instead of using non-existant default value
+            # raise instead of using non-existent default value
             for n in seq:
                 if attr not in node_subgraph.nodes[n]:
                     raise nx.NetworkXError(f"Attribute '{attr}' missing for node {n}")
@@ -677,7 +677,7 @@ def display(
         attr = kwargs.get(param_name, attr)
 
         if default is None:
-            # raise instead of using non-existant default value
+            # raise instead of using non-existent default value
             for e in seq:
                 if attr not in edge_subgraph.edges[e]:
                     raise nx.NetworkXError(f"Attribute '{attr}' missing for edge {e}")

--- a/networkx/drawing/tests/test_pylab.py
+++ b/networkx/drawing/tests/test_pylab.py
@@ -54,7 +54,7 @@ defaults = {
     },
     "edge_style": "-",
     "edge_alpha": 1.0,
-    # These are for undirected-graphs. Directed graphs shouls use "-|>" and 10, respectively
+    # These are for undirected-graphs. Directed graphs should use "-|>" and 10, respectively
     "edge_arrowstyle": "-",
     "edge_arrowsize": 0,
     "edge_curvature": "arc3",


### PR DESCRIPTION
Fix minor typos found by codespell.

- `nameing` -> `naming` (3 occurrences in `nx_pylab.py` docstring)
- `minimumm` -> `minimum` (`nx_pylab.py` docstring)
- `non-existant` -> `non-existent` (2 occurrences in `nx_pylab.py` comments)
- `shouls` -> `should` (`test_pylab.py` comment)
- `positve` -> `positive` (2 occurrences in `graph_hashing.py` docstrings)