### PR TITLE
BUG: fix Louvain infinite loop caused by floating-point ties

### DIFF
--- a/networkx/algorithms/community/louvain.py
+++ b/networkx/algorithms/community/louvain.py
@@ -282,6 +282,9 @@ def _one_level(G, partition, m, resolution, is_directed, seed):
     improvement = False
     while nb_moves > 0:
         nb_moves = 0
+        # Track the cumulative modularity gain for this pass to detect
+        # oscillations driven by floating-point noise (see gh-8739).
+        pass_total_gain = 0.0
         for u in rand_nodes:
             u_com = node2com[u]
             u_deg_by_com = defaultdict(float)
@@ -326,7 +329,12 @@ def _one_level(G, partition, m, resolution, is_directed, seed):
                 inner_partition[best_com].add(u)
                 improvement = True
                 nb_moves += 1
+                pass_total_gain += best_mod
                 node2com[u] = best_com
+        # If the total gain across this pass is negligible, the remaining
+        # moves are just floating-point noise causing oscillation.
+        if pass_total_gain <= 1e-15:
+            break
     partition = [p for p in partition if p]
     inner_partition = [p for p in inner_partition if p]
     return partition, inner_partition, improvement

--- a/networkx/algorithms/community/tests/test_louvain.py
+++ b/networkx/algorithms/community/tests/test_louvain.py
@@ -262,3 +262,22 @@ def test_max_level():
         ValueError, match="max_level argument must be a positive integer"
     ):
         nx.community.louvain_communities(G, max_level=0)
+
+
+def test_louvain_no_infinite_loop_on_ties():
+    """Louvain terminates when modularity gains are zero (floating-point ties).
+
+    Regression test for gh-8739: on certain small graphs the local modularity
+    gain for moving a node between two communities is exactly zero (up to
+    floating-point noise), causing the algorithm to oscillate indefinitely.
+    """
+    # Graph Atlas G674 — the reproducer from gh-8739
+    G = nx.Graph(
+        [(0, 1), (0, 2), (0, 5), (0, 6), (1, 2), (1, 4), (2, 3), (2, 5), (2, 6), (3, 4)]
+    )
+    # Must terminate (previously hung forever) and produce a valid partition
+    for seed in range(20):
+        partition = nx.community.louvain_communities(
+            G, weight="weight", resolution=1, seed=seed
+        )
+        assert nx.community.is_partition(G, partition)


### PR DESCRIPTION
## BUG: fix Louvain infinite loop caused by floating-point ties

Closes #8739

### Summary

On certain small graphs the Louvain algorithm enters an infinite loop because the local modularity gain for moving a node between two communities is zero up to floating-point rounding (~1e-17). Since `gain > best_mod` with `best_mod = 0` evaluates to `True` for these epsilon-positive values, the algorithm keeps swapping nodes between equivalent partitions forever.

### Root cause

The modularity gain formula involves subtracting nearly-equal floating-point quantities. When the "true" gain is mathematically zero, the computed value can be a tiny positive residual (e.g. `2.78e-17`). The existing code treats any `gain > 0` as a reason to move, causing oscillation:

```
Iteration 2: Move node 2: com 0 -> 2 (gain=2.78e-17)
             Move node 0: com 2 -> 0 (gain=6.94e-18)
Iteration 3: Move node 2: com 2 -> 0 (gain=2.78e-17)  ← repeats forever
             ...
```

### Fix

Track the **cumulative modularity gain** across each full pass through all nodes. If the total gain for a pass is negligible (`<= 1e-15`), break out of the inner loop. This approach:

1. **Allows** individual tiny-gain moves that are needed for initial community merges on regular graphs (e.g. the Petersen graph, where some legitimate first-pass moves have gains of ~3e-18 due to perfect symmetry).
2. **Prevents** infinite oscillation where nodes swap back and forth with zero net modularity improvement across the full pass.

The key insight is that in the bug case, the *total* modularity across a pass never improves (nodes just oscillate), while in legitimate cases like the Petersen graph, even though individual moves have tiny gains, the cumulative effect across the pass is positive in early iterations and the algorithm converges naturally.

This approach is similar to how [python-louvain](https://github.com/taynaud/python-louvain) uses a `__MIN` threshold and how [gonum](https://github.com/gonum/gonum/issues/1488) addressed the same issue.

### Tests

Added `test_louvain_no_infinite_loop_on_ties` — runs the exact reproducer from the issue  with 20 different seeds, verifying termination and valid partition output.

All 190 existing community detection tests continue to pass, including:
- Petersen graph doctest (unchanged output)
- Karate club partition (unchanged)
- Directed graph cases
- LFR benchmark quality tests