### PR TITLE
A more readable havel_hakimi graph creation algorithm

### DIFF
--- a/networkx/algorithms/core.py
+++ b/networkx/algorithms/core.py
@@ -74,10 +74,10 @@ def core_number(G):
 
     Examples
     --------
-    >>> degrees = [0, 1, 2, 2, 2, 2, 3]
-    >>> H = nx.havel_hakimi_graph(degrees)
+    >>> H = nx.Graph([(0, 4), (1, 2), (1, 3), (2, 5), (3, 5), (4, 5)])
+    >>> H.add_node(6)
     >>> nx.core_number(H)
-    {0: 1, 1: 2, 2: 2, 3: 2, 4: 1, 5: 2, 6: 0}
+    {0: 1, 4: 1, 1: 2, 2: 2, 3: 2, 5: 2, 6: 0}
     >>> G = nx.DiGraph()
     >>> G.add_edges_from([(1, 2), (2, 1), (2, 3), (2, 4), (3, 4), (4, 3)])
     >>> nx.core_number(G)
@@ -186,10 +186,10 @@ def k_core(G, k=None, core_number=None):
 
     Examples
     --------
-    >>> degrees = [0, 1, 2, 2, 2, 2, 3]
-    >>> H = nx.havel_hakimi_graph(degrees)
+    >>> H = nx.Graph([(0, 4), (1, 2), (1, 3), (2, 5), (3, 5), (4, 5)])
+    >>> H.add_node(6)
     >>> H.degree
-    DegreeView({0: 1, 1: 2, 2: 2, 3: 2, 4: 2, 5: 3, 6: 0})
+    DegreeView({0: 1, 4: 2, 1: 2, 2: 2, 3: 2, 5: 3, 6: 0})
     >>> nx.k_core(H).nodes
     NodeView((1, 2, 3, 5))
 
@@ -250,10 +250,10 @@ def k_shell(G, k=None, core_number=None):
 
     Examples
     --------
-    >>> degrees = [0, 1, 2, 2, 2, 2, 3]
-    >>> H = nx.havel_hakimi_graph(degrees)
+    >>> H = nx.Graph([(0, 4), (1, 2), (1, 3), (2, 5), (3, 5), (4, 5)])
+    >>> H.add_node(6)
     >>> H.degree
-    DegreeView({0: 1, 1: 2, 2: 2, 3: 2, 4: 2, 5: 3, 6: 0})
+    DegreeView({0: 1, 4: 2, 1: 2, 2: 2, 3: 2, 5: 3, 6: 0})
     >>> nx.k_shell(H, k=1).nodes
     NodeView((0, 4))
 
@@ -316,10 +316,10 @@ def k_crust(G, k=None, core_number=None):
 
     Examples
     --------
-    >>> degrees = [0, 1, 2, 2, 2, 2, 3]
-    >>> H = nx.havel_hakimi_graph(degrees)
+    >>> H = nx.Graph([(0, 4), (1, 2), (1, 3), (2, 5), (3, 5), (4, 5)])
+    >>> H.add_node(6)
     >>> H.degree
-    DegreeView({0: 1, 1: 2, 2: 2, 3: 2, 4: 2, 5: 3, 6: 0})
+    DegreeView({0: 1, 4: 2, 1: 2, 2: 2, 3: 2, 5: 3, 6: 0})
     >>> nx.k_crust(H, k=1).nodes
     NodeView((0, 4, 6))
 
@@ -380,10 +380,10 @@ def k_corona(G, k, core_number=None):
 
     Examples
     --------
-    >>> degrees = [0, 1, 2, 2, 2, 2, 3]
-    >>> H = nx.havel_hakimi_graph(degrees)
+    >>> H = nx.Graph([(0, 4), (1, 2), (1, 3), (2, 5), (3, 5), (4, 5)])
+    >>> H.add_node(6)
     >>> H.degree
-    DegreeView({0: 1, 1: 2, 2: 2, 3: 2, 4: 2, 5: 3, 6: 0})
+    DegreeView({0: 1, 4: 2, 1: 2, 2: 2, 3: 2, 5: 3, 6: 0})
     >>> nx.k_corona(H, k=2).nodes
     NodeView((1, 2, 3, 5))
 
@@ -446,12 +446,12 @@ def k_truss(G, k):
 
     Examples
     --------
-    >>> degrees = [0, 1, 2, 2, 2, 2, 3]
-    >>> H = nx.havel_hakimi_graph(degrees)
+    >>> H = nx.Graph([(0, 4), (1, 2), (1, 3), (2, 5), (3, 5), (4, 5)])
+    >>> H.add_node(6)
     >>> H.degree
-    DegreeView({0: 1, 1: 2, 2: 2, 3: 2, 4: 2, 5: 3, 6: 0})
-    >>> nx.k_truss(H, k=2).nodes
-    NodeView((0, 1, 2, 3, 4, 5))
+    DegreeView({0: 1, 4: 2, 1: 2, 2: 2, 3: 2, 5: 3, 6: 0})
+    >>> sorted(nx.k_truss(H, k=2))
+    [0, 1, 2, 3, 4, 5]
 
     References
     ----------
@@ -516,10 +516,10 @@ def onion_layers(G):
 
     Examples
     --------
-    >>> degrees = [0, 1, 2, 2, 2, 2, 3]
-    >>> H = nx.havel_hakimi_graph(degrees)
+    >>> H = nx.Graph([(0, 4), (1, 2), (1, 3), (2, 5), (3, 5), (4, 5)])
+    >>> H.add_node(6)
     >>> H.degree
-    DegreeView({0: 1, 1: 2, 2: 2, 3: 2, 4: 2, 5: 3, 6: 0})
+    DegreeView({0: 1, 4: 2, 1: 2, 2: 2, 3: 2, 5: 3, 6: 0})
     >>> nx.onion_layers(H)
     {6: 1, 0: 2, 4: 3, 1: 4, 2: 4, 3: 4, 5: 4}
 

--- a/networkx/algorithms/tests/test_clique.py
+++ b/networkx/algorithms/tests/test_clique.py
@@ -11,8 +11,23 @@ def find_clique_fn(request):
 
 @pytest.fixture
 def G():
-    z = [3, 4, 3, 4, 2, 4, 2, 1, 1, 1, 1]
-    return cnlti(nx.generators.havel_hakimi_graph(z), first_label=1)
+    return nx.Graph(
+        [
+            (1, 3),
+            (1, 6),
+            (1, 2),
+            (3, 6),
+            (3, 2),
+            (2, 6),
+            (6, 4),
+            (2, 4),
+            (4, 5),
+            (5, 7),
+            (4, 7),
+            (8, 9),
+            (10, 11),
+        ]
+    )
 
 
 @pytest.mark.parametrize(

--- a/networkx/algorithms/tests/test_core.py
+++ b/networkx/algorithms/tests/test_core.py
@@ -41,13 +41,12 @@ class TestCore:
         G.add_node(21)
         cls.G = G
 
-        # Create the graph H resulting from the degree sequence
-        # [0, 1, 2, 2, 2, 2, 3] when using the Havel-Hakimi algorithm.
-
-        degseq = [0, 1, 2, 2, 2, 2, 3]
-        H = nx.havel_hakimi_graph(degseq)
-        mapping = {6: 0, 0: 1, 4: 3, 5: 6, 3: 4, 1: 2, 2: 5}
-        cls.H = nx.relabel_nodes(H, mapping)
+        # A 4-cycle with a P2 "tail", and one isolated node. Degree distribution
+        # [0, 1, 2, 2, 2, 2, 3]
+        H = nx.Graph()
+        H.add_node(0)
+        H.add_edges_from([(1, 3), (3, 6), (6, 4), (4, 2), (2, 5), (5, 6)])
+        cls.H = H
 
     def test_trivial(self):
         """Empty graph"""

--- a/networkx/generators/degree_seq.py
+++ b/networkx/generators/degree_seq.py
@@ -481,52 +481,24 @@ def havel_hakimi_graph(deg_sequence, create_using=None):
     if not nx.is_graphical(deg_sequence):
         raise nx.NetworkXError("Invalid degree sequence")
 
-    p = len(deg_sequence)
-    G = nx.empty_graph(p, create_using)
+    G = nx.empty_graph(len(deg_sequence), create_using)
     if G.is_directed():
         raise nx.NetworkXError("Directed graphs are not supported")
-    num_degs = [[] for i in range(p)]
-    dmax, n = 0, 0
-    for d in deg_sequence:
-        # Process only the non-zero integers
-        if d > 0:
-            num_degs[d].append(n)
-            dmax, n = max(dmax, d), n + 1
-    # Return graph if no edges
-    if n == 0:
-        return G
 
-    modstubs = [(0, 0)] * (dmax + 1)
-    # Successively reduce degree sequence by removing the maximum degree
-    while n > 0:
-        # Retrieve the maximum degree in the sequence
-        while len(num_degs[dmax]) == 0:
-            dmax -= 1
-        # If there are not enough stubs to connect to, then the sequence is
-        # not graphical
-        if dmax > n - 1:
-            raise nx.NetworkXError("Non-graphical integer sequence")
-
-        # Remove largest stub in list
-        source = num_degs[dmax].pop()
-        n -= 1
-        # Reduce the next dmax largest stubs
-        mslen = 0
-        k = dmax
-        for i in range(dmax):
-            while len(num_degs[k]) == 0:
-                k -= 1
-            target = num_degs[k].pop()
-            G.add_edge(source, target)
-            n -= 1
-            if k > 1:
-                modstubs[mslen] = (k - 1, target)
-                mslen += 1
-        # Add back to the list any nonzero stubs that were removed
-        for i in range(mslen):
-            (stubval, stubtarget) = modstubs[i]
-            num_degs[stubval].append(stubtarget)
-            n += 1
+    d = dict(enumerate(deg_sequence))
+    while d:
+        # Select the highest-degree node and remove it from the candidates to
+        # prevent selfloops
+        node = max(d, key=d.get)
+        deg = d.pop(node)
+        # Add edges to the top-k node candidates by degree. Here we rely on
+        # `zip` to terminate once `range(deg)` is exhausted
+        for _, tgt in zip(range(deg), sorted(d, key=d.get, reverse=True)):
+            G.add_edge(node, tgt)
+            d[tgt] -= 1
+            # Remove candidates from consideration if degree drops to 0
+            if d[tgt] < 1:
+                del d[tgt]
 
     return G
 

--- a/networkx/linalg/tests/test_graphmatrix.py
+++ b/networkx/linalg/tests/test_graphmatrix.py
@@ -29,8 +29,9 @@ def test_adjacency_matrix_format(ary_format):
 
 
 def test_incidence_matrix_simple():
-    deg = [3, 2, 2, 1, 0]
-    G = nx.havel_hakimi_graph(deg)
+    G = nx.Graph()
+    G.add_nodes_from(range(5))
+    G.add_edges_from([(0, 2), (0, 1), (0, 3), (1, 2)])
     deg = [(1, 0), (1, 0), (1, 0), (2, 0), (1, 0), (2, 1), (0, 1), (0, 1)]
     MG = nx.random_clustered_graph(deg, seed=42)
 


### PR DESCRIPTION
I'd like to preface this with: I don't think this should be merged! The reason being that, while deterministic, this implementation produces *different* deterministic results than the existing `havel_hakimi_graph` implementation. While NX doesn't make any explicit guarantees, this change will break folks who are implicitly relying on the *exact* result from `havel_hakimi_graph`, e.g. when setting up test cases. This is evidenced by the breakages in NetworkX's own test suite - cf. all of the test changes in this PR!

---

This idea came about while reviewing #8710. I hadn't ever taken a close look at the `havel_hakimi_graph` function before, but while reading it during review it struck me as hard to follow due to all of the internal local variables and packing/unpacking in the mechanism used to track candidate degree.

It occurred to me that you arrive at the same semantics with a single mapping which maps node candidate labels (i.e. integers) to their "remaining" degree. IMO, this really helps to highlight the underlying algorithm: select the highest degree node, connect it to the next `k` highest degree nodes, and repeat - removing candidate nodes when their degree hits 0. Simple!

One interesting bit that came out of this exercise was the fact that different, i.e. *non-isomorphic* graphs can arise from this procedure! For example take the following degree sequence: `z = [1, 2, 2, 2, 2, 3]` (from the test suite). On `main` you get a 4-cycle with a P2 tail; with this implementation you get a 3-cycle with a P3 tail:

```python
>>> z = z = [1, 2, 2, 2, 2, 3]
>>> G = nx.havel_hakimi_graph(z)
>>> nx.draw(G, with_labels=True)
```

<img width="797" height="451" alt="havel_comp" src="https://github.com/user-attachments/assets/fac24372-1b11-48f4-812d-53673a650e8c" />

Both graphs have the same degree sequence, and both implementations are deterministic (i.e. will always give the same graph from the given degree sequence). The difference comes down to tie-breaking in the sorting order. For example, incorporating the node value in the sorting key (i.e. switching `key=d.get` with `key=lambda n: (d[n], n)`) recovers the 4-cycle in this example (though the labels are still permuted). I played around with this a bit in an attempt to exactly match the results of the existing implementation - i.e. adding some special casing for the 0-degree nodes and switching to the more complicated sorting key; but while that appears to give graphs that are *isomorphic* with the existing implementation (not exhaustively tested), there are still label permutations as the existing implementation isn't strictly lexicographic either.

---

Ultimately, I don't think there's anything really actionable here. I'd be -1 on changing the behavior of the `havel_hakimi_generator` as that will almost certainly break downstream code that implicitly depends on the exact result. In principle, we could add this implementation in parallel to the existing havel_hakimi_generator as e.g. `generalized_havel_hakimi` or some other name, but I personally am -1 on increasing the API surface for readability reasons. Nevertheless - I found the results here interesting and wanted to share!