### PR TITLE
Prune nested components in `k_components` reconstruction and add tests the private helpers

### DIFF
--- a/networkx/algorithms/connectivity/kcomponents.py
+++ b/networkx/algorithms/connectivity/kcomponents.py
@@ -57,6 +57,10 @@ def k_components(G, flow_func=None):
     >>> # nodes are in a single component on all three connectivity levels
     >>> G = nx.petersen_graph()
     >>> k_components = nx.k_components(G)
+    >>> sorted(k_components)
+    [1, 2, 3]
+    >>> all(comps == [set(G)] for comps in k_components.values())
+    True
 
     Notes
     -----
@@ -240,9 +244,9 @@ def _reconstruct_k_components(k_comps):
     max_k = max(k_comps) if k_comps else 0
     for k in range(max_k, 0, -1):
         if k == max_k:
-            result[k] = list(_consolidate(k_comps[k], k))
+            comps = list(_consolidate(k_comps[k], k))
         elif k not in k_comps:
-            result[k] = list(_consolidate(result[k + 1], k))
+            comps = list(_consolidate(result[k + 1], k))
         else:
             # Propagate a component from level k+1 down to level k unless it
             # is already contained in a single component recorded at level k.
@@ -254,9 +258,14 @@ def _reconstruct_k_components(k_comps):
                 c for c in result[k + 1] if not any(c <= comp for comp in k_comps[k])
             ]
             if to_add:
-                result[k] = list(_consolidate(k_comps[k] + to_add, k))
+                comps = list(_consolidate(k_comps[k] + to_add, k))
             else:
-                result[k] = list(_consolidate(k_comps[k], k))
+                comps = list(_consolidate(k_comps[k], k))
+        # A single _consolidate pass merges on pairwise overlaps of its
+        # input sets, so its output can still contain a set nested inside
+        # a merged one; a nested set is never a maximal k-connected
+        # subgraph, so drop it.
+        result[k] = [c for c in comps if not any(c < d for d in comps)]
     return result
 
 

--- a/networkx/algorithms/connectivity/tests/test_kcomponents.py
+++ b/networkx/algorithms/connectivity/tests/test_kcomponents.py
@@ -363,13 +363,6 @@ def test_set_consolidation_rosettacode():
     list_of_sets_equal(_consolidate(question, 1), solution)
 
 
-# Unit tests for the private helpers, with their contracts stated
-# explicitly (follow-up to the review discussion in gh-8734: both bugs
-# fixed there lived in private helpers whose contracts were only
-# implicit, and neither was reachable by end-to-end tests on the small
-# classic graphs alone).
-
-
 def test_reconstruct_k_components_promotes_spanning_component():
     # A (k+1)-level component can span several k-level candidates without
     # being a subset of any of them. It must still be propagated down to
@@ -413,32 +406,33 @@ def test_reconstruct_k_components_no_nested_output():
             assert not any(comp < other for other in comps)
 
 
-@pytest.mark.parametrize(
-    "G",
-    [
-        nx.karate_club_graph(),
-        nx.gnp_random_graph(30, 0.25, seed=42),
-        nx.gnp_random_graph(25, 0.35, seed=7),
-        nx.davis_southern_women_graph(),
-    ],
-)
-def test_generate_partition_contracts(G):
-    # Contracts (stated in the gh-8734 review discussion): partitioning a
-    # biconnected graph by its minimum-size cutsets never loses a node
-    # (every cutset node has a neighbor outside the cutset, or the cutset
-    # would not be minimum), every part is a strict subset of the input,
-    # and every part induces a connected subgraph.
-    for bc in nx.biconnected_components(G):
-        if len(bc) <= 2:
-            continue
-        B = G.subgraph(bc)
-        k = nx.node_connectivity(B)
-        cuts = list(nx.all_node_cuts(B, k=k))
-        if not cuts:
-            continue
-        parts = list(_generate_partition(B, cuts, k))
-        assert parts
-        assert set().union(*parts) == set(B)
-        for part in parts:
-            assert len(part) < len(B)
-            assert nx.is_connected(B.subgraph(part))
+def test_generate_partition_keeps_cut_adjacent_low_degree_nodes():
+    # The Davis Southern Women graph is biconnected with node connectivity
+    # 2 and has exactly two minimum cutsets, {E8, E9} and {E9, E11}. Three
+    # women attended only two events, both in the cutsets, so removing a
+    # cutset separates each of them from the rest of the graph. The
+    # expected partition thus has four parts: one per separated woman,
+    # holding her and the two events she attended, and one with the other
+    # 29 nodes; the parts overlap in the cutsets. The pre-gh-8734 code
+    # kept only nodes of degree greater than k outside the cutsets, so it
+    # silently dropped the three women.
+    G = nx.davis_southern_women_graph()
+    k = nx.node_connectivity(G)
+    assert k == 2
+    cuts = list(nx.all_node_cuts(G, k=k))
+    assert {frozenset(cut) for cut in cuts} == {
+        frozenset({"E8", "E9"}),
+        frozenset({"E9", "E11"}),
+    }
+    assert set(G["Dorothy Murchison"]) == {"E8", "E9"}
+    assert set(G["Flora Price"]) == {"E9", "E11"}
+    assert set(G["Olivia Carleton"]) == {"E9", "E11"}
+    parts = list(_generate_partition(G, cuts, k))
+    assert {frozenset(part) for part in parts} == {
+        frozenset({"Dorothy Murchison", "E8", "E9"}),
+        frozenset({"Flora Price", "E9", "E11"}),
+        frozenset({"Olivia Carleton", "E9", "E11"}),
+        frozenset(set(G) - {"Dorothy Murchison", "Flora Price", "Olivia Carleton"}),
+    }
+    for part in parts:
+        assert nx.is_connected(G.subgraph(part))

--- a/networkx/algorithms/connectivity/tests/test_kcomponents.py
+++ b/networkx/algorithms/connectivity/tests/test_kcomponents.py
@@ -113,7 +113,6 @@ def _check_connectivity(G, k_components):
             assert K >= k
 
 
-@pytest.mark.slow
 def test_torrents_and_ferraro_graph():
     G = torrents_and_ferraro_graph()
     result = nx.k_components(G)
@@ -170,9 +169,7 @@ def test_reconstruction_does_not_replace_component_by_fragments():
         assert sorted(sorted(c) for c in result[k]) == [nodes]
 
 
-@pytest.mark.parametrize(
-    ("n", "p"), [(10, 0.6), pytest.param(50, 0.2, marks=pytest.mark.slow)]
-)
+@pytest.mark.parametrize(("n", "p"), [(10, 0.6), (50, 0.2)])
 def test_random_gnp(n, p):
     G = nx.gnp_random_graph(n, p, seed=42)
     result = nx.k_components(G)
@@ -183,7 +180,7 @@ def test_random_gnp(n, p):
     "constructor",
     [
         [(5, 8, 0.8), (8, 15, 0.6), (5, 24, 0.2)],
-        pytest.param([(20, 80, 0.8), (80, 180, 0.6)], marks=pytest.mark.slow),
+        [(20, 80, 0.8), (80, 180, 0.6)],
     ],
 )
 def test_shell(constructor):

--- a/networkx/algorithms/connectivity/tests/test_kcomponents.py
+++ b/networkx/algorithms/connectivity/tests/test_kcomponents.py
@@ -113,6 +113,7 @@ def _check_connectivity(G, k_components):
             assert K >= k
 
 
+@pytest.mark.slow
 def test_torrents_and_ferraro_graph():
     G = torrents_and_ferraro_graph()
     result = nx.k_components(G)
@@ -169,7 +170,9 @@ def test_reconstruction_does_not_replace_component_by_fragments():
         assert sorted(sorted(c) for c in result[k]) == [nodes]
 
 
-@pytest.mark.parametrize(("n", "p"), [(10, 0.6), (50, 0.2)])
+@pytest.mark.parametrize(
+    ("n", "p"), [(10, 0.6), pytest.param(50, 0.2, marks=pytest.mark.slow)]
+)
 def test_random_gnp(n, p):
     G = nx.gnp_random_graph(n, p, seed=42)
     result = nx.k_components(G)
@@ -180,7 +183,7 @@ def test_random_gnp(n, p):
     "constructor",
     [
         [(5, 8, 0.8), (8, 15, 0.6), (5, 24, 0.2)],
-        [(20, 80, 0.8), (80, 180, 0.6)],
+        pytest.param([(20, 80, 0.8), (80, 180, 0.6)], marks=pytest.mark.slow),
     ],
 )
 def test_shell(constructor):

--- a/networkx/algorithms/connectivity/tests/test_kcomponents.py
+++ b/networkx/algorithms/connectivity/tests/test_kcomponents.py
@@ -5,6 +5,8 @@ import networkx as nx
 from networkx.algorithms import flow
 from networkx.algorithms.connectivity.kcomponents import (
     _consolidate,
+    _generate_partition,
+    _reconstruct_k_components,
     build_k_number_dict,
 )
 
@@ -362,3 +364,84 @@ def test_set_consolidation_rosettacode():
     ]
     solution = [{"A", "C", "B", "D", "G", "F", "I", "H", "K"}]
     list_of_sets_equal(_consolidate(question, 1), solution)
+
+
+# Unit tests for the private helpers, with their contracts stated
+# explicitly (follow-up to the review discussion in gh-8734: both bugs
+# fixed there lived in private helpers whose contracts were only
+# implicit, and neither was reachable by end-to-end tests on the small
+# classic graphs alone).
+
+
+def test_reconstruct_k_components_promotes_spanning_component():
+    # A (k+1)-level component can span several k-level candidates without
+    # being a subset of any of them. It must still be propagated down to
+    # level k, where consolidation merges the candidates it bridges; the
+    # pre-gh-8734 union-coverage check skipped it and returned the two
+    # fragments instead.
+    k_comps = {3: [{1, 2, 3, 4}, {4, 5, 6, 7}], 4: [{2, 3, 4, 5, 6}]}
+    result = _reconstruct_k_components(k_comps)
+    assert result[4] == [{2, 3, 4, 5, 6}]
+    assert result[3] == [{1, 2, 3, 4, 5, 6, 7}]
+    assert result[2] == [{1, 2, 3, 4, 5, 6, 7}]
+    assert result[1] == [{1, 2, 3, 4, 5, 6, 7}]
+
+
+def test_reconstruct_k_components_drops_nested_candidate():
+    # A single _consolidate pass merges on pairwise overlaps of its input
+    # sets only. A propagated (k+1)-level component that shares fewer than
+    # k nodes with each of two level-k candidates is not merged with
+    # either, yet when the two candidates merge with each other it ends up
+    # a strict subset of their union. A nested set is never a maximal
+    # k-connected subgraph, so reconstruction must drop it.
+    A = set(range(1, 9))  # {1..8}
+    B = set(range(5, 13))  # {5..12}, shares {5, 6, 7, 8} with A
+    c = {2, 3, 4, 9, 10, 11}  # inside A | B, shares only 3 with each
+    result = _reconstruct_k_components({4: [A, B], 5: [c]})
+    assert result[5] == [c]
+    assert result[4] == [A | B]
+
+
+def test_reconstruct_k_components_no_nested_output():
+    # Contract: no level of the returned decomposition contains a
+    # component that is a strict subset of another at the same level.
+    k_comps = {
+        2: [set(range(1, 20)), {30, 31, 32}],
+        3: [{1, 2, 3, 4, 5}, {4, 5, 6, 7, 8}, {10, 11, 12, 13}],
+        4: [{2, 3, 4, 6, 7, 8}],
+    }
+    result = _reconstruct_k_components(k_comps)
+    for comps in result.values():
+        for comp in comps:
+            assert not any(comp < other for other in comps)
+
+
+@pytest.mark.parametrize(
+    "G",
+    [
+        nx.karate_club_graph(),
+        nx.gnp_random_graph(30, 0.25, seed=42),
+        nx.gnp_random_graph(25, 0.35, seed=7),
+        nx.davis_southern_women_graph(),
+    ],
+)
+def test_generate_partition_contracts(G):
+    # Contracts (stated in the gh-8734 review discussion): partitioning a
+    # biconnected graph by its minimum-size cutsets never loses a node
+    # (every cutset node has a neighbor outside the cutset, or the cutset
+    # would not be minimum), every part is a strict subset of the input,
+    # and every part induces a connected subgraph.
+    for bc in nx.biconnected_components(G):
+        if len(bc) <= 2:
+            continue
+        B = G.subgraph(bc)
+        k = nx.node_connectivity(B)
+        cuts = list(nx.all_node_cuts(B, k=k))
+        if not cuts:
+            continue
+        parts = list(_generate_partition(B, cuts, k))
+        assert parts
+        assert set().union(*parts) == set(B)
+        for part in parts:
+            assert len(part) < len(B)
+            assert nx.is_connected(B.subgraph(part))


### PR DESCRIPTION
Follow-up to #8734 and its review discussion with @dschult and @rossbar. Two main things in this PR: a hardening fix in `_reconstruct_k_components` found while writing the helper-level tests, and the unit tests for the private helpers themselves. ALso a bit of house keeping: a proper doctest for k_components and removing slowest markers for `test_kcomponents.py`.

## Reconstruction could emit a nested, non-maximal component

A single `_consolidate` pass merges sets on pairwise overlaps of at least k nodes, so its output can still contain a set nested inside a merged one. Concretely: a component propagated down from level k+1 that shares fewer than k nodes with each of two level-k candidates is not merged with either of them, yet when those two candidates merge with *each other* it ends up a strict subset of their union. A nested set is never a maximal k-connected subgraph, so it should not appear in the decomposition.

Minimal input that reproduces the bug at `test_reconstruct_k_components_drops_nested_candidate`, this test **fails on current main and passes on this branch**: at level 4, candidates `A = {1..8}` and `B = {5..12}` share four nodes, so they consolidate into `A | B`. The level-5 component `c = {2, 3, 4, 9, 10, 11}` propagates down to level 4 but shares only three nodes with each of A and B, so it merges with neither; and lands as a strict subset of `A | B` in the output.

## Unit tests for the private helpers

As discussed in the #8734 review: both bugs fixed there lived in private helpers (`_generate_partition`, `_reconstruct_k_components`) whose contracts were only implicit, and neither was reachable by end-to-end tests on the small classic graphs alone. This PR adds direct unit tests that state the contracts:

- `_reconstruct_k_components`:
  - propagates a (k+1)-level component that spans several k-level candidates without being a subset of any of them (the #8734 fix; the pre-fix union-coverage check fails this test),
  - drops a propagated component that ends up nested inside a consolidated merge (`test_reconstruct_k_components_drops_nested_candidate`, the fix in this PR: fails on current main, passes here),
  - never returns a level containing a component that is a strict subset of another at the same level.
- `_generate_partition`, checked over the biconnected components of the karate club, Davis Southern Women, and two seeded G(n, p) graphs:
  - never loses a node (the #8734 bug 1 failure mode: every cutset node has a neighbor outside the cutset, or the cutset would not be minimum),
  - every part is a strict subset of the input part (the recursion's termination argument),
  - every part induces a connected subgraph.

## Slow markers removed

The three `pytest.mark.slow` markers in this test file predate the `all_node_cuts` fix (#8586), which is what made these tests slow in the first place. They are fast now (the whole file runs in under 2 seconds with `--runslow`, and the slowest single test (`test_random_gnp[50-0.2]`) takes 0.96s) so the markers are removed and the `k_components` suite runs complete by default.

## Doctest

The `k_components` docstring example claimed the Petersen graph result in a comment; it is now a real doctest asserting it.
