### PR TITLE
Avoid building the flow dict in maximum_flow_value

### DIFF
--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -325,6 +325,9 @@ def maximum_flow_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwa
     if not callable(flow_func):
         raise nx.NetworkXError("flow_func has to be callable.")
 
+    # All flow functions return a residual network R that follows the
+    # conventions described in the Notes section: in particular, they
+    # store the maximum flow value in R.graph["flow_value"].
     R = flow_func(flowG, _s, _t, capacity=capacity, value_only=True, **kwargs)
 
     return R.graph["flow_value"]

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -310,8 +310,20 @@ def maximum_flow_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwa
     True
 
     """
-    flow_value, _ = maximum_flow(flowG, _s, _t, capacity, flow_func, **kwargs)
-    return flow_value
+    if flow_func is None:
+        if kwargs:
+            raise nx.NetworkXError(
+                "You have to explicitly set a flow_func if"
+                " you need to pass parameters via kwargs."
+            )
+        flow_func = default_flow_func
+
+    if not callable(flow_func):
+        raise nx.NetworkXError("flow_func has to be callable.")
+
+    R = flow_func(flowG, _s, _t, capacity=capacity, value_only=True, **kwargs)
+
+    return R.graph["flow_value"]
 
 
 @nx._dispatchable(

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -77,7 +77,9 @@ def maximum_flow(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     NetworkXError
         The algorithm does not support MultiGraph and MultiDiGraph. If
         the input graph is an instance of one of these two classes, a
-        NetworkXError is raised.
+        NetworkXError is raised. It is also raised if `flow_func` is not
+        callable, or if keyword parameters are passed via ``kwargs``
+        without explicitly setting `flow_func`.
 
     NetworkXUnbounded
         If the graph has a path of infinite capacity, the value of a
@@ -121,7 +123,7 @@ def maximum_flow(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
 
     Specific algorithms may store extra data in :samp:`R`.
 
-    The function should supports an optional boolean parameter value_only. When
+    The function should support an optional boolean parameter value_only. When
     True, it can optionally terminate the algorithm as soon as the maximum flow
     value and the minimum cut can be determined.
 
@@ -233,7 +235,9 @@ def maximum_flow_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwa
     NetworkXError
         The algorithm does not support MultiGraph and MultiDiGraph. If
         the input graph is an instance of one of these two classes, a
-        NetworkXError is raised.
+        NetworkXError is raised. It is also raised if `flow_func` is not
+        callable, or if keyword parameters are passed via ``kwargs``
+        without explicitly setting `flow_func`.
 
     NetworkXUnbounded
         If the graph has a path of infinite capacity, the value of a
@@ -277,7 +281,7 @@ def maximum_flow_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwa
 
     Specific algorithms may store extra data in :samp:`R`.
 
-    The function should supports an optional boolean parameter value_only. When
+    The function should support an optional boolean parameter value_only. When
     True, it can optionally terminate the algorithm as soon as the maximum flow
     value and the minimum cut can be determined.
 
@@ -385,9 +389,17 @@ def minimum_cut(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
 
     Raises
     ------
+    NetworkXError
+        The algorithm does not support MultiGraph and MultiDiGraph. If
+        the input graph is an instance of one of these two classes, a
+        NetworkXError is raised. It is also raised if `flow_func` is not
+        callable, if keyword parameters are passed via ``kwargs`` without
+        explicitly setting `flow_func`, or if a cutoff is specified with
+        the :meth:`preflow_push` flow function.
+
     NetworkXUnbounded
         If the graph has a path of infinite capacity, all cuts have
-        infinite capacity and the function raises a NetworkXError.
+        infinite capacity and the function raises a NetworkXUnbounded.
 
     See also
     --------
@@ -426,7 +438,7 @@ def minimum_cut(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
 
     Specific algorithms may store extra data in :samp:`R`.
 
-    The function should supports an optional boolean parameter value_only. When
+    The function should support an optional boolean parameter value_only. When
     True, it can optionally terminate the algorithm as soon as the maximum flow
     value and the minimum cut can be determined.
 
@@ -554,9 +566,17 @@ def minimum_cut_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwar
 
     Raises
     ------
+    NetworkXError
+        The algorithm does not support MultiGraph and MultiDiGraph. If
+        the input graph is an instance of one of these two classes, a
+        NetworkXError is raised. It is also raised if `flow_func` is not
+        callable, if keyword parameters are passed via ``kwargs`` without
+        explicitly setting `flow_func`, or if a cutoff is specified with
+        the :meth:`preflow_push` flow function.
+
     NetworkXUnbounded
         If the graph has a path of infinite capacity, all cuts have
-        infinite capacity and the function raises a NetworkXError.
+        infinite capacity and the function raises a NetworkXUnbounded.
 
     See also
     --------
@@ -595,7 +615,7 @@ def minimum_cut_value(flowG, _s, _t, capacity="capacity", flow_func=None, **kwar
 
     Specific algorithms may store extra data in :samp:`R`.
 
-    The function should supports an optional boolean parameter value_only. When
+    The function should support an optional boolean parameter value_only. When
     True, it can optionally terminate the algorithm as soon as the maximum flow
     value and the minimum cut can be determined.
 


### PR DESCRIPTION
`maximum_flow_value` delegated to `maximum_flow`, so every call built the full flow dictionary via `build_flow_dict`  (a fresh dict-of-dicts over all nodes and edges) and immediately discarded it, keeping only the scalar value. This PR calls the flow function directly with `value_only=True` and returns the flow value from the residual network.

The `maximum_flow_value` already requires flow functions to support the `value_only` parameter, and `minimum_cut` / `minimum_cut_value` already invoke the flow function with `value_only=True`. This change helps improving run time in two ways: it skips the O(n + m) `build_flow_dict` construction on every call, and it lets algorithms that honor `value_only` terminate early (e.g. `preflow_push` skips its second phase, which computes the actual flows).

This change has a significant impact in flow based connectivity: both connectivity primitives return `nx.maximum_flow_value(...)` directly: `local_node_connectivity` and `local_edge_connectivity`; so this benefits everything built on them: `node_connectivity`, `edge_connectivity`, `all_node_cuts`, `k_components`, and the connectivity approximations.

The size of the gain depends on how expensive each max-flow is relative to the discarded dict. It is largest on sparse graphs, where every flow terminates after at most k augmentations (k small) while `build_flow_dict` still constructs a dict-of-dicts over the whole auxiliary graph on each call: profiling `node_connectivity` on `random_regular_graph(4, 2000, seed=42)` on current main, `build_flow_dict` accounts for 58% of the running time. On denser graphs the flow computation itself dominates and the gain is smaller but still visible.

Benchmarks (best of 5):

| benchmark | main | this PR |
|---|---|---|
| `node_connectivity`, `random_regular_graph(4, 2000)` (sparse) | 15.94s | 6.03s (~2.6x) |
| `node_connectivity`, `gnp_random_graph(120, 0.2)` (dense) | 0.365s | 0.231s (~1.6x) |
| `k_components`, `powerlaw_cluster_graph(200, 5, 0.3)` | 4.220s | 3.696s (~1.15x) |
