### PR TITLE
escape tuple labels in generate_gml

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -757,7 +757,7 @@ def generate_gml(G, stringizer=None):
                 yield indent + "]"
             elif isinstance(value, tuple) and key == "label":
                 label = f"({','.join(repr(v) for v in value)})"
-                yield indent + key + ' "' + escape(label) + '"'
+                yield f'{indent}{key} "{escape(label)}"'
             elif isinstance(value, list | tuple) and key != "label" and not in_list:
                 if len(value) == 0:
                     yield indent + key + " " + f'"{value!r}"'

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -756,7 +756,8 @@ def generate_gml(G, stringizer=None):
                     yield from stringize(key, value, (), next_indent)
                 yield indent + "]"
             elif isinstance(value, tuple) and key == "label":
-                yield indent + key + f' "({",".join(repr(v) for v in value)})"'
+                label = f"({','.join(repr(v) for v in value)})"
+                yield indent + key + ' "' + escape(label) + '"'
             elif isinstance(value, list | tuple) and key != "label" and not in_list:
                 if len(value) == 0:
                     yield indent + key + " " + f'"{value!r}"'

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -230,6 +230,19 @@ graph
 ]"""
         assert data == answer
 
+    def test_tuple_label_quote_escape(self):
+        # A tuple used as a label whose repr contains a double quote must be
+        # escaped like any other string, otherwise the extra quote closes the
+        # GML string early and lets crafted content inject nodes/attributes.
+        G = nx.Graph()
+        G.add_node(('x"] node [ id 99 label "pwn', "y"))
+        data = "\n".join(nx.generate_gml(G))
+        assert "&#34;" in data
+        assert '"pwn' not in data
+        H = nx.parse_gml(data)
+        assert len(H) == 1
+        assert list(H) == ["('x\"] node [ id 99 label \"pwn','y')"]
+
     def test_quotes(self, tmp_path):
         # https://github.com/networkx/networkx/issues/1061
         # Encoding quotes as HTML entities.

--- a/networkx/readwrite/tests/test_gml.py
+++ b/networkx/readwrite/tests/test_gml.py
@@ -241,7 +241,7 @@ graph
         assert '"pwn' not in data
         H = nx.parse_gml(data)
         assert len(H) == 1
-        assert list(H) == ["('x\"] node [ id 99 label \"pwn','y')"]
+        assert list(H) == ["""('x"] node [ id 99 label "pwn','y')"""]
 
     def test_quotes(self, tmp_path):
         # https://github.com/networkx/networkx/issues/1061


### PR DESCRIPTION
When a node or edge label is a tuple, generate_gml joins repr() of the elements directly into a quoted GML string without running it through escape() the way every other string value goes. A tuple element whose repr contains a double quote closes the string early, so a crafted label injects extra nodes, edges, or attributes into the output that another reader then parses back. The fix builds the tuple text and escapes it before emitting, so legitimate tuple labels are unchanged and quotes become the usual &#34; entities. Added a round-trip regression test alongside the existing tuple-label and quoting tests.