### PR TITLE
Speed up the residual flow reset in `edmonds_karp` and simplify the `minimum_cut` partition

### DIFF
--- a/networkx/algorithms/flow/edmondskarp.py
+++ b/networkx/algorithms/flow/edmondskarp.py
@@ -105,9 +105,14 @@ def edmonds_karp_impl(G, s, t, capacity, residual, cutoff):
     else:
         R = residual
 
-    # Initialize/reset the residual network.
-    for u in R:
-        for e in R[u].values():
+    # Initialize/reset the residual network: zero the flow on every
+    # edge. Iterating the internal adjacency dicts directly instead of
+    # the public views is ~3x faster here, which matters on workloads
+    # that run many small-cutoff flow computations on one reused
+    # residual network (e.g. node_connectivity): for these, this reset
+    # costs more than the flow computation itself.
+    for nbrs in R._succ.values():
+        for e in nbrs.values():
             e["flow"] = 0
 
     if cutoff is None:

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -471,18 +471,23 @@ def minimum_cut(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
         raise nx.NetworkXError("cutoff should not be specified.")
 
     R = flow_func(flowG, _s, _t, capacity=capacity, value_only=True, **kwargs)
-    # Remove saturated edges from the residual network
-    cutset = [(u, v, d) for u, v, d in R.edges(data=True) if d["flow"] == d["capacity"]]
-    R.remove_edges_from(cutset)
 
-    # Then, reachable and non reachable nodes from source in the
-    # residual network form the node partition that defines
-    # the minimum cut.
-    non_reachable = set(nx.shortest_path_length(R, target=_t))
+    # The nodes that reach _t in the residual network over edges with
+    # spare capacity (flow < capacity) form one side of the minimum
+    # cut, the rest the other (see the residual network conventions in
+    # the Notes): a reverse breadth-first search from _t.
+    non_reachable = {_t}
+    queue = [_t]
+    R_pred = R.pred
+    while queue:
+        next_layer = []
+        for v in queue:
+            for u, attr in R_pred[v].items():
+                if u not in non_reachable and attr["flow"] < attr["capacity"]:
+                    non_reachable.add(u)
+                    next_layer.append(u)
+        queue = next_layer
     partition = (set(flowG) - non_reachable, non_reachable)
-    # Finally add again cutset edges to the residual network to make
-    # sure that it is reusable.
-    R.add_edges_from(cutset)
     return (R.graph["flow_value"], partition)
 
 

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -478,7 +478,7 @@ def minimum_cut(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     # the Notes): a reverse breadth-first search from _t.
     non_reachable = {_t}
     queue = [_t]
-    R_pred = R.pred
+    R_pred = R._pred
     while queue:
         next_layer = []
         for v in queue:

--- a/networkx/algorithms/flow/tests/test_maxflow.py
+++ b/networkx/algorithms/flow/tests/test_maxflow.py
@@ -550,6 +550,25 @@ class TestMaxFlowMinCutInterface:
                         result = result[0]
                     assert fv == result, errmsg
 
+    def test_reusing_residual_after_edge_replacement(self):
+        # Replacing residual edges between runs rebuilds their attribute
+        # dicts without changing the edge count (and the copies retain
+        # stale flow values); flow functions must still reset and compute
+        # correctly, so any per-edge state cached across runs on the
+        # residual network must not trust previously seen dicts.
+        G = self.G
+        s, t = "x", "y"
+        R = build_residual_network(G, "capacity")
+        for flow_func in flow_funcs:
+            errmsg = f"Assertion failed in function: {flow_func.__name__}"
+            fv = nx.maximum_flow_value(G, s, t, flow_func=flow_func, residual=R)
+            for u, v in [("x", "a"), ("b", "c")]:
+                d = dict(R[u][v])
+                R.remove_edge(u, v)
+                R.add_edge(u, v, **d)
+            result = nx.maximum_flow_value(G, s, t, flow_func=flow_func, residual=R)
+            assert fv == result, errmsg
+
 
 # Tests specific to one algorithm
 def test_preflow_push_global_relabel_freq():


### PR DESCRIPTION
Two commits, both about the same hot path: workloads that run many flow computations on one reused residual network: `node_connectivity`, `all_node_cuts`, `k_components`, `gomory_hu_tree`, the connectivity approximations. Companion to #8754, which removed a different kind of waste (building and discarding the flow dict) from the same path; the two compose.

## Commit 1: `edmonds_karp` residual reset via the internal adjacency dicts

`edmonds_karp` zeroes the `flow` attribute of every residual edge before each run. Profiled on `node_connectivity` over a 2,129-node kernel of a real collaboration network (thousands of `edmonds_karp` calls at small cutoffs on one reused residual) this reset outweighed the actual flow work about 5:1, and nearly all of it was the public adjacency-view machinery rather than the assignments: 129M dict-view `__iter__` calls and 141M `coreviews.__getitem__` calls in a single `node_connectivity` computation, against 8.1s cumulative in the flow BFS itself.

The fix is to iterate the internal adjacency dicts directly instead of going through `R[u].values()` view objects. Reset semantics are unchanged: every edge, every call. Micro-benchmark, 2,000 resets on the kernel's 56,402-arc residual: 21.1s -> 6.9s (3.1x).

Rejected alternatives:

- *Touched-edge tracking* (reset only the edges the previous run modified): fastest, but its correctness invariant had to be defended by every other flow function and every caller that mutates a reused residual: an implicit cross-module contract with silent-wrongness as the failure mode.
- *A cached flat tuple of edge dicts*: broken by callers that remove and re-add residual edges (the attribute dicts are rebuilt), and `__networkx_cache__` cannot help because residual networks deliberately disable it (`build_residual_network` sets it to `None`; flow attributes are written via direct dict access, which bypasses `_clear_cache`).

The boring version keeps most of the win with zero staleness surface. A new test (`test_reusing_residual_after_edge_replacement`) pins the residual-reuse semantics that made the cached designs unsound, guarding any future attempt.

## Commit 2: `minimum_cut` partition without mutating the residual network

To extract the node partition, `minimum_cut` snapshotted all saturated edges, removed them from the residual network, ran `shortest_path_length` towards the sink, and re-added them "to make sure that it is reusable". This commit replaces the dance with a reverse breadth-first search from the sink over edges with `flow < capacity`; which is exactly how the residual-network documentation defines the induced minimum cut.

This is a simplification, not a fix: outputs are identical on every benchmark. It is also faster; the old version scanned every edge and traversed the whole residual, while the reverse BFS explores only the sink side of the cut:

| isolated partition step (per call, 200 reps) | old | new | speedup |
|---|---|---|---|
| `gnp(300, 0.05)` | 0.30ms | 0.004ms | 77x |
| `barabasi_albert(1000, 3)` | 0.46ms | 0.008ms | 56x |
| `grid_2d(30, 30)` | 0.27ms | 0.008ms | 35x |
| `gnp(1000, 0.01)` | 0.72ms | 0.009ms | 79x |

And it removes the last place in NetworkX that structurally mutates a residual network between reuses: after this, flow functions write flow attributes and nobody rebuilds edges, which keeps the residual-reuse contract simple.

## End-to-end effect (this branch vs current main, best of 3)

| benchmark | main | this PR |
|---|---|---|
| `gomory_hu_tree`, `gnp(300, 0.05)` with random capacities | 0.476s | 0.350s (1.36x) |
| `gomory_hu_tree`, `barabasi_albert(1000, 3)` with random capacities | 1.750s | 1.151s (1.52x) |
| `node_connectivity`, collaboration-network kernel (n=2,129, m=13,036) | 46.19s | 40.19s (1.15x) |

`gomory_hu_tree` shows the full effect of both commits (n - 1 `minimum_cut` calls on one reused residual, and it never built flow dicts). The `node_connectivity` gain looks muted on current main because the dominant waste there is the discarded flow dict that #8754 removes; with both PRs applied, the same kernel computation goes from 46.2s to 8.1s (5.7x). On exact `k_components` over real collaboration networks (where these kernels arise per connectivity level), the two PRs plus algorithm-level work in preparation combine to 2-3x end to end.
