### PR TITLE
MAINT: Avoid Louvain infinite loops

### DIFF
--- a/networkx/algorithms/community/louvain.py
+++ b/networkx/algorithms/community/louvain.py
@@ -99,7 +99,7 @@ def louvain_communities(
     --------
     >>> import networkx as nx
     >>> G = nx.petersen_graph()
-    >>> nx.community.louvain_communities(G, seed=123)
+    >>> nx.community.louvain_communities(G, seed=111)
     [{0, 4, 5, 7, 9}, {1, 2, 3, 6, 8}]
 
     Notes

--- a/networkx/algorithms/community/louvain.py
+++ b/networkx/algorithms/community/louvain.py
@@ -298,16 +298,16 @@ def _one_level(G, partition, m, resolution, is_directed, seed):
                 degree = degrees[u]
                 Stot[u_com] -= degree
                 x = Stot[u_com] * degree
-            move_cost = u_deg_by_com[u_com] * m - gamma * x
+            remove_cost = u_deg_by_com[u_com] * m - gamma * x
 
-            best_gain = 0
+            best_gain = remove_cost  # check that best_gain > remove_cost
             best_com = u_com
             for nbr_com, wt in u_deg_by_com.items():
                 if is_directed:
                     x = out_degree * Stot_in[nbr_com] + in_degree * Stot_out[nbr_com]
                 else:
                     x = Stot[nbr_com] * degree
-                gain = wt * m  - gamma * x
+                gain = wt * m - gamma * x
                 if gain > best_gain:
                     best_gain = gain
                     best_com = nbr_com

--- a/networkx/algorithms/community/louvain.py
+++ b/networkx/algorithms/community/louvain.py
@@ -298,18 +298,18 @@ def _one_level(G, partition, m, resolution, is_directed, seed):
                 degree = degrees[u]
                 Stot[u_com] -= degree
                 x = Stot[u_com] * degree
-            remove_cost = -u_deg_by_com[u_com] / m + gamma * x / m**2
+            move_cost = u_deg_by_com[u_com] * m - gamma * x
 
-            best_mod = 0
+            best_gain = 0
             best_com = u_com
             for nbr_com, wt in u_deg_by_com.items():
                 if is_directed:
                     x = out_degree * Stot_in[nbr_com] + in_degree * Stot_out[nbr_com]
                 else:
                     x = Stot[nbr_com] * degree
-                gain = remove_cost + wt / m - gamma * x / m**2
-                if gain > best_mod:
-                    best_mod = gain
+                gain = wt * m  - gamma * x
+                if gain > best_gain:
+                    best_gain = gain
                     best_com = nbr_com
 
             if is_directed:

--- a/networkx/algorithms/community/louvain.py
+++ b/networkx/algorithms/community/louvain.py
@@ -298,6 +298,11 @@ def _one_level(G, partition, m, resolution, is_directed, seed):
                 degree = degrees[u]
                 Stot[u_com] -= degree
                 x = Stot[u_com] * degree
+            # Formula for merging u with u_com (algebra on modularity formula)
+            # is sum(wts from u to u_com) / m - gamma * x / m**2.
+            # Remove cost is negative of merge gain. Need best_gain > remove_cost.
+            # We multiply by m**2 to avoid floating point errors.
+            # Does not change best_com.  See gh-8739.
             remove_cost = u_deg_by_com[u_com] * m - gamma * x
 
             best_gain = remove_cost  # check that best_gain > remove_cost
@@ -307,6 +312,10 @@ def _one_level(G, partition, m, resolution, is_directed, seed):
                     x = out_degree * Stot_in[nbr_com] + in_degree * Stot_out[nbr_com]
                 else:
                     x = Stot[nbr_com] * degree
+                # Formula for merging u with u_com (algebra on modularity formula)
+                # is sum(wts from u to nbr_com) / m - gamma * x / m**2.
+                # We multiply by m**2 to avoid floating point errors.
+                # Does not change best_com.  See gh-8739.
                 gain = wt * m - gamma * x
                 if gain > best_gain:
                     best_gain = gain

--- a/networkx/algorithms/community/tests/test_louvain.py
+++ b/networkx/algorithms/community/tests/test_louvain.py
@@ -262,3 +262,11 @@ def test_max_level():
         ValueError, match="max_level argument must be a positive integer"
     ):
         nx.community.louvain_communities(G, max_level=0)
+
+
+def test_inf_loops():
+    e = [(0, 1), (0, 2), (0, 5), (0, 6), (1, 2), (1, 4), (2, 3), (2, 5), (2, 6), (3, 4)]
+    G = nx.Graph(e)
+    P = nx.community.louvain_communities(G, weight="weight", seed=123)
+    # not an infinite loop!  But still check whether ties change output
+    assert {frozenset(C) for C in P} == {frozenset({0, 2, 5, 6}), frozenset({1, 3, 4})}

--- a/networkx/algorithms/community/tests/test_louvain.py
+++ b/networkx/algorithms/community/tests/test_louvain.py
@@ -270,3 +270,10 @@ def test_inf_loops():
     P = nx.community.louvain_communities(G, weight="weight", seed=123)
     # not an infinite loop!  But still check whether ties change output
     assert {frozenset(C) for C in P} == {frozenset({0, 2, 5, 6}), frozenset({1, 3, 4})}
+
+
+def test_petersen():
+    G = nx.petersen_graph()
+    expected = {frozenset(c) for c in ({0, 4, 5, 7, 9}, {1, 2, 3, 6, 8})}
+    P = nx.community.louvain_communities(G, weight="weight", seed=111)
+    assert {frozenset(C) for C in P} == expected

--- a/networkx/algorithms/community/tests/test_louvain.py
+++ b/networkx/algorithms/community/tests/test_louvain.py
@@ -265,6 +265,8 @@ def test_max_level():
 
 
 def test_inf_loops():
+    # Graph Atlas G674 had an inf loop. See gh-8739.
+    # Multiply formula by m**2 to avoid floating point trouble to fix it.
     e = [(0, 1), (0, 2), (0, 5), (0, 6), (1, 2), (1, 4), (2, 3), (2, 5), (2, 6), (3, 4)]
     G = nx.Graph(e)
     P = nx.community.louvain_communities(G, weight="weight", seed=123)


### PR DESCRIPTION
Fixes #8739   (Louvain infinite loop on simple graph

The infinite loops are caused by round-off error (ties) when finding the best community for `u` to move to. We want to keep `u` where it is unless another community is strictly better. So round-off is trouble because equal scores appear as not equal.

I played with `math.isclose`, but avoiding floating point issues is subtle when inputs are not known. I then realized that the `gain` formulas (delta_func in Leiden) have `m**2` in the denominator. Dividing by large numbers before comparing is a good way to create round-off trouble. And we can multiply the formula by `m**2` without changing which community is the best.  This is also nice because it makes it more likely that we could be comparing integers (only if all weights and also param `resolution` are integers) which would eliminate round-off.  But the main point is that **not** dividing by `m**2` makes the expression have smaller (relative) round-off error.

The infinite loop test just takes forever when the infinite loop is present. We could use pytest-timeout to mark the test  so it fails if not completed within a specified time. But that adds a testing dependency and this shouldn't need it when its fixed. I can certainly add timeout marks if that is preferred.
