### PR TITLE
MAINT: avoid timeouts on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ jobs:
             export OMP_NUM_THREADS=1
             source venv/bin/activate
             make -C doc/ SPHINXOPTS="-j 2" html
+          no_output_timeout: 30m
 
       - store_artifacts:
           path: doc/build/html


### PR DESCRIPTION
It looks like the doc builds have a gallery step that is often taking more than the 10 minute limit without any output. I'm not sure if this will go away with planned changes. But it is annoying to not be able to see the docs for the PRs.  I'm thinking we can revert to the 10m timeout later if needed.

This PR extends the timeout-without-output to 30m for the documentation build.