### PR TITLE
write lowercase xsd:boolean literals in graphml writer

### DIFF
--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -549,7 +549,12 @@ class GraphMLWriter(GraphML):
             # add subelement for data default value if present
             if default is not None:
                 default_element = self.myElement("default")
-                default_element.text = str(default)
+                # xsd:boolean literals are lowercase; str(True) -> "True" is
+                # not a valid boolean value for other GraphML readers.
+                if attr_type == self.get_xml_type(bool):
+                    default_element.text = str(default).lower()
+                else:
+                    default_element.text = str(default)
                 key_element.append(default_element)
             self.xml.insert(0, key_element)
         return new_id
@@ -565,7 +570,12 @@ class GraphMLWriter(GraphML):
             )
         keyid = self.get_key(name, self.get_xml_type(element_type), scope, default)
         data_element = self.myElement("data", key=keyid)
-        data_element.text = str(value)
+        # xsd:boolean literals are lowercase; str(True) -> "True" is not a valid
+        # boolean value for other GraphML readers.
+        if element_type is bool:
+            data_element.text = str(value).lower()
+        else:
+            data_element.text = str(value)
         return data_element
 
     def add_attributes(self, scope, xml_obj, data, default):

--- a/networkx/readwrite/tests/test_graphml.py
+++ b/networkx/readwrite/tests/test_graphml.py
@@ -1124,6 +1124,25 @@ class TestWriteGraphML(BaseGraphML):
         H = G.copy()
         gmlw.add_graphs([G, H])
 
+    def test_boolean_written_as_lowercase(self):
+        # boolean-typed data and defaults must use the xsd:boolean literals
+        # 'true'/'false', not Python's 'True'/'False'.
+        G = nx.Graph()
+        G.graph["node_default"] = {"flag": True}
+        G.add_node(0, flag=True)
+        G.add_node(1, flag=False)
+        fh = io.BytesIO()
+        self.writer(G, fh)
+        text = fh.getvalue().decode("utf-8")
+        assert ">true<" in text
+        assert ">false<" in text
+        assert ">True<" not in text
+        assert ">False<" not in text
+        fh.seek(0)
+        H = nx.read_graphml(fh)
+        assert H.nodes["0"]["flag"] is True
+        assert H.nodes["1"]["flag"] is False
+
     def test_write_read_simple_no_prettyprint(self):
         G = self.simple_directed_graph
         G.graph["hi"] = "there"


### PR DESCRIPTION
The GraphML writer serializes boolean data and defaults with str(value), so a key declared attr.type="boolean" ends up holding Python's True/False as its text. xsd:boolean only permits true/false/0/1, so other GraphML readers (yEd, the Java reference reader) reject or misread the output even though networkx reads it back fine. Handle the bool case in the shared add_data and get_key so both the lxml and stdlib writers emit lowercase literals, and values still round-trip to Python bools.