### PR TITLE
DOC: Add example of floating point handling for maximum_flow capacity

### DIFF
--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -178,10 +178,11 @@ def maximum_flow(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     We recommend converting floating point to integers when possible based on your
     knowledge of the weight values and the precision needed. For 6 digits:
 
+    >>> precision = 1e6
     >>> flow_value, _ = nx.maximum_flow(
-    ...     G, 0, 1, capacity=lambda u, v, d: int(1e6 * d["capacity"])
+    ...     G, 0, 1, capacity=lambda u, v, d: int(precision * d["capacity"])
     ... )
-    >>> flow_value / 1e6 == 0.9
+    >>> flow_value / precision == 0.9
     True
 
     """

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -157,8 +157,7 @@ def maximum_flow(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     >>> flow_value == nx.maximum_flow(G, "x", "y", flow_func=sap)[0]
     True
 
-    Floating point values can cause round-off errors which dramatically change
-    results. For example:
+    Floating point values can cause round-off errors which change results. For example:
 
     >>> G = nx.DiGraph()
     >>> nx.add_path(G, (0, "a", 1))
@@ -167,7 +166,8 @@ def maximum_flow(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     >>> nx.set_edge_attributes(G, {e: 0.3 for e in G.edges}, "capacity")
 
     All weights are 0.3 which cannot be represented exactly in binary floating point.
-    So the total flow is off by a little bit.
+    So the total flow is off a little. In a more complex network the small differences
+    can become larger, and can lead to incorrect flow patterns and/or cut partitions.
 
     >>> flow_value, flow_dict = nx.maximum_flow(G, 0, 1)
     >>> flow_value

--- a/networkx/algorithms/flow/maxflow.py
+++ b/networkx/algorithms/flow/maxflow.py
@@ -153,10 +153,35 @@ def maximum_flow(flowG, _s, _t, capacity="capacity", flow_func=None, **kwargs):
     You can also use alternative algorithms for computing the
     maximum flow by using the flow_func parameter.
 
-    >>> from networkx.algorithms.flow import shortest_augmenting_path
-    >>> flow_value == nx.maximum_flow(G, "x", "y", flow_func=shortest_augmenting_path)[
-    ...     0
-    ... ]
+    >>> sap = nx.flow.shortest_augmenting_path
+    >>> flow_value == nx.maximum_flow(G, "x", "y", flow_func=sap)[0]
+    True
+
+    Floating point values can cause round-off errors which dramatically change
+    results. For example:
+
+    >>> G = nx.DiGraph()
+    >>> nx.add_path(G, (0, "a", 1))
+    >>> nx.add_path(G, (0, "b", 1))
+    >>> nx.add_path(G, (0, "c", 1))
+    >>> nx.set_edge_attributes(G, {e: 0.3 for e in G.edges}, "capacity")
+
+    All weights are 0.3 which cannot be represented exactly in binary floating point.
+    So the total flow is off by a little bit.
+
+    >>> flow_value, flow_dict = nx.maximum_flow(G, 0, 1)
+    >>> flow_value
+    0.8999999999999999
+    >>> flow_value == 0.9
+    False
+
+    We recommend converting floating point to integers when possible based on your
+    knowledge of the weight values and the precision needed. For 6 digits:
+
+    >>> flow_value, _ = nx.maximum_flow(
+    ...     G, 0, 1, capacity=lambda u, v, d: int(1e6 * d["capacity"])
+    ... )
+    >>> flow_value / 1e6 == 0.9
     True
 
     """


### PR DESCRIPTION
This PR adds an example to the doc_string for `maximum_flow`. The example shows how one can use the `capacity` kwarg as a function to adjust the weights to integers and eliminate round-off errors.

This is possible because of #8406 which enabled functions in the `capacity` kwarg.
There are many other functions where this sort of thing could be done. Perhaps long term we want to discuss floating point errors in one place of the docs and point to it from others. That one place could also point to doc_strings for each suite of functions where one example is housed for that suite.  For example, this would be the canonical example for flow and cut functions. Those functions would point to the main page which would explain the trouble and solution as well as house a list of pointers to examples, the "flow and cut" example could be this one.

An example like this first appeared in #8402.