### PR TITLE
Fix bare except clause in networkx/readwrite/graphml.py

### DIFF
--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -408,7 +408,7 @@ class GraphML:
         # These additions to types allow writing numpy types
         try:
             import numpy as np
-        except:
+        except ImportError:
             pass
         else:
             # prepend so that python types are created upon read (last entry wins)


### PR DESCRIPTION
Replace bare `except:` with `except ImportError:` in the numpy import fallback block.

Bare `except:` catches `BaseException` (including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`), which is almost never intended. Since this block is catching a failed numpy import, `except ImportError:` is the correct specific exception type.