### PR TITLE
ENH: add ALT algorithm for shortest_path astar heuristics

### DIFF
--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -322,7 +322,7 @@ def alt_heuristic(G, k=8, weight="weight", method="farthest", seed=None):
 
         d(u, v) \geq d(u, \ell) - d(v, \ell)
         \qquad
-        d(u, v) \geq d(\ell, u) - d(\ell, v)
+        d(u, v) \geq d(\ell, v) - d(\ell, u)
 
     The heuristic returns the maximum of these bounds over all landmarks, or 0 if no landmark
     yields a finite bound (for example, across disconnected components).

--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -242,7 +242,9 @@ def astar_path_length(
 
 @py_random_state("seed")
 @nx._dispatchable(edge_attrs="weight")
-def alt_heuristic(G, k=8, weight="weight", method="farthest", seed=None):
+def alt_heuristic(
+    G, k=8, weight="weight", method="farthest", landmarks=None, seed=None
+):
     r"""Returns an ALT (A*, Landmarks, Triangle inequality) heuristic for graph `G`.
 
     It selects `k` landmark nodes and computes shortest-path distances between every
@@ -262,7 +264,7 @@ def alt_heuristic(G, k=8, weight="weight", method="farthest", seed=None):
     k : int, optional (default=8)
         Number of landmarks to select. Larger values give tighter bounds at the cost of more
         preprocessing time and ``O(k * n)`` memory (``O(2 * k * n)`` for directed graphs).
-        Values greater than ``len(G)`` are capped.
+        Values greater than ``len(G)`` are capped. Ignored when `landmarks` is given.
 
     weight : string or function
         If this is a string, then edge weights will be accessed via the
@@ -280,7 +282,14 @@ def alt_heuristic(G, k=8, weight="weight", method="farthest", seed=None):
         Landmark selection strategy. ``"farthest"`` greedily selects landmarks that are
         far apart: the first landmark is chosen uniformly at random and each subsequent
         landmark maximizes the shortest-path distance to its nearest already-selected landmark.
-        ``"random"`` selects `k` landmarks uniformly at random.
+        ``"random"`` selects `k` landmarks uniformly at random. Ignored when `landmarks` is given.
+
+    landmarks : list of nodes, optional (default=None)
+        An explicit collection of nodes in `G` to use as landmarks. When provided, these nodes
+        are used directly and the automatic selection is skipped, so `k` and `method` are
+        ignored. Good landmarks are far apart and near the "corners" of the graph; poorly
+        placed landmarks remain admissible but give looser bounds. Every node must be in `G`
+        and the collection must be non-empty.
 
     seed : integer, random_state, or None (default)
         Indicator of random number generation state.
@@ -303,6 +312,12 @@ def alt_heuristic(G, k=8, weight="weight", method="farthest", seed=None):
 
     ValueError
         If `method` is not ``"farthest"`` or ``"random"``.
+
+    NetworkXError
+        If `landmarks` is given but empty.
+
+    NodeNotFound
+        If `landmarks` contains a node that is not in `G`.
 
     Examples
     --------
@@ -338,24 +353,37 @@ def alt_heuristic(G, k=8, weight="weight", method="farthest", seed=None):
     https://www.cs.princeton.edu/courses/archive/spr06/cos423/Handouts/GH05.pdf
     """
 
-    if k < 1:
-        raise nx.NetworkXError(f"Number of landmarks k={k} must be at least 1.")
     if len(G) == 0:
         raise nx.NetworkXPointlessConcept(
             "ALT heuristic is undefined for empty graphs."
         )
-    if method not in {"farthest", "random"}:
-        raise ValueError(
-            f"Unknown landmark selection method: {method}, must be 'farthest' or 'random'."
-        )
-
-    k = min(k, len(G))
+    if landmarks is not None:
+        landmarks = list(landmarks)
+        if len(landmarks) == 0:
+            raise nx.NetworkXError("Landmarks must contain at least one node.")
+        for node in landmarks:
+            if node not in G:
+                raise nx.NodeNotFound(f"Landmark {node!r} is not a node in G.")
+    else:
+        if k < 1:
+            raise nx.NetworkXError(f"Number of landmarks k={k} must be at least 1.")
+        if method not in {"farthest", "random"}:
+            raise ValueError(
+                f"Unknown landmark selection method: {method}, must be 'farthest' or 'random'."
+            )
+        k = min(k, len(G))
 
     inf = float("inf")
     nodes = list(G)
 
     # Select landmarks and compute distances *from* each landmark.
-    if method == "random":
+    if landmarks is not None:
+        # User-supplied landmarks are used directly.
+        dist_from = [
+            nx.single_source_dijkstra_path_length(G, landmark, weight=weight)
+            for landmark in landmarks
+        ]
+    elif method == "random":
         landmarks = seed.sample(nodes, k)
         dist_from = [
             nx.single_source_dijkstra_path_length(G, landmark, weight=weight)

--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -5,8 +5,9 @@ from itertools import count
 
 import networkx as nx
 from networkx.algorithms.shortest_paths.weighted import _weight_function
+from networkx.utils import py_random_state
 
-__all__ = ["astar_path", "astar_path_length"]
+__all__ = ["astar_path", "astar_path_length", "alt_heuristic"]
 
 
 @nx._dispatchable(edge_attrs="weight", preserve_node_attrs="heuristic")
@@ -237,3 +238,170 @@ def astar_path_length(
     weight = _weight_function(G, weight)
     path = astar_path(G, source, target, heuristic, weight, cutoff=cutoff)
     return sum(weight(u, v, G[u][v]) for u, v in zip(path[:-1], path[1:]))
+
+
+@py_random_state("seed")
+@nx._dispatchable(edge_attrs="weight")
+def alt_heuristic(G, k=8, weight="length", method="farthest", seed=None):
+    """Returns an ALT (A*, Landmarks, Triangle inequality) heuristic for graph `G`.
+
+    It selects `k` landmark nodes and computes shortest-path distances between every
+    node and each landmark (one Dijkstra sweep per landmark, two on directed graphs).
+    The returned function ``h(u,v)`` us a lower bound on the shortest-path distance
+    from ``u`` to ``v`` obtained from the triangle inequality, and can be passed
+    directly as the ``heuristic`` argument of :func:`astar_path` or :func:`astar_path_length`.
+
+    The heuristic is admissible (it never overestimates the true distance) and consistent,
+    so A* retains its optimality guarantee. The one-time preprocessing cost is amortized over
+    repeated shortest-path queries on the same graph.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+
+    k : int, optional (default=8)
+        Number of landmarks to select. Larger values give tighter bounds at the cost of more
+        preprocessing time and ``O(k * n)`` memory (``O(2 * k * n)`` for directed graphs).
+        Values greater than ``len(G)`` are capped.
+
+    weight : string or function
+        If this is a string, then edge weights will be accessed via the
+        edge attribute with this key (that is, the weight of the edge
+        joining `u` to `v` will be ``G.edges[u, v][weight]``). If no
+        such edge attribute exists, the weight of the edge is assumed to
+        be one.
+        If this is a function, the weight of an edge is the value
+        returned by the function. The function must accept exactly three
+        positional arguments: the two endpoints of an edge and the
+        dictionary of edge attributes for that edge. The function must
+        return a number or None to indicate a hidden edge.
+
+    method : string, optional (default="farthest")
+        Landmark selection strategy. ``"farthest"`` greedily selects landmarks that are
+        far apart: the first landmark is chosen uniformly at random and each subsequent
+        landmark maximizes the shortest-path distance to its nearest already-selected landmark.
+        ``"random"`` selects `k` landmarks uniformly at random.
+
+    seed : integer, random_state, or None (default)
+        Indicator of random number generation state.
+        See :ref:`Randomness<randomness>`.
+
+    Returns
+    -------
+    heuristic : callable
+        A function ``h(u,v)`` that returns a lower bound on the shortest-path distance from
+        ``u`` to ``v`` in `G`. The function is admissible and consistent. Suitable for the
+        ``heuristic`` argument of :func:`astar_path` or :func:`astar_path_length`.
+
+    Raises
+    ------
+    NetworkXError
+        If `k` is less than 1.
+
+    NetworkXPointlessConcept
+        If `G` is empty.
+
+    ValueError
+        If `method` is not ``"farthest"`` or ``"random"``.
+
+    Examples
+    --------
+    >>> G = nx.path_graph(5)
+    >>> h = nx.alt_heuristic(G, k=2, seed=10)
+    >>> nx.astar_path(G, 0, 4, heuristic=h)
+    [0, 1, 2, 3, 4]
+    >>> h(0, 4)
+    4
+
+    Notes
+    -----
+    For each landmark :math:`\ell` with precomputed distances, the triangle inequality yields
+    two lower bounds on the distance :math:`d(u, v)`:
+
+    .. math::
+
+        d(u, v) \geq |d(u, \ell) - d(v, \ell)|
+        \qquad
+        d(u, v) \geq |d(\ell, u) - d(\ell, v)|
+
+    The heuristic returns the maximum of these bounds over all landmarks, or 0 if no landmark
+    yields a finite bound (for example, across disconnected components).
+
+    All shortest-path queries answered with this heuristic must use the same `weight` attribute
+    that was used to build it; using a different weight may make the heuristic inadmissible and
+    A* may return suboptimal paths.
+
+    References
+    ----------
+    ..  [1] Goldberg, Andrew V., and Chris Harrelson. "Computing the shortest path: A search
+    meets graph theory." In SODA, vol. 5, pp. 156-165. 2005.
+    https://www.cs.princeton.edu/courses/archive/spr06/cos423/Handouts/GH05.pdf
+    """
+
+    if k < 1:
+        raise nx.NetworkXError(f"Number of landmarks k={k} must be at least 1.")
+    if len(G) == 0:
+        raise nx.NetworkXPointlessConcept(
+            "ALT heuristic is undefined for empty graphs."
+        )
+    if method not in {"farthest", "random"}:
+        raise ValueError(
+            f"Unknown landmark selection method: {method}, must be 'farthest' or 'random'."
+        )
+
+    k = min(k, len(G))
+
+    inf = float("inf")
+    nodes = list(G)
+
+    # Select landmarks and compute distances *from* each landmark.
+    if method == "random":
+        landmarks = seed.sample(nodes, k)
+        dist_from = [
+            nx.single_source_dijkstra_path_length(G, landmark, weight=weight)
+            for landmark in landmarks
+        ]
+    elif method == "farthest":
+        # Greedy farthest-point selection. Unreachable nodes are at distance infinity from each landmark,
+        # so they are selected first, placing landmarks in every component.
+        landmarks = [seed.choice(nodes)]
+        dist_from = [
+            nx.single_source_dijkstra_path_length(G, landmarks[0], weight=weight)
+        ]
+        nearest = {v: dist_from[0].get(v, inf) for v in nodes}
+        while len(landmarks) < k:
+            chosen = set(landmarks)
+            farthest = max(
+                (v for v in nodes if v not in chosen), key=nearest.__getitem__
+            )
+            landmarks.append(farthest)
+            dists = nx.single_source_dijkstra_path_length(G, farthest, weight=weight)
+            dist_from.append(dists)
+            for v, d in dists.items():
+                if d < nearest[v]:
+                    nearest[v] = d
+
+    # Distances *to* each landmark. On undirected graphs these equal the distances from each landmark,
+    # so the same tables are reused.
+    if G.is_directed():
+        dist_to = [
+            nx.single_source_dijkstra_path_length(
+                G.reverse(copy=False), landmark, weight=weight
+            )
+            for landmark in landmarks
+        ]
+    else:
+        dist_to = dist_from
+
+    def heuristic(u, v):
+        best = 0
+        for d_from, d_to in zip(dist_from, dist_to):
+            u_to, v_to = d_to.get(u, inf), d_to.get(v, inf)
+            if u_to < inf and v_to < inf and u_to - v_to > best:
+                best = u_to - v_to
+            u_from, v_from = d_from.get(u, inf), d_from.get(v, inf)
+            if u_from < inf and v_from < inf and v_from - u_from > best:
+                best = v_from - u_from
+        return best
+
+    return heuristic

--- a/networkx/algorithms/shortest_paths/astar.py
+++ b/networkx/algorithms/shortest_paths/astar.py
@@ -242,12 +242,12 @@ def astar_path_length(
 
 @py_random_state("seed")
 @nx._dispatchable(edge_attrs="weight")
-def alt_heuristic(G, k=8, weight="length", method="farthest", seed=None):
-    """Returns an ALT (A*, Landmarks, Triangle inequality) heuristic for graph `G`.
+def alt_heuristic(G, k=8, weight="weight", method="farthest", seed=None):
+    r"""Returns an ALT (A*, Landmarks, Triangle inequality) heuristic for graph `G`.
 
     It selects `k` landmark nodes and computes shortest-path distances between every
     node and each landmark (one Dijkstra sweep per landmark, two on directed graphs).
-    The returned function ``h(u,v)`` us a lower bound on the shortest-path distance
+    The returned function ``h(u,v)`` is a lower bound on the shortest-path distance
     from ``u`` to ``v`` obtained from the triangle inequality, and can be passed
     directly as the ``heuristic`` argument of :func:`astar_path` or :func:`astar_path_length`.
 
@@ -320,9 +320,9 @@ def alt_heuristic(G, k=8, weight="length", method="farthest", seed=None):
 
     .. math::
 
-        d(u, v) \geq |d(u, \ell) - d(v, \ell)|
+        d(u, v) \geq d(u, \ell) - d(v, \ell)
         \qquad
-        d(u, v) \geq |d(\ell, u) - d(\ell, v)|
+        d(u, v) \geq d(\ell, u) - d(\ell, v)
 
     The heuristic returns the maximum of these bounds over all landmarks, or 0 if no landmark
     yields a finite bound (for example, across disconnected components).
@@ -333,7 +333,7 @@ def alt_heuristic(G, k=8, weight="length", method="farthest", seed=None):
 
     References
     ----------
-    ..  [1] Goldberg, Andrew V., and Chris Harrelson. "Computing the shortest path: A search
+    ..  [1] Goldberg, Andrew V., and Chris Harrelson. "Computing the shortest path: A* search
     meets graph theory." In SODA, vol. 5, pp. 156-165. 2005.
     https://www.cs.princeton.edu/courses/archive/spr06/cos423/Handouts/GH05.pdf
     """

--- a/networkx/algorithms/shortest_paths/tests/test_astar.py
+++ b/networkx/algorithms/shortest_paths/tests/test_astar.py
@@ -252,3 +252,39 @@ class TestAStar:
         G = nx.gnp_random_graph(10, 0.2, seed=10)
         with pytest.raises(nx.NodeNotFound):
             nx.astar_path_length(G, 11, 9)
+
+    def test_alt_heuristic(self):
+        """Tests that alt_heuristic returns a heuristic function
+        that is admissible and consistent"""
+        G = nx.grid_graph(dim=[5, 5])  # nodes are two-tuples (x,y)
+        h = nx.alt_heuristic(G, k=4, weight="weight", method="farthest", seed=10)
+        for u in G.nodes():
+            for v in G.nodes():
+                assert h(u, v) <= nx.shortest_path_length(G, u, v)
+
+    def test_alt_heuristic_k_greater_than_nodes(self):
+        """Tests that alt_heuristic caps k at the number of nodes in the graph"""
+        G = nx.grid_graph(dim=[3, 3])
+        h = nx.alt_heuristic(G, k=10, weight="weight", method="farthest", seed=10)
+        for u in G.nodes():
+            for v in G.nodes():
+                assert h(u, v) <= nx.shortest_path_length(G, u, v)
+
+    def test_alt_heuristic_negative_k(self):
+        """Tests that alt_heuristic raises NetworkXError for negative k"""
+        G = nx.grid_graph(dim=[3, 3])
+        with pytest.raises(nx.NetworkXError):
+            nx.alt_heuristic(G, k=-1, weight="weight", method="farthest", seed=10)
+
+    def test_alt_heuristic_zero_k(self):
+        """Tests that alt_heuristic raises NetworkXError for k=0"""
+        G = nx.grid_graph(dim=[3, 3])
+        with pytest.raises(nx.NetworkXError):
+            nx.alt_heuristic(G, k=0, weight="weight", method="farthest", seed=10)
+
+    def test_alt_heuristic_invalid_method(self):
+        """Tests that alt_heuristic raises ValueError for invalid
+        method (not 'farthest' or 'random')"""
+        G = nx.grid_graph(dim=[3, 3])
+        with pytest.raises(ValueError):
+            nx.alt_heuristic(G, k=4, weight="weight", method="invalid", seed=10)

--- a/networkx/algorithms/shortest_paths/tests/test_astar.py
+++ b/networkx/algorithms/shortest_paths/tests/test_astar.py
@@ -1,3 +1,5 @@
+import random
+
 import pytest
 
 import networkx as nx
@@ -288,3 +290,66 @@ class TestAStar:
         G = nx.grid_graph(dim=[3, 3])
         with pytest.raises(ValueError):
             nx.alt_heuristic(G, k=4, weight="weight", method="invalid", seed=10)
+
+    def test_alt_heuristic_empty_graph(self):
+        with pytest.raises(nx.NetworkXPointlessConcept):
+            nx.alt_heuristic(nx.Graph())
+
+    def test_alt_heuristic_default_weight_directed(self):
+        # Regression guard: with default arguments on a directed weighted graph,
+        # the heuristic must stay admissible
+        G = self._weighted_random_graph(25, 120, seed=10, directed=True)
+        h = nx.alt_heuristic(G, k=4, seed=10)
+        assert self._admissible(G, h)
+
+    def test_alt_heuristic_directed_consistent(self):
+        G = self._weighted_random_graph(25, 120, seed=2, directed=True)
+        h = nx.alt_heuristic(G, k=6, weight="weight", seed=3)
+        assert self._admissible(G, h)
+        assert self._consistent(G, h)
+
+    def test_alt_heuristic_random_method(self):
+        G = nx.grid_2d_graph(5, 5)
+        nx.set_edge_attributes(G, 1, "weight")
+        h = nx.alt_heuristic(G, k=4, weight="weight", method="random", seed=7)
+        assert self._admissible(G, h)
+
+    def test_alt_heuristic_disconnected(self):
+        G = nx.disjoint_union(nx.path_graph(5), nx.cycle_graph(5))
+        nx.set_edge_attributes(G, 1, "weight")
+        h = nx.alt_heuristic(G, k=3, weight="weight", seed=0)
+        assert all(0 <= h(u, 7) < float("inf") for u in G)
+
+    def test_alt_heuristic_matches_dijkstra(self):
+        G = self._weighted_random_graph(40, 150, seed=3, directed=True)
+        h = nx.alt_heuristic(G, k=8, weight="weight", seed=0)
+        rng = random.Random(0)
+        pairs = 0
+        while pairs < 15:
+            s, t = rng.sample(list(G), 2)
+            if not nx.has_path(G, s, t):
+                continue
+            pairs += 1
+            assert nx.astar_path_length(
+                G, s, t, heuristic=h, weight="weight"
+            ) == pytest.approx(nx.dijkstra_path_length(G, s, t, weight="weight"))
+
+    def _admissible(self, G, h, weight="weight"):
+        true = dict(nx.all_pairs_dijkstra_path_length(G, weight=weight))
+        return all(h(u, t) <= true[u].get(t, float("inf")) + 1e-9 for t in G for u in G)
+
+    def _consistent(self, G, h, weight="weight"):
+        for t in G:
+            for u, v, d in G.edges(data=True):
+                w = d.get(weight, 1)
+                if h(u, t) > w + h(v, t) + 1e-9:
+                    return False
+                if not G.is_directed() and h(v, t) > w + h(u, t) + 1e-9:
+                    return False
+        return True
+
+    def _weighted_random_graph(self, n, m, seed, directed=False):
+        G = nx.gnm_random_graph(n, m, seed=seed, directed=directed)
+        for u, v in G.edges():
+            G[u][v]["weight"] = random.Random(u * 31 + v).uniform(0.1, 5)
+        return G

--- a/networkx/algorithms/shortest_paths/tests/test_astar.py
+++ b/networkx/algorithms/shortest_paths/tests/test_astar.py
@@ -320,6 +320,38 @@ class TestAStar:
         h = nx.alt_heuristic(G, k=3, weight="weight", seed=0)
         assert all(0 <= h(u, 7) < float("inf") for u in G)
 
+    def test_alt_heuristic_explicit_landmarks(self):
+        """Tests that alt_heuristic accepts an explicit list of landmarks and
+        stays admissible"""
+        G = nx.grid_graph(dim=[5, 5])  # nodes are two-tuples (x,y)
+        nx.set_edge_attributes(G, 1, "weight")
+        landmarks = [(0, 0), (4, 4)]
+        h = nx.alt_heuristic(G, weight="weight", landmarks=landmarks)
+        for u in G.nodes():
+            for v in G.nodes():
+                assert h(u, v) <= nx.shortest_path_length(G, u, v, weight="weight")
+
+    def test_alt_heuristic_explicit_landmarks_ignores_k_method(self):
+        """Explicit landmarks are used directly, so an otherwise-invalid k or
+        method does not raise"""
+        G = nx.grid_graph(dim=[3, 3])
+        h = nx.alt_heuristic(G, k=0, method="invalid", landmarks=[(0, 0)])
+        assert h((0, 0), (2, 2)) <= nx.shortest_path_length(G, (0, 0), (2, 2))
+
+    def test_alt_heuristic_empty_landmarks(self):
+        """Tests that alt_heuristic raises NetworkXError for an empty
+        landmarks list"""
+        G = nx.grid_graph(dim=[3, 3])
+        with pytest.raises(nx.NetworkXError):
+            nx.alt_heuristic(G, landmarks=[])
+
+    def test_alt_heuristic_landmark_not_in_graph(self):
+        """Tests that alt_heuristic raises NodeNotFound when a landmark is not
+        a node in G"""
+        G = nx.grid_graph(dim=[3, 3])
+        with pytest.raises(nx.NodeNotFound):
+            nx.alt_heuristic(G, landmarks=[(0, 0), "not-a-node"])
+
     def test_alt_heuristic_matches_dijkstra(self):
         G = self._weighted_random_graph(40, 150, seed=3, directed=True)
         h = nx.alt_heuristic(G, k=8, weight="weight", seed=0)


### PR DESCRIPTION
This PR implements the "alt_heuristic" function in algorithm/shortest_path/astar.py along with necessary unit tests and coding conventions, addressing discussion #8763 

The ALT algorithm incorporates A* with Landmark selection and triangle inequalities to introduce a more time-efficient way of computing the shortest path between O-D in large graph contexts. 

1. It starts with a pre-processing step of computing "landmarks" on the provided maps and calculating their distances to nodes using Dijkstra's algorithm.
2. When being used within the A* algorithm, the algorithm uses the alt heuristic's distances to select the next node to advance to. It scans the next node using all the pre-computed distances from landmarks and uses triangle inequalities to give a better approximation of the distance to the destination. This reduces the # of edges compared to a classic A* algorithm with direct node-to-destination distance estimate, as direct distance representation does not necessarily identify the closest node to the destination in the graph network.

Evidence from https://github.com/peterhxk/BIXIMapping:
I implemented ALT (A*, Landmarks, Triangle inequality) for a bike-share route-inference pipeline over the Montreal street network: an OSMnx-derived MultiDiGraph (~163K nodes / ~513K edges). It solved 500K+ OD shortest-path queries. Against NetworkX's weighted Dijkstra (single_source_dijkstra, weight="length"), ALT with 8 farthest-point landmarks reduced mean settled nodes per query by 91% and median wall-clock by 85% (235 ms → 35 ms/query), while returning identical-cost paths. Preprocessing is a one-time ~15 s (two Dijkstra sweeps per landmark, forward and reversed, for the directed graph), amortized across the full query set.

Reference: Goldberg, Andrew V., and Chris Harrelson. "Computing the shortest path: A* search meets graph theory." In SODA, vol. 5, pp. 156-165. 2005.

Documentation is properly followed against the Contribution rubric. One small concern is that the reference paper has no official public copy link. I still included an available one from Princeton's archives.

I acknowledge the assistance from Claude Opus 4.8 and Fable 5 that I received for implementation, code review, docstring formatting, and logic testing.