### PR TITLE
fix: replace bare except clauses in pajek.py with specific exception types

### DIFF
--- a/networkx/readwrite/pajek.py
+++ b/networkx/readwrite/pajek.py
@@ -192,7 +192,7 @@ def parse_pajek(lines):
     while lines:
         try:
             l = next(lines)
-        except:  # EOF
+        except StopIteration:  # EOF
             break
         if l.lower().startswith("*network"):
             try:
@@ -223,7 +223,7 @@ def parse_pajek(lines):
                     G.nodes[label].update(
                         {"x": float(x), "y": float(y), "shape": shape}
                     )
-                except:
+                except (ValueError, TypeError):
                     pass
                 extra_attr = zip(splitline[5::2], splitline[6::2])
                 G.nodes[label].update(extra_attr)
@@ -253,7 +253,7 @@ def parse_pajek(lines):
                     # there should always be a single value on the edge?
                     w = splitline[2:3]
                     edge_data.update({"weight": float(w[0])})
-                except:
+                except (ValueError, IndexError):
                     pass
                     # if there isn't, just assign a 1
                 #                    edge_data.update({'value':1})


### PR DESCRIPTION
## Problem

`networkx/readwrite/pajek.py` has three bare `except:` clauses that catch all exceptions including `KeyboardInterrupt` and `SystemExit`, which can prevent the user from interrupting a long-running parse.

## Changes

- **Line ~195**: `except:  # EOF` → `except StopIteration:` (correctly names the exception raised by `next()` at end-of-iterator)
- **Line ~226**: `except: pass` → `except (ValueError, TypeError):` (handles failed `x, y, shape = splitline[2:5]` unpacking and `float()` conversion errors)
- **Line ~256**: `except: pass` → `except (ValueError, IndexError):` (handles missing edge weight: `w[0]` raises `IndexError` if empty, `float()` raises `ValueError` for non-numeric)

No behavior change for valid/invalid input — only prevents swallowing signals like Ctrl-C.