### PR TITLE
Add normalized adjacency matrix and spectrum (#3834)

### DIFF
--- a/doc/reference/linalg.rst
+++ b/doc/reference/linalg.rst
@@ -13,6 +13,7 @@ Graph Matrix
    :toctree: generated/
 
    adjacency_matrix
+   normalized_adjacency_matrix
    incidence_matrix
 
 Laplacian Matrix
@@ -72,6 +73,7 @@ Spectrum
    :toctree: generated/
 
    adjacency_spectrum
+   normalized_adjacency_spectrum
    laplacian_spectrum
    bethe_hessian_spectrum
    normalized_laplacian_spectrum

--- a/networkx/linalg/graphmatrix.py
+++ b/networkx/linalg/graphmatrix.py
@@ -4,7 +4,7 @@ Adjacency matrix and incidence matrix of graphs.
 
 import networkx as nx
 
-__all__ = ["incidence_matrix", "adjacency_matrix"]
+__all__ = ["incidence_matrix", "adjacency_matrix", "normalized_adjacency_matrix"]
 
 
 @nx._dispatchable(edge_attrs="weight")
@@ -172,3 +172,90 @@ def adjacency_matrix(G, nodelist=None, dtype=None, weight="weight", *, format="c
     return nx.to_scipy_sparse_array(
         G, nodelist=nodelist, dtype=dtype, weight=weight, format=format
     )
+
+
+@nx._dispatchable(edge_attrs="weight")
+def normalized_adjacency_matrix(G, nodelist=None, weight="weight"):
+    r"""Returns the normalized adjacency matrix of G.
+
+    The normalized adjacency matrix is the matrix
+
+    .. math::
+
+        \hat{A} = D^{-1/2} A D^{-1/2}
+
+    where `A` is the adjacency matrix and `D` is the diagonal matrix of
+    node degrees [1]_.
+
+    Parameters
+    ----------
+    G : graph
+       A NetworkX graph
+
+    nodelist : list, optional
+       The rows and columns are ordered according to the nodes in nodelist.
+       If nodelist is None, then the ordering is produced by G.nodes().
+
+    weight : string or None, optional (default='weight')
+       The edge data key used to compute each value in the matrix.
+       If None, then each edge has weight 1.
+
+    Returns
+    -------
+    A : SciPy sparse array
+      The normalized adjacency matrix of G.
+
+    Notes
+    -----
+    For MultiGraph, the edges weights are summed.
+    See :func:`to_numpy_array` for other options.
+
+    The normalized adjacency matrix and the normalized Laplacian matrix `N`
+    are related by :math:`N = I - \hat{A}` for a graph with no isolated
+    nodes. Nodes with zero degree contribute an all-zero row and column,
+    since ``D^{-1/2}`` is taken to be 0 there.
+
+    If the Graph contains selfloops, D is defined as ``diag(sum(A, 1))``, where A is
+    the adjacency matrix [2]_.
+
+    This calculation uses the out-degree of the graph `G`. To use the
+    in-degree for calculations instead, use `G.reverse(copy=False)` and
+    take the transpose.
+
+    For an unnormalized output, use `adjacency_matrix`.
+
+    Examples
+    --------
+    >>> G = nx.path_graph(3)
+    >>> print(nx.normalized_adjacency_matrix(G).toarray())
+    [[0.         0.70710678 0.        ]
+     [0.70710678 0.         0.70710678]
+     [0.         0.70710678 0.        ]]
+
+    See Also
+    --------
+    adjacency_matrix
+    normalized_adjacency_spectrum
+    normalized_laplacian_matrix
+
+    References
+    ----------
+    .. [1] Fan Chung-Graham, Spectral Graph Theory,
+       CBMS Regional Conference Series in Mathematics, Number 92, 1997.
+    .. [2] Steve Butler, Interlacing For Weighted Graphs Using The Normalized
+       Laplacian, Electronic Journal of Linear Algebra, Volume 16, pp. 90-98,
+       March 2007.
+    """
+    import numpy as np
+    import scipy as sp
+
+    if nodelist is None:
+        nodelist = list(G)
+    A = nx.to_scipy_sparse_array(G, nodelist=nodelist, weight=weight, format="csr")
+    n, _ = A.shape
+    diags = A.sum(axis=1)
+    with np.errstate(divide="ignore"):
+        diags_sqrt = 1.0 / np.sqrt(diags)
+    diags_sqrt[np.isinf(diags_sqrt)] = 0
+    DH = sp.sparse.dia_array((diags_sqrt, 0), shape=(n, n)).tocsr()
+    return DH @ (A @ DH)

--- a/networkx/linalg/spectrum.py
+++ b/networkx/linalg/spectrum.py
@@ -9,6 +9,7 @@ __all__ = [
     "adjacency_spectrum",
     "modularity_spectrum",
     "normalized_laplacian_spectrum",
+    "normalized_adjacency_spectrum",
     "bethe_hessian_spectrum",
 ]
 
@@ -88,6 +89,45 @@ def normalized_laplacian_spectrum(G, weight="weight"):
 
     return sp.linalg.eigvalsh(
         nx.normalized_laplacian_matrix(G, weight=weight).todense()
+    )
+
+
+@nx._dispatchable(edge_attrs="weight")
+def normalized_adjacency_spectrum(G, weight="weight"):
+    """Return eigenvalues of the normalized adjacency matrix of G
+
+    Parameters
+    ----------
+    G : graph
+       A NetworkX graph
+
+    weight : string or None, optional (default='weight')
+       The edge data key used to compute each value in the matrix.
+       If None, then each edge has weight 1.
+
+    Returns
+    -------
+    evals : NumPy array
+      Eigenvalues
+
+    Notes
+    -----
+    For MultiGraph/MultiDiGraph, the edges weights are summed.
+    See to_numpy_array for other options.
+
+    The eigenvalues of the normalized adjacency matrix and of the normalized
+    Laplacian matrix are related by :math:`\\mu = 1 - \\lambda`, where
+    :math:`\\lambda` is a normalized Laplacian eigenvalue.
+
+    See Also
+    --------
+    normalized_adjacency_matrix
+    normalized_laplacian_spectrum
+    """
+    import scipy as sp
+
+    return sp.linalg.eigvalsh(
+        nx.normalized_adjacency_matrix(G, weight=weight).todense()
     )
 
 

--- a/networkx/linalg/tests/test_graphmatrix.py
+++ b/networkx/linalg/tests/test_graphmatrix.py
@@ -294,3 +294,34 @@ class TestGraphMatrix:
             nx.adjacency_matrix(self.no_edges_G, nodelist=[1, 3]).todense(),
             self.no_edges_A,
         )
+
+    def test_normalized_adjacency_matrix(self):
+        "Conversion to normalized adjacency matrix"
+        s = 1 / np.sqrt(2)
+        # fmt: off
+        P3 = np.array(
+            [[0, s, 0],
+             [s, 0, s],
+             [0, s, 0]]
+        )
+        # fmt: on
+        np.testing.assert_almost_equal(
+            nx.normalized_adjacency_matrix(nx.path_graph(3)).todense(), P3
+        )
+        # Undirected normalized adjacency is symmetric.
+        A = nx.normalized_adjacency_matrix(self.G).todense()
+        np.testing.assert_almost_equal(A, A.T)
+        # Weighting the whole graph uniformly leaves the normalization unchanged.
+        np.testing.assert_almost_equal(
+            nx.normalized_adjacency_matrix(self.WG).todense(), A
+        )
+        np.testing.assert_almost_equal(
+            nx.normalized_adjacency_matrix(self.G, weight=None).todense(), A
+        )
+        # A zero-degree node yields an all-zero row/column (D^{-1/2} is 0 there).
+        np.testing.assert_almost_equal(A[4], np.zeros(5))
+        # Identity with the normalized Laplacian: N = I - A_hat (no isolated nodes).
+        H = nx.petersen_graph()
+        Ah = nx.normalized_adjacency_matrix(H).todense()
+        N = nx.normalized_laplacian_matrix(H).todense()
+        np.testing.assert_almost_equal(N, np.eye(H.number_of_nodes()) - Ah)

--- a/networkx/linalg/tests/test_spectrum.py
+++ b/networkx/linalg/tests/test_spectrum.py
@@ -43,6 +43,16 @@ class TestSpectrum:
         e = sorted(nx.normalized_laplacian_spectrum(self.WG, weight="other"))
         np.testing.assert_almost_equal(e, evals)
 
+    def test_normalized_adjacency_spectrum(self):
+        "Normalized adjacency eigenvalues"
+        evals = np.array([-1, 0, 1])
+        e = sorted(nx.normalized_adjacency_spectrum(self.P))
+        np.testing.assert_almost_equal(e, evals)
+        # Eigenvalues relate to the normalized Laplacian by mu = 1 - lambda.
+        na = sorted(nx.normalized_adjacency_spectrum(self.P))
+        nl = sorted(1 - x for x in nx.normalized_laplacian_spectrum(self.P))
+        np.testing.assert_almost_equal(na, nl)
+
     def test_adjacency_spectrum(self):
         "Adjacency eigenvalues"
         evals = np.array([-np.sqrt(2), 0, np.sqrt(2)])


### PR DESCRIPTION
Closes #3834.

Adds `normalized_adjacency_matrix` and `normalized_adjacency_spectrum`, following the existing `normalized_laplacian_matrix` / `normalized_laplacian_spectrum` functions.

- `normalized_adjacency_matrix(G, nodelist=None, weight="weight")` in `linalg/graphmatrix.py`: returns `D^{-1/2} A D^{-1/2}` as a sparse array. Zero-degree nodes give an all-zero row/column, matching the `D^{-1/2} = 0` convention already used in `normalized_laplacian_matrix`.
- `normalized_adjacency_spectrum(G, weight="weight")` in `linalg/spectrum.py`: its eigenvalues.
- Both added to `__all__` and to `doc/reference/linalg.rst`.

Tests in `test_graphmatrix.py` and `test_spectrum.py` check explicit values on small graphs, symmetry, zero-degree handling, the identity `N = I - A_hat` against the normalized Laplacian, and the `mu = 1 - lambda` eigenvalue relationship.

Ran locally: `pytest networkx/linalg/` (120 passed), the graphmatrix/spectrum doctests, `networkx/utils/tests/test_backends.py`, and `ruff check` / `ruff format --check` — all pass.

I used AI tools (Claude) to help write this change. I have reviewed, understood, and tested it myself.
