### PR TITLE
DOC: add MultiGraph edge recovery example to shortest_path

### DIFF
--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -118,6 +118,18 @@ def shortest_path(G, source=None, target=None, weight=None, method="dijkstra"):
     >>> p[2][4]  # shortest path from source=2 to target=4
     [2, 3, 4]
 
+    Find edges of shortest path in Multigraph
+
+    >>> G = nx.MultiDiGraph()
+    >>> G.add_weighted_edges_from([(1, 2, 0.75), (1, 2, 0.5), (2, 3, 0.5), (1, 3, 1.5)])
+    >>> nodes = nx.shortest_path(G, 1, 3, weight="weight")
+    >>> edges = nx.utils.pairwise(nodes)
+    >>> list(
+    ...     (u, v, min(G[u][v], key=lambda k: G[u][v][k].get("weight", 1)))
+    ...     for u, v in edges
+    ... )
+    [(1, 2, 1), (2, 3, 0)]
+
     Notes
     -----
     There may be more than one shortest path between a source and target.


### PR DESCRIPTION
Closes #4980.

Following the example added to `dijkstra_path` in #6497, this adds a similar example to `shortest_path` showing how to reconstruct the shortest path's edges for a `MultiGraph`.