### PR TITLE
DOC: add example to bipartite min_edge_cover

### DIFF
--- a/doc/reference/algorithms/isomorphism.vf2.rst
+++ b/doc/reference/algorithms/isomorphism.vf2.rst
@@ -13,6 +13,7 @@ Graph Matcher
 .. autosummary::
    :toctree: generated/
 
+    GraphMatcher
     GraphMatcher.__init__
     GraphMatcher.initialize
     GraphMatcher.is_isomorphic
@@ -34,6 +35,7 @@ DiGraph Matcher
 .. autosummary::
    :toctree: generated/
 
+    DiGraphMatcher
     DiGraphMatcher.__init__
     DiGraphMatcher.initialize
     DiGraphMatcher.is_isomorphic
@@ -46,6 +48,50 @@ DiGraph Matcher
     DiGraphMatcher.match
     DiGraphMatcher.semantic_feasibility
     DiGraphMatcher.syntactic_feasibility
+
+
+MultiGraph Matcher
+------------------
+.. currentmodule:: networkx.algorithms.isomorphism
+
+.. autosummary::
+   :toctree: generated/
+
+    MultiGraphMatcher
+    MultiGraphMatcher.__init__
+    MultiGraphMatcher.initialize
+    MultiGraphMatcher.is_isomorphic
+    MultiGraphMatcher.subgraph_is_isomorphic
+    MultiGraphMatcher.subgraph_is_monomorphic
+    MultiGraphMatcher.isomorphisms_iter
+    MultiGraphMatcher.subgraph_isomorphisms_iter
+    MultiGraphMatcher.subgraph_monomorphisms_iter
+    MultiGraphMatcher.candidate_pairs_iter
+    MultiGraphMatcher.match
+    MultiGraphMatcher.semantic_feasibility
+    MultiGraphMatcher.syntactic_feasibility
+
+
+MultiDiGraph Matcher
+--------------------
+.. currentmodule:: networkx.algorithms.isomorphism
+
+.. autosummary::
+   :toctree: generated/
+
+    MultiDiGraphMatcher
+    MultiDiGraphMatcher.__init__
+    MultiDiGraphMatcher.initialize
+    MultiDiGraphMatcher.is_isomorphic
+    MultiDiGraphMatcher.subgraph_is_isomorphic
+    MultiDiGraphMatcher.subgraph_is_monomorphic
+    MultiDiGraphMatcher.isomorphisms_iter
+    MultiDiGraphMatcher.subgraph_isomorphisms_iter
+    MultiDiGraphMatcher.subgraph_monomorphisms_iter
+    MultiDiGraphMatcher.candidate_pairs_iter
+    MultiDiGraphMatcher.match
+    MultiDiGraphMatcher.semantic_feasibility
+    MultiDiGraphMatcher.syntactic_feasibility
 
 
 Match helpers

--- a/networkx/algorithms/bipartite/covering.py
+++ b/networkx/algorithms/bipartite/covering.py
@@ -40,6 +40,12 @@ def min_edge_cover(G, matching_algorithm=None):
         pairs of nodes. It contains both the edges `(u, v)` and `(v, u)`
         for given nodes `u` and `v` among the edges of minimum edge cover.
 
+    Examples
+    --------
+    >>> G = nx.bipartite.random_graph(2, 2, 0.5, seed=42)
+    >>> sorted(nx.bipartite.min_edge_cover(G))
+    [(0, 3), (1, 2), (2, 1), (3, 0)]
+
     Notes
     -----
     An edge cover of a graph is a set of edges such that every node of

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -118,6 +118,18 @@ def shortest_path(G, source=None, target=None, weight=None, method="dijkstra"):
     >>> p[2][4]  # shortest path from source=2 to target=4
     [2, 3, 4]
 
+    Find edges of shortest path in Multigraph
+
+    >>> G = nx.MultiDiGraph()
+    >>> G.add_weighted_edges_from([(1, 2, 0.75), (1, 2, 0.5), (2, 3, 0.5), (1, 3, 1.5)])
+    >>> nodes = nx.shortest_path(G, 1, 3, weight="weight")
+    >>> edges = nx.utils.pairwise(nodes)
+    >>> list(
+    ...     (u, v, min(G[u][v], key=lambda k: G[u][v][k].get("weight", 1)))
+    ...     for u, v in edges
+    ... )
+    [(1, 2, 1), (2, 3, 0)]
+
     Notes
     -----
     There may be more than one shortest path between a source and target.


### PR DESCRIPTION
Closes #5472.

Adds an example of `min_edge_cover` for a bipartite graph under `networkx/algorithms/bipartite/covering.py`.