### PR TITLE
docs: Format docstrings in tournament.py to numpydoc format

### DIFF
--- a/networkx/algorithms/tournament.py
+++ b/networkx/algorithms/tournament.py
@@ -48,6 +48,23 @@ def index_satisfying(iterable, condition):
     `iterable` must not be empty. If `iterable` is empty, this
     function raises :exc:`ValueError`.
 
+    Parameters
+    ----------
+    iterable : iterable
+        An iterable.
+    condition : function
+        A function that takes an element of `iterable` and returns a boolean.
+
+    Returns
+    -------
+    int
+        The index of the first element that satisfies the condition, or the
+        length of the iterable if no such element is found.
+
+    Raises
+    ------
+    ValueError
+        If `iterable` is empty.
     """
     # Pre-condition: iterable must not be empty.
     for i, x in enumerate(iterable):


### PR DESCRIPTION
This PR formats the docstrings in `networkx/algorithms/tournament.py` to adhere to the `numpydoc` format.