### PR TITLE
docs: Format docstrings in coloring algorithms to numpydoc format

### DIFF
--- a/networkx/algorithms/coloring/equitable_coloring.py
+++ b/networkx/algorithms/coloring/equitable_coloring.py
@@ -407,8 +407,9 @@ def equitable_color(G, num_colors):
 
     Returns
     -------
-    A dictionary with keys representing nodes and values representing
-    corresponding coloring.
+    dict
+        A dictionary with keys representing nodes and values representing
+        corresponding coloring.
 
     Examples
     --------

--- a/networkx/algorithms/coloring/greedy_coloring.py
+++ b/networkx/algorithms/coloring/greedy_coloring.py
@@ -313,8 +313,9 @@ def greedy_color(G, strategy="largest_first", interchange=False):
 
     Returns
     -------
-    A dictionary with keys representing nodes and values representing
-    corresponding coloring.
+    dict
+        A dictionary with keys representing nodes and values representing
+        corresponding coloring.
 
     Examples
     --------


### PR DESCRIPTION
This PR formats the docstrings in `networkx/algorithms/coloring/greedy_coloring.py` and `networkx/algorithms/coloring/equitable_coloring.py` to adhere to the `numpydoc` format.