### PR TITLE
docs: Format docstrings in bipartite/basic.py to numpydoc format

### DIFF
--- a/networkx/algorithms/bipartite/basic.py
+++ b/networkx/algorithms/bipartite/basic.py
@@ -90,6 +90,11 @@ def is_bipartite(G):
     ----------
     G : NetworkX graph
 
+    Returns
+    -------
+    bool
+        True if graph G is bipartite, False if not.
+
     Examples
     --------
     >>> G = nx.path_graph(4)
@@ -120,6 +125,11 @@ def is_bipartite_node_set(G, nodes):
 
     nodes: list or container
       Check if nodes are a one of a bipartite set.
+
+    Returns
+    -------
+    bool
+        True if nodes and G/nodes are a bipartition of G, False otherwise.
 
     Examples
     --------


### PR DESCRIPTION
This PR formats the docstrings in `networkx/algorithms/bipartite/basic.py` to adhere to the `numpydoc` format.