### PR TITLE
docs: Format docstrings in components/connected.py to numpydoc format

### DIFF
--- a/networkx/algorithms/components/connected.py
+++ b/networkx/algorithms/components/connected.py
@@ -112,7 +112,7 @@ def number_connected_components(G):
 
     Returns
     -------
-    n : integer
+    n : int
        Number of connected components
 
     Raises


### PR DESCRIPTION
This PR formats the docstrings in `networkx/algorithms/components/connected.py` to adhere to the `numpydoc` format.