### PR TITLE
docs: Format docstrings in strongly/weakly connected algorithms to numpydoc format

### DIFF
--- a/networkx/algorithms/components/strongly_connected.py
+++ b/networkx/algorithms/components/strongly_connected.py
@@ -229,7 +229,7 @@ def number_strongly_connected_components(G):
 
     Returns
     -------
-    n : integer
+    n : int
        Number of strongly connected components
 
     Raises

--- a/networkx/algorithms/components/weakly_connected.py
+++ b/networkx/algorithms/components/weakly_connected.py
@@ -79,7 +79,7 @@ def number_weakly_connected_components(G):
 
     Returns
     -------
-    n : integer
+    n : int
         Number of weakly connected components
 
     Raises


### PR DESCRIPTION
This PR formats the docstrings in `networkx/algorithms/components/strongly_connected.py` and `networkx/algorithms/components/weakly_connected.py` to adhere to the `numpydoc` format.