### PR TITLE
docs: Format docstrings in connectivity algorithms to numpydoc format

### DIFF
--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -82,7 +82,7 @@ def local_node_connectivity(
 
     Returns
     -------
-    K : integer
+    K : int
         local node connectivity for nodes s and t
 
     Examples
@@ -237,7 +237,7 @@ def node_connectivity(G, s=None, t=None, flow_func=None):
 
     Returns
     -------
-    K : integer
+    K : int
         Node connectivity of G, or local node connectivity if source
         and target are provided.
 
@@ -533,7 +533,7 @@ def local_edge_connectivity(
 
     Returns
     -------
-    K : integer
+    K : int
         local edge connectivity for nodes s and t.
 
     Examples
@@ -679,7 +679,7 @@ def edge_connectivity(G, s=None, t=None, flow_func=None, cutoff=None):
 
     Returns
     -------
-    K : integer
+    K : int
         Edge connectivity for G, or local edge connectivity if source
         and target were provided
 

--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -48,9 +48,9 @@ def all_node_cuts(G, k=None, flow_func=None):
 
     Returns
     -------
-    cuts : a generator of node cutsets
-        Each node cutset has cardinality equal to the node connectivity of
-        the input graph.
+    cuts : generator
+        A generator of node cutsets. Each node cutset has cardinality
+        equal to the node connectivity of the input graph.
 
     Examples
     --------


### PR DESCRIPTION
This PR formats the docstrings in `networkx/algorithms/connectivity/kcutsets.py` and `networkx/algorithms/connectivity/connectivity.py` to adhere to the `numpydoc` format.