### PR TITLE
docs: Format docstrings in clique and chordal algorithms to numpydoc format

### DIFF
--- a/networkx/algorithms/chordal.py
+++ b/networkx/algorithms/chordal.py
@@ -107,7 +107,7 @@ def find_induced_nodes(G, s, t, treewidth_bound=sys.maxsize):
 
     Returns
     -------
-    induced_nodes : Set of nodes
+    induced_nodes : set
         The set of induced nodes in the path from s to t in G
 
     Raises
@@ -364,7 +364,7 @@ def complete_to_chordal_graph(G):
     -------
     H : NetworkX graph
         The chordal enhancement of G
-    alpha : Dictionary
+    alpha : dict
             The elimination ordering of nodes of G
 
     Notes

--- a/networkx/algorithms/clique.py
+++ b/networkx/algorithms/clique.py
@@ -536,7 +536,7 @@ def node_clique_number(G, nodes=None, cliques=None, separate_nodes=False):
 
     Returns
     -------
-    int or dict
+    size : int or dict
         If `nodes` is a single node, returns the size of the
         largest maximal clique in `G` containing that node.
         Otherwise return a dict keyed by node to the size
@@ -602,7 +602,7 @@ def number_of_cliques(G, nodes=None, cliques=None):
 
     Returns
     -------
-    int or dict
+    num_cliques : int or dict
         If `nodes` is a single node, return the number of maximal cliques it is
         part of. If `nodes` is a list, return a dictionary keyed by node to the
         number of maximal cliques it is part of.


### PR DESCRIPTION
This PR formats the docstrings in `networkx/algorithms/clique.py` and `networkx/algorithms/chordal.py` to adhere to the `numpydoc` format.