### PR TITLE
docs: Format docstrings in centrality algorithms to numpydoc format

### DIFF
--- a/networkx/algorithms/centrality/betweenness.py
+++ b/networkx/algorithms/centrality/betweenness.py
@@ -576,7 +576,7 @@ def _add_edge_keys(G, betweenness, weight=None):
 
     Returns
     -------
-    edges : dictionary
+    edges : dict
         The parameter `betweenness` including edges with keys and their
         betweenness centrality values.
 

--- a/networkx/algorithms/centrality/closeness.py
+++ b/networkx/algorithms/centrality/closeness.py
@@ -72,7 +72,7 @@ def closeness_centrality(G, u=None, distance=None, wf_improved=True, *, sp=None)
 
     Returns
     -------
-    nodes : dictionary
+    nodes : dict
       Dictionary of nodes with closeness centrality as the value.
 
     Examples
@@ -231,7 +231,7 @@ def incremental_closeness_centrality(
 
     Returns
     -------
-    nodes : dictionary
+    nodes : dict
       Dictionary of nodes with closeness centrality as the value.
 
     See Also

--- a/networkx/algorithms/centrality/current_flow_betweenness.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness.py
@@ -84,7 +84,7 @@ def approximate_current_flow_betweenness_centrality(
 
     Returns
     -------
-    nodes : dictionary
+    nodes : dict
        Dictionary of nodes with betweenness centrality as the value.
 
     See Also
@@ -206,7 +206,7 @@ def current_flow_betweenness_centrality(
 
     Returns
     -------
-    nodes : dictionary
+    nodes : dict
        Dictionary of nodes with betweenness centrality as the value.
 
     See Also
@@ -301,7 +301,7 @@ def edge_current_flow_betweenness_centrality(
 
     Returns
     -------
-    nodes : dictionary
+    nodes : dict
        Dictionary of edge tuples with betweenness centrality as the value.
 
     Raises

--- a/networkx/algorithms/centrality/current_flow_betweenness_subset.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness_subset.py
@@ -56,7 +56,7 @@ def current_flow_betweenness_centrality_subset(
 
     Returns
     -------
-    nodes : dictionary
+    nodes : dict
        Dictionary of nodes with betweenness centrality as the value.
 
     See Also

--- a/networkx/algorithms/centrality/current_flow_closeness.py
+++ b/networkx/algorithms/centrality/current_flow_closeness.py
@@ -42,7 +42,7 @@ def current_flow_closeness_centrality(G, weight=None, dtype=float, solver="lu"):
 
     Returns
     -------
-    nodes : dictionary
+    nodes : dict
        Dictionary of nodes with current flow closeness centrality as the value.
 
     See Also

--- a/networkx/algorithms/centrality/degree_alg.py
+++ b/networkx/algorithms/centrality/degree_alg.py
@@ -21,7 +21,7 @@ def degree_centrality(G):
 
     Returns
     -------
-    nodes : dictionary
+    nodes : dict
        Dictionary of nodes with degree centrality as the value.
 
     Examples
@@ -79,7 +79,7 @@ def in_degree_centrality(G):
 
     Returns
     -------
-    nodes : dictionary
+    nodes : dict
         Dictionary of nodes with in-degree centrality as values.
 
     Raises
@@ -129,7 +129,7 @@ def out_degree_centrality(G):
 
     Returns
     -------
-    nodes : dictionary
+    nodes : dict
         Dictionary of nodes with out-degree centrality as values.
 
     Raises

--- a/networkx/algorithms/centrality/dispersion.py
+++ b/networkx/algorithms/centrality/dispersion.py
@@ -32,7 +32,7 @@ def dispersion(G, u=None, v=None, normalized=True, alpha=1.0, b=0.0, c=0.0):
 
     Returns
     -------
-    nodes : dictionary
+    nodes : dict
         If u (v) is specified, returns a dictionary of nodes with dispersion
         score for all "target" ("source") nodes. If neither u nor v is
         specified, returns a dictionary of dictionaries for all nodes 'u' in the


### PR DESCRIPTION
This PR formats the docstrings in several centrality algorithms (`betweenness.py`, `closeness.py`, `current_flow_betweenness.py`, `current_flow_betweenness_subset.py`, `current_flow_closeness.py`, `degree_alg.py`, `dispersion.py`) to adhere to the `numpydoc` format by replacing `dictionary` with `dict`.