### PR TITLE
Return NaN instead of raising ZeroDivisionError in rich_club_coefficient

### DIFF
--- a/networkx/algorithms/richclub.py
+++ b/networkx/algorithms/richclub.py
@@ -1,5 +1,6 @@
 """Functions for computing rich-club coefficients."""
 
+import math
 from itertools import accumulate
 
 import networkx as nx
@@ -96,7 +97,12 @@ def rich_club_coefficient(G, normalized=True, Q=100, seed=None):
         E = R.number_of_edges()
         nx.double_edge_swap(R, Q * E, max_tries=Q * E * 10, seed=seed)
         rcran = _compute_rc(R)
-        rc = {k: v / rcran[k] for k, v in rc.items()}
+        # rcran[k] can be 0 for a given degree k if none of the randomized
+        # graph's edges connect nodes of degree > k, even though rc[k] (for
+        # the original graph) is not 0. The ratio is then undefined rather
+        # than well-defined-but-large, so report it as NaN instead of
+        # raising ZeroDivisionError. See GH #8485.
+        rc = {k: (v / rcran[k] if rcran[k] != 0 else math.nan) for k, v in rc.items()}
     return rc
 
 

--- a/networkx/algorithms/tests/test_richclub.py
+++ b/networkx/algorithms/tests/test_richclub.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 
 import networkx as nx
@@ -135,6 +137,42 @@ def test_rich_club_leq_3_nodes_normalized():
         G.add_node(i)
         with pytest.raises(nx.NetworkXError, match="Graph has fewer than four nodes"):
             rc = nx.rich_club_coefficient(G, normalized=True)
+
+
+def test_richclub_normalized_returns_nan_instead_of_raising():
+    """Regression test for
+    https://github.com/networkx/networkx/issues/8485
+
+    For some graphs, the randomized comparison graph's rich-club
+    coefficient can be 0 for a degree at which the original graph's
+    coefficient is not, making the normalized ratio undefined. This
+    must return NaN for that degree rather than raising
+    ZeroDivisionError.
+    """
+    G = nx.Graph()
+    nodes = ["A", "A_1", "A_2", "B", "B_1", "B_2", "C", "D"]
+    G.add_nodes_from(nodes)
+    edges = [
+        ("A", "A_1"),
+        ("A", "A_2"),
+        ("B", "B_1"),
+        ("B", "B_2"),
+        ("A", "B"),
+        ("C", "D"),
+    ]
+    G.add_edges_from(edges)
+
+    nan_seen = False
+    for seed in range(200):
+        rc = nx.rich_club_coefficient(G, normalized=True, Q=1, seed=seed)
+        for value in rc.values():
+            if isinstance(value, float) and math.isnan(value):
+                nan_seen = True
+    assert nan_seen, (
+        "expected at least one NaN across repeated runs "
+        "(if this starts failing, the random swaps may no longer "
+        "reach the zero-coefficient case for this graph/seed range)"
+    )
 
 
 # def test_richclub2_normalized():


### PR DESCRIPTION
Fixes #8485.

Computing the normalized rich-club coefficient divides each degree's coefficient in the original graph by the corresponding coefficient in a randomized comparison graph: `rc[k] / rcran[k]`. For sparse graphs with relatively few high-degree nodes, it's possible for `rcran[k]` to be exactly 0 for some degree `k` (no edges in the randomized graph happen to connect nodes of degree > k) while `rc[k]` in the original graph is not 0, raising `ZeroDivisionError`. Since the randomization is seed-dependent, this can happen intermittently across repeated calls on the same graph, as shown in the issue's 1000-iteration reproduction.

The referenced literature (McAuley et al., Milo et al.) doesn't address this edge case, and the ratio is genuinely undefined here (0/0-like, not "well-defined but very large"), so silently choosing an arbitrary numeric value would be misleading. This returns `NaN` for that degree instead -- the standard numerical convention for an indeterminate ratio -- while leaving every other (well-defined) degree untouched. This preserves the existing return type and dict keys, unlike the issue's alternative suggestion of truncating the returned data, which doesn't cleanly apply to this dict-based implementation in the current codebase anyway.

**Testing**: verified with the issue's exact reproduction: 1000 iterations of the example graph complete without raising, with `NaN` correctly appearing for the affected degree at least once across those iterations. Confirmed well-connected graphs unlikely to hit the zero-coefficient case still return only real (non-NaN) values, matching prior behavior exactly.

Added a regression test using the same example graph, running across 200 seeds and asserting at least one `NaN` is observed (matching the intermittent, seed-dependent nature of the bug). I confirmed the test fails with the original code (raises `ZeroDivisionError`) and passes with the fix. Ran the full existing `test_richclub.py` suite (12 passed: 11 baseline + 1 new, no regressions).
