### PR TITLE
fix: replace bare except clauses with specific exception types across 6 files

### DIFF
--- a/networkx/algorithms/structuralholes.py
+++ b/networkx/algorithms/structuralholes.py
@@ -155,7 +155,7 @@ def effective_size(G, nodes=None, weight=None):
         import scipy as sp
 
         has_scipy = True
-    except:
+    except ImportError:
         has_scipy = False
 
     if nodes is None and has_scipy:
@@ -271,7 +271,7 @@ def constraint(G, nodes=None, weight=None):
         import scipy as sp
 
         has_scipy = True
-    except:
+    except ImportError:
         has_scipy = False
 
     if nodes is None and has_scipy:

--- a/networkx/algorithms/time_dependent.py
+++ b/networkx/algorithms/time_dependent.py
@@ -118,7 +118,7 @@ def cd_index(G, node, time_delta, *, time="time", weight=None):
         target_date = G.nodes[node][time] + time_delta
         # keep the predecessors that existed before the target date
         pred = {i for i in G.pred[node] if G.nodes[i][time] <= target_date}
-    except:
+    except (TypeError, KeyError):
         raise nx.NetworkXError(
             "Addition and comparison are not supported between 'time_delta' "
             "and 'time' types."

--- a/networkx/convert.py
+++ b/networkx/convert.py
@@ -110,7 +110,7 @@ def to_networkx_graph(data, create_using=None, multigraph_input=False):
     if isinstance(data, list | tuple | nx.reportviews.EdgeViewABC | Iterator):
         try:
             return from_edgelist(data, create_using=create_using)
-        except:
+        except Exception:
             pass
 
     # pygraphviz  agraph

--- a/networkx/drawing/nx_agraph.py
+++ b/networkx/drawing/nx_agraph.py
@@ -319,7 +319,7 @@ def pygraphviz_layout(G, prog="neato", root=None, args=""):
         try:
             xs = node.attr["pos"].split(",")
             node_pos[n] = tuple(float(x) for x in xs)
-        except:
+        except (ValueError, KeyError):
             print("no position for node", n)
             node_pos[n] = (0.0, 0.0)
     return node_pos

--- a/networkx/lazy_imports.py
+++ b/networkx/lazy_imports.py
@@ -159,7 +159,7 @@ def _lazy_import(fullname):
     """
     try:
         return sys.modules[fullname]
-    except:
+    except KeyError:
         pass
 
     # Not previously loaded -- look it up

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -408,7 +408,7 @@ class GraphML:
         # These additions to types allow writing numpy types
         try:
             import numpy as np
-        except:
+        except ImportError:
             pass
         else:
             # prepend so that python types are created upon read (last entry wins)

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -294,7 +294,7 @@ def parse_multiline_adjlist(
             else:
                 try:  # try to evaluate
                     edgedata = literal_eval(data)
-                except:
+                except (ValueError, SyntaxError):
                     edgedata = {}
             G.add_edge(u, v, **edgedata)
 


### PR DESCRIPTION
Follow-up to #8769 (which fixed `pajek.py`). This PR addresses the remaining bare `except:` clauses in the main `networkx/` source tree.

## Changes

| File | Fix |
|------|-----|
| `networkx/lazy_imports.py` | `except KeyError:` — `sys.modules[fullname]` raises `KeyError` when module not cached |
| `networkx/convert.py` | `except Exception:` — fallback when converting data to edge list |
| `networkx/algorithms/time_dependent.py` | `except (TypeError, KeyError):` — node attribute access and date arithmetic |
| `networkx/algorithms/structuralholes.py` | `except ImportError:` (×2) — optional scipy import guard |
| `networkx/drawing/nx_agraph.py` | `except (ValueError, KeyError):` — node position string parsing |
| `networkx/readwrite/graphml.py` | `except ImportError:` — optional numpy import guard |
| `networkx/readwrite/multiline_adjlist.py` | `except (ValueError, SyntaxError):` — `ast.literal_eval` on edge data |

No behavior changes for valid input. Prevents bare `except:` from silently swallowing `KeyboardInterrupt` and `SystemExit`.