### PR TITLE
Fix dominating_set raising StopIteration on the empty graph

### DIFF
--- a/networkx/algorithms/dominating.py
+++ b/networkx/algorithms/dominating.py
@@ -51,6 +51,8 @@ def dominating_set(G, start_with=None):
 
     """
     all_nodes = set(G)
+    if not all_nodes:
+        return set()
     if start_with is None:
         start_with = nx.utils.arbitrary_element(all_nodes)
     if start_with not in G:

--- a/networkx/algorithms/tests/test_dominating.py
+++ b/networkx/algorithms/tests/test_dominating.py
@@ -21,6 +21,14 @@ def test_complete():
     assert len(nx.dominating_set(K5)) == 1
 
 
+def test_null_graph_dominating_set():
+    """The dominating set of the empty graph is the empty set."""
+    G = nx.Graph()
+    D = nx.dominating_set(G)
+    assert D == set()
+    assert nx.is_dominating_set(G, D)
+
+
 def test_raise_dominating_set():
     with pytest.raises(nx.NetworkXError):
         G = nx.path_graph(4)


### PR DESCRIPTION
### Bug

`dominating_set` crashes on the empty (null) graph:

```python
>>> import networkx as nx
>>> nx.dominating_set(nx.Graph())
StopIteration
```

The `StopIteration` comes from `nx.utils.arbitrary_element(all_nodes)` being called on an empty node set.

### Fix

Return the empty set for a graph with no nodes. The empty set is provably the correct answer:

```python
>>> nx.is_dominating_set(nx.Graph(), set())
True
```

This also matches the existing convention in the same module and elsewhere — `min_weighted_dominating_set(nx.Graph())`, `connected_dominating_set(nx.Graph())` and `maximal_matching(nx.Graph())` all already return an empty set gracefully.

### Tests

Added `test_null_graph_dominating_set`. The full `test_dominating.py` suite passes locally (21 passed), and the approximation dominating-set tests are unaffected.

Found via edge-case fuzzing; there's no existing issue or PR for it.