### PR TITLE
Fix maximal_independent_set raising IndexError on the empty graph

### DIFF
--- a/networkx/algorithms/mis.py
+++ b/networkx/algorithms/mis.py
@@ -98,6 +98,8 @@ def maximal_independent_set(G, nodes=None, seed=None):
         maximal independent set of maximum cardinality.
     """
     if not nodes:
+        if len(G) == 0:
+            return set()
         nodes = {seed.choice(list(G))}
     else:
         nodes = set(nodes)

--- a/networkx/algorithms/tests/test_mis.py
+++ b/networkx/algorithms/tests/test_mis.py
@@ -15,6 +15,12 @@ def test_random_seed():
     assert nx.maximal_independent_set(G, seed=1) == {1, 0, 3, 2, 4}
 
 
+def test_null_graph():
+    """The maximal independent set of the null (empty) graph is the empty set."""
+    assert nx.maximal_independent_set(nx.Graph()) == set()
+    assert nx.maximal_independent_set(nx.empty_graph(0)) == set()
+
+
 @pytest.mark.parametrize("graph", [nx.complete_graph(5), nx.complete_graph(55)])
 def test_K5(graph):
     """Maximal independent set for complete graphs"""


### PR DESCRIPTION
### Bug

`maximal_independent_set` crashes on the empty (null) graph:

```python
>>> import networkx as nx
>>> nx.maximal_independent_set(nx.Graph())
IndexError: Cannot choose from an empty sequence
```

When no starting `nodes` are given, the function does `seed.choice(list(G))`, which fails on a graph with no nodes.

### Fix

Return the empty set when the graph has no nodes. The empty set is trivially a maximal independent set of the null graph (there is no node that could be added). This matches the convention of similar set-finding functions such as `maximal_matching(nx.Graph())`, which already returns `set()`.

### Tests

Added `test_null_graph`; the full `test_mis.py` suite passes locally (8 passed).

Found via edge-case fuzzing; no existing issue or PR.