### PR TITLE
Write network text output files as UTF-8

### DIFF
--- a/networkx/readwrite/tests/test_text.py
+++ b/networkx/readwrite/tests/test_text.py
@@ -1,3 +1,4 @@
+import os
 import random
 from itertools import product
 from textwrap import dedent
@@ -56,6 +57,31 @@ def test_write_network_text_empty_graph():
     assert _graph_str(nx.Graph()) == "╙"
     assert _graph_str(nx.DiGraph(), ascii_only=True) == "+"
     assert _graph_str(nx.Graph(), ascii_only=True) == "+"
+
+
+def test_write_network_text_to_file_is_utf8(tmp_path, monkeypatch):
+    # The default glyphs are non-ASCII, so the output file must be opened as
+    # UTF-8. Previously it used the platform default encoding, which raised
+    # UnicodeEncodeError on Windows (cp1252). Force a non-UTF-8 default here so
+    # the regression is caught on any platform.
+    real_open = open
+    target = tmp_path / "graph.txt"
+
+    def locale_default_open(file, mode="r", *args, **kwargs):
+        if (
+            os.fspath(file) == os.fspath(target)
+            and "b" not in mode
+            and "encoding" not in kwargs
+        ):
+            kwargs["encoding"] = "cp1252"
+        return real_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", locale_default_open)
+
+    graph = nx.balanced_tree(r=2, h=2, create_using=nx.DiGraph)
+    nx.write_network_text(graph, path=target)
+
+    assert "╙── 0" in target.read_text(encoding="utf-8")
 
 
 def test_write_network_text_within_forest_glyph():

--- a/networkx/readwrite/text.py
+++ b/networkx/readwrite/text.py
@@ -419,7 +419,7 @@ def generate_network_text(
                 stack.append(try_frame)
 
 
-@open_file(1, "w")
+@open_file(1, "w", encoding="utf-8")
 def write_network_text(
     graph,
     path=None,

--- a/networkx/utils/decorators.py
+++ b/networkx/utils/decorators.py
@@ -101,7 +101,7 @@ fopeners = {
 _dispatch_dict = defaultdict(lambda: open, **fopeners)
 
 
-def open_file(path_arg, mode="r"):
+def open_file(path_arg, mode="r", encoding=None):
     """Decorator to ensure clean opening and closing of files.
 
     Parameters
@@ -111,6 +111,12 @@ def open_file(path_arg, mode="r"):
 
     mode : str
         String for opening mode.
+
+    encoding : str or None
+        Encoding passed to the file opener for text modes. If None (the
+        default), the opener's own default is used, which is the platform's
+        preferred encoding and can raise on Windows when writing non-ASCII
+        text. Has no effect when the argument is already an open file object.
 
     Returns
     -------
@@ -191,7 +197,11 @@ def open_file(path_arg, mode="r"):
             # could be None, or a file handle, in which case the algorithm will deal with it
             return path, lambda: None
 
-        fobj = _dispatch_dict[ext](path, mode=mode)
+        opener = _dispatch_dict[ext]
+        if encoding is None:
+            fobj = opener(path, mode=mode)
+        else:
+            fobj = opener(path, mode=mode, encoding=encoding)
         return fobj, lambda: fobj.close()
 
     return argmap(_open_file, path_arg, try_finally=True)


### PR DESCRIPTION
## Problem

`nx.write_network_text(G, path="out.txt")` raises `UnicodeEncodeError` on Windows for any non-trivial graph:

```
UnicodeEncodeError: 'charmap' codec can't encode characters in position 0-2: character maps to <undefined>
```

`write_network_text` draws the tree with Unicode box drawing glyphs by default (`ascii_only=False`), so writing to a file fails wherever the platform preferred encoding cannot represent those glyphs. On Windows that default is cp1252.

## Root cause

`write_network_text` is wrapped in `@open_file(1, "w")`. `open_file` opens the destination through `_dispatch_dict[ext](path, mode=mode)`, and the default opener is builtins `open` with no `encoding=`, so the file is opened with the platform preferred encoding. The function then writes str lines containing the glyphs, which raises on cp1252.

Reproduced on Windows (cp1252):

```python
import networkx as nx
G = nx.balanced_tree(r=2, h=2, create_using=nx.DiGraph)
nx.write_network_text(G, path="out.txt")                  # UnicodeEncodeError
nx.write_network_text(G, path="out.txt", ascii_only=True)  # fine
```

The existing tests do not catch this because they all pass a callable (`path=list.append`), which the decorator returns unchanged without opening a file. None of them write to an actual file.

## Fix

- `open_file` gains an optional `encoding=None` argument, forwarded to the opener only when set. Every existing caller passes nothing, so their behaviour is unchanged.
- `write_network_text` opts into `encoding="utf-8"`. Its output is always UTF-8 safe, and `ascii_only=True` still works since ASCII is valid UTF-8.

## Tests

Adds `test_write_network_text_to_file_is_utf8`, which writes to a real file with a monkeypatched cp1252-default `open` so the regression is caught on any platform, not just Windows. It fails on the current code with the `UnicodeEncodeError` above and passes with the fix. Full `test_text.py` and `test_decorators.py` pass, and ruff check and format are clean.

## Scope

`encoding` on `open_file` defaults to `None`, preserving current behaviour for every other reader and writer. Only `write_network_text` requests utf-8. There is no user facing API change.
