### PR TITLE
Fix ISMAGS ignoring matches when graph has extra node/edge colors (gh-8738)

### DIFF
--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -650,7 +650,7 @@ class ISMAGS:
         if Ncolors < N:
             extra = [g_partition[c] for c in range(N) if c not in gc_to_sgc]
             new_g_p = list(new_g_p) + extra
-            new_sg_p = list(new_sg_p) + [set()] * len(extra)
+            # no pad for new_sg_p -- not used. And keeps len for check in find_isos
 
         return new_sg_p, new_g_p, Ncolors
 
@@ -679,10 +679,10 @@ class ISMAGS:
             return
         elif len(self.graph) < len(self.subgraph):
             return
-        elif any(self._sgn_partition[self.N_node_colors :]):
+        elif len(self._sgn_partition) > self.N_node_colors:
             # some subgraph nodes have a color that doesn't occur in graph
             return
-        elif any(self._sge_partition[self.N_edge_colors :]):
+        elif len(self._sge_partition) > self.N_edge_colors:
             # some subgraph edges have a color that doesn't occur in graph
             return
 

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -679,10 +679,10 @@ class ISMAGS:
             return
         elif len(self.graph) < len(self.subgraph):
             return
-        elif len(self._sgn_partition) > self.N_node_colors:
+        elif any(self._sgn_partition[self.N_node_colors :]):
             # some subgraph nodes have a color that doesn't occur in graph
             return
-        elif len(self._sge_partition) > self.N_edge_colors:
+        elif any(self._sge_partition[self.N_edge_colors :]):
             # some subgraph edges have a color that doesn't occur in graph
             return
 

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -274,23 +274,18 @@ class TestSubgraphIsomorphism:
         )
 
     def test_edgeless_subgraph_with_edge_match(self):
-        # gh-8738: a subgraph with no edges should behave the same whether
-        # ``edge_match`` is ``None`` (all edges equal) or a callable that
-        # accepts every pair of edges. The graph having edge "colors" absent
-        # from the (edgeless) subgraph must not prevent matches.
+        # gh-8738: A subgraph should give the same for edge_match=None (all edges
+        # equal) or a callable that accepts all edges.
         graph = nx.Graph([(0, 1)])
         subgraph = nx.Graph()
         subgraph.add_node(0)
 
-        expected = [{0: 0}, {1: 0}]
+        expected = _matches_to_sets([{0: 0}, {1: 0}])
         none_matches = iso.ISMAGS(graph, subgraph, edge_match=None)
-        assert _matches_to_sets(none_matches.find_isomorphisms()) == _matches_to_sets(
-            expected
-        )
+        assert _matches_to_sets(none_matches.find_isomorphisms()) == expected
+
         all_matches = iso.ISMAGS(graph, subgraph, edge_match=lambda e1, e2: True)
-        assert _matches_to_sets(all_matches.find_isomorphisms()) == _matches_to_sets(
-            expected
-        )
+        assert _matches_to_sets(all_matches.find_isomorphisms()) == expected
 
     def test_subgraph_with_graph_only_node_color(self):
         # gh-8738: a node color present in the graph but not in the subgraph
@@ -302,35 +297,34 @@ class TestSubgraphIsomorphism:
         subgraph = nx.Graph()
         subgraph.add_node(0, color="a")
 
-        ismags = iso.ISMAGS(graph, subgraph, node_match=nm)
-        assert _matches_to_sets(ismags.find_isomorphisms()) == _matches_to_sets(
-            [{0: 0}]
-        )
+        expected = [{0: 0}]
+        result = list(iso.ISMAGS(graph, subgraph, node_match=nm).find_isomorphisms())
+        assert result == expected
 
         # A color that only the subgraph has should still yield no matches.
         subgraph.nodes[0]["color"] = "z"
-        ismags = iso.ISMAGS(graph, subgraph, node_match=nm)
-        assert list(ismags.find_isomorphisms()) == []
+        result = list(iso.ISMAGS(graph, subgraph, node_match=nm).find_isomorphisms())
+        assert result == []
 
     def test_subgraph_color_with_only_node(self):
-        # see gh-8738: default of None used to lead to result == []
+        # see gh-8738: node_match default of None should not lead to result == []
         graph = nx.Graph([(0, 1)])
         graph.nodes[1]["attr1"] = 0
-        subgraph = nx.empty_graph([5])
+        subgraph = nx.Graph()
         subgraph.add_node(5, attr1=0)
 
         nodematch = nx.isomorphism.categorical_node_match(["attr1"], [None])
-        ismags = iso.ISMAGS(graph, subgraph, node_match=nodematch, edge_match=None)
+        ismags = iso.ISMAGS(graph, subgraph, node_match=nodematch)
         result = list(ismags.find_isomorphisms())
         assert result == [{1: 5}]
 
         nodematch = nx.isomorphism.categorical_node_match(["attr1"], [0])
-        ismags = iso.ISMAGS(graph, subgraph, node_match=nodematch, edge_match=None)
+        ismags = iso.ISMAGS(graph, subgraph, node_match=nodematch)
         result = list(ismags.find_isomorphisms())
         assert result == [{0: 5}, {1: 5}]
 
         nodematch = nx.isomorphism.categorical_node_match(["attr1"], ["blue"])
-        ismags = iso.ISMAGS(graph, subgraph, node_match=nodematch, edge_match=None)
+        ismags = iso.ISMAGS(graph, subgraph, node_match=nodematch)
         result = list(ismags.find_isomorphisms())
         assert result == [{1: 5}]
 

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -312,6 +312,28 @@ class TestSubgraphIsomorphism:
         ismags = iso.ISMAGS(graph, subgraph, node_match=nm)
         assert list(ismags.find_isomorphisms()) == []
 
+    def test_subgraph_color_with_only_node(self):
+        # see gh-8738: default of None used to lead to result == []
+        graph = nx.Graph([(0, 1)])
+        graph.nodes[1]["attr1"] = 0
+        subgraph = nx.empty_graph([5])
+        subgraph.add_node(5, attr1=0)
+
+        nodematch = nx.isomorphism.categorical_node_match(["attr1"], [None])
+        ismags = iso.ISMAGS(graph, subgraph, node_match=nodematch, edge_match=None)
+        result = list(ismags.find_isomorphisms())
+        assert result == [{1: 5}]
+
+        nodematch = nx.isomorphism.categorical_node_match(["attr1"], [0])
+        ismags = iso.ISMAGS(graph, subgraph, node_match=nodematch, edge_match=None)
+        result = list(ismags.find_isomorphisms())
+        assert result == [{0: 5}, {1: 5}]
+
+        nodematch = nx.isomorphism.categorical_node_match(["attr1"], ["blue"])
+        ismags = iso.ISMAGS(graph, subgraph, node_match=nodematch, edge_match=None)
+        result = list(ismags.find_isomorphisms())
+        assert result == [{1: 5}]
+
     def test_exceptions_for_bad_match_functions(self):
         def non_transitive_match(attrs1, attrs2):
             return abs(attrs1["freq"] - attrs2["freq"]) <= 1

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -273,6 +273,45 @@ class TestSubgraphIsomorphism:
             expected_symmetric + expected_asymmetric
         )
 
+    def test_edgeless_subgraph_with_edge_match(self):
+        # gh-8738: a subgraph with no edges should behave the same whether
+        # ``edge_match`` is ``None`` (all edges equal) or a callable that
+        # accepts every pair of edges. The graph having edge "colors" absent
+        # from the (edgeless) subgraph must not prevent matches.
+        graph = nx.Graph([(0, 1)])
+        subgraph = nx.Graph()
+        subgraph.add_node(0)
+
+        expected = [{0: 0}, {1: 0}]
+        none_matches = iso.ISMAGS(graph, subgraph, edge_match=None)
+        assert _matches_to_sets(none_matches.find_isomorphisms()) == _matches_to_sets(
+            expected
+        )
+        all_matches = iso.ISMAGS(graph, subgraph, edge_match=lambda e1, e2: True)
+        assert _matches_to_sets(all_matches.find_isomorphisms()) == _matches_to_sets(
+            expected
+        )
+
+    def test_subgraph_with_graph_only_node_color(self):
+        # gh-8738: a node color present in the graph but not in the subgraph
+        # must not prevent otherwise valid isomorphisms from being found.
+        nm = iso.categorical_node_match("color", None)
+        graph = nx.Graph([(0, 1)])
+        graph.nodes[0]["color"] = "a"
+        graph.nodes[1]["color"] = "b"
+        subgraph = nx.Graph()
+        subgraph.add_node(0, color="a")
+
+        ismags = iso.ISMAGS(graph, subgraph, node_match=nm)
+        assert _matches_to_sets(ismags.find_isomorphisms()) == _matches_to_sets(
+            [{0: 0}]
+        )
+
+        # A color that only the subgraph has should still yield no matches.
+        subgraph.nodes[0]["color"] = "z"
+        ismags = iso.ISMAGS(graph, subgraph, node_match=nm)
+        assert list(ismags.find_isomorphisms()) == []
+
     def test_exceptions_for_bad_match_functions(self):
         def non_transitive_match(attrs1, attrs2):
             return abs(attrs1["freq"] - attrs2["freq"]) <= 1


### PR DESCRIPTION
Fixes #8738 (the `edge_match` half; also fixes the analogous node-color case).

## Root cause

`ISMAGS.find_isomorphisms` short-circuits with:

```python
elif len(self._sgn_partition) > self.N_node_colors:
    return
elif len(self._sge_partition) > self.N_edge_colors:
    return
```

The intent is "some subgraph color doesn't occur in the graph, so no match is possible." But `create_aligned_partitions` **pads** the subgraph partition with empty sets so that *graph-only* colors (present in the graph, absent from the subgraph) line up positionally against the graph partition. Those empty padding sets make `len(self._sg*_partition)` larger than `N_*_colors` even though every subgraph color *is* present in the graph — so a valid match gets rejected.

This is exactly why the reported example behaves inconsistently:

```python
graph = nx.Graph([(0, 1)])
subgraph = nx.Graph(); subgraph.add_node(0)

nx.algorithms.isomorphism.ISMAGS(graph, subgraph, edge_match=lambda e1, e2: True).find_isomorphisms()  # was []
nx.algorithms.isomorphism.ISMAGS(graph, subgraph, edge_match=None).find_isomorphisms()                 # [{0: 0}, {1: 0}]
```

With `edge_match=None` the graph edge partition is a single lumped part and nothing gets padded; with a callable, the graph's real edge produces an edge color that pads the (empty) subgraph edge partition, tripping the length check. The same latent bug exists for node colors when the graph has a node color the subgraph lacks.

## Fix

Only bail out when the subgraph has a genuinely **non-empty** part beyond the matched colors (a color that really only the subgraph has). Padding sets are empty, so they're correctly ignored:

```python
elif any(self._sgn_partition[self.N_node_colors :]):
    return
elif any(self._sge_partition[self.N_edge_colors :]):
    return
```

## Tests

Added two regression tests in `TestSubgraphIsomorphism`:

- `test_edgeless_subgraph_with_edge_match` — `edge_match=None` and `edge_match=lambda e1, e2: True` now both yield `[{0: 0}, {1: 0}]`.
- `test_subgraph_with_graph_only_node_color` — a graph-only node color no longer blocks a match, while a genuine subgraph-only color still correctly yields no isomorphisms.

```
$ pytest networkx/algorithms/isomorphism/tests/test_ismags.py -q
93 passed

$ pytest networkx/algorithms/isomorphism/tests/ -q
1301 passed, 960 xfailed
```

Note: this PR intentionally scopes to the `create_aligned_partitions` padding bug. The `categorical_node_match([...], [None]*0)` default-length pitfall discussed in the issue thread is a separate concern and not touched here.
