### PR TITLE
Allow spectral_layout to handle dim>=len(G). Added dim tests.

### DIFF
--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1116,6 +1116,9 @@ def spectral_layout(G, weight="weight", scale=1, center=None, dim=2, store_pos_a
             A += A.T
         pos = _spectral(A, dim)
 
+    if pos.shape[1] < dim:
+        pos = np.pad(pos, ((0, 0), (0, dim - pos.shape[1])), constant_values=0)
+
     pos = rescale_layout(pos, scale=scale) + center
     pos = dict(zip(G, pos))
 

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -633,6 +633,27 @@ def test_layouts_negative_dim(layout):
 
 
 @pytest.mark.parametrize(
+    "layout",
+    [
+        nx.random_layout,
+        nx.circular_layout,
+        nx.kamada_kawai_layout,
+        nx.spring_layout,
+        nx.spectral_layout,
+    ],
+)
+@pytest.mark.parametrize("dim", [3, 4, 5])
+def test_dim_parameter(layout, dim):
+    """Test layouts that support unrestricted dim kwarg."""
+    G = nx.path_graph(4)
+    pos = layout(G, dim=dim)
+    
+    assert len(pos) == len(G)
+    for coords in pos.values():
+        assert len(coords) == dim
+
+
+@pytest.mark.parametrize(
     ("num_nodes", "expected_method"), [(100, "force"), (501, "energy")]
 )
 @pytest.mark.parametrize(

--- a/networkx/drawing/tests/test_layout.py
+++ b/networkx/drawing/tests/test_layout.py
@@ -647,7 +647,6 @@ def test_dim_parameter(layout, dim):
     """Test layouts that support unrestricted dim kwarg."""
     G = nx.path_graph(4)
     pos = layout(G, dim=dim)
-    
     assert len(pos) == len(G)
     for coords in pos.values():
         assert len(coords) == dim


### PR DESCRIPTION
Added a check for the shape of the `spectral_layout` output to match the given `dim`, and pad the array with zeroes if necessary. This doesn't affect the general result but it creates a more consistent output from layout methods with the dimensions that the user is expecting.

Another option would be to raise a `ValueError` when `dim>len(G)` for this layout method, but it would mean a different behaviour compared to the other layout methods that do allow that range of `dim`.

Without the modification the new tests would fail for `spectral_layout` but not for any other of the 'unrestricted' layout methods, and the error raised internally is a broadcast error when `center` is added, which is not very informative. 