### PR TITLE
MAINT: allow isomorphism match helpers to be lists or not

### DIFF
--- a/networkx/algorithms/isomorphism/matchhelpers.py
+++ b/networkx/algorithms/isomorphism/matchhelpers.py
@@ -51,11 +51,11 @@ G1 and G2 are the same, then the constructed function returns True.
 Parameters
 ----------
 attr : string | list
-    The categorical node attribute to compare, or a list of categorical
+    The name of the categorical node attribute to compare, or a list of categorical
     node attributes to compare.
 default : value | list
-    The default value for the categorical node attribute, or a list of
-    default values for the categorical node attributes.
+    When `attr` is a string, the default value for that categorical node attribute.
+    Otherwise, a list of default values for each node attributes.
 
 Returns
 -------
@@ -78,7 +78,10 @@ def categorical_node_match(attr, default):
             return data1.get(attr, default) == data2.get(attr, default)
 
     else:
-        attrs = list(zip(attr, default))  # Python 3
+        if isinstance(default, list):
+            attrs = list(zip(attr, default, strict=True))
+        else:
+            attrs = [(a, default) for a in attr]
 
         def match(data1, data2):
             return all(data1.get(attr, d) == data2.get(attr, d) for attr, d in attrs)
@@ -98,7 +101,10 @@ def categorical_multiedge_match(attr, default):
             return values1 == values2
 
     else:
-        attrs = list(zip(attr, default))  # Python 3
+        if isinstance(default, list):
+            attrs = list(zip(attr, default, strict=True))
+        else:
+            attrs = [(a, default) for a in attr]
 
         def match(datasets1, datasets2):
             values1 = set()
@@ -132,11 +138,11 @@ tolerance, then the constructed function returns True.
 Parameters
 ----------
 attr : string | list
-    The numerical node attribute to compare, or a list of numerical
+    The name of the numerical node attribute to compare, or a list of numerical
     node attributes to compare.
 default : value | list
-    The default value for the numerical node attribute, or a list of
-    default values for the numerical node attributes.
+    If `attr` is a string, the default numerical value for that attribute.
+    Otherwise, a list of same length as `attr` with default values for each attribute.
 rtol : float
     The relative error tolerance.
 atol : float
@@ -168,7 +174,10 @@ def numerical_node_match(attr, default, rtol=1.0000000000000001e-05, atol=1e-08)
             )
 
     else:
-        attrs = list(zip(attr, default))  # Python 3
+        if isinstance(default, list):
+            attrs = list(zip(attr, default, strict=True))
+        else:
+            attrs = [(a, default) for a in attr]
 
         def match(data1, data2):
             values1 = [data1.get(attr, d) for attr, d in attrs]
@@ -190,7 +199,10 @@ def numerical_multiedge_match(attr, default, rtol=1.0000000000000001e-05, atol=1
             return allclose(values1, values2, rtol=rtol, atol=atol)
 
     else:
-        attrs = list(zip(attr, default))  # Python 3
+        if isinstance(default, list):
+            attrs = list(zip(attr, default, strict=True))
+        else:
+            attrs = [(a, default) for a in attr]
 
         def match(datasets1, datasets2):
             values1 = []
@@ -233,11 +245,11 @@ attr : string | list
     The node attribute to compare, or a list of node attributes
     to compare.
 default : value | list
-    The default value for the node attribute, or a list of
-    default values for the node attributes.
+    When `attr` is a string, the default value for that attribute.
+    Otherwise, a list the same length as `attr` with default values for each attribute.
 op : callable | list
-    The operator to use when comparing attribute values, or a list
-    of operators to use when comparing values for each attribute.
+    When `attr` is a string, the operator to use when comparing attribute values.
+    Otherwise, a list the same length as `attr` with operators to for each attribute.
 
 Returns
 -------
@@ -263,7 +275,16 @@ def generic_node_match(attr, default, op):
             return op(data1.get(attr, default), data2.get(attr, default))
 
     else:
-        attrs = list(zip(attr, default, op))  # Python 3
+        if isinstance(default, list):
+            if isinstance(op, list):
+                attrs = list(zip(attr, default, op, strict=True))
+            else:
+                attrs = [(a, d, op) for a, d in zip(attr, default, strict=True)]
+        else:
+            if isinstance(op, list):
+                attrs = [(a, default, o) for a, o in zip(attr, op, strict=True)]
+            else:
+                attrs = [(a, default, op) for a in attr]
 
         def match(data1, data2):
             for attr, d, operator in attrs:
@@ -293,11 +314,17 @@ def generic_multiedge_match(attr, default, op):
         The edge attribute to compare, or a list of node attributes
         to compare.
     default : value | list
-        The default value for the edge attribute, or a list of
-        default values for the edgeattributes.
+        When `attr` is a string, `default` is the default value for that
+        edge attribute.
+        When `attr` is a list, `default` is a default value for all edge
+        attributes or a list of length same as `attr` holding default
+        values for each edge attributes.
     op : callable | list
-        The operator to use when comparing attribute values, or a list
-        of operators to use when comparing values for each attribute.
+        When `attr` is a string, `op` is the operator to use when comparing
+        that attribute.
+        When `attr` is a list, `op` is an operator to use when comparing
+        each edge attribute or a list of length same as `attr` holding
+        operators to use when comparing values for each attribute.
 
     Returns
     -------
@@ -316,33 +343,40 @@ def generic_multiedge_match(attr, default, op):
     """
 
     # This is slow, but generic.
-    # We must test every possible isomorphism between the edges.
+    # We must test every possible isomorphism between the multiedges.
     if isinstance(attr, str):
         attr = [attr]
         default = [default]
-        op = [op]
-    attrs = list(zip(attr, default))  # Python 3
+
+    if isinstance(default, list):
+        attrs = list(zip(attr, default, strict=True))
+    else:
+        attrs = [(a, default) for a in attr]
+
+    # ops is a list of functions to check for a match of each attr in order
+    if isinstance(op, list):
+        if len(op) != len(attr):
+            msg = f"zip() argument length not right. Got {len(op)=}. Need {len(attr)=}"
+            raise ValueError(msg)
+        ops = op
+    else:
+        ops = [op] * len(attr)
 
     def match(datasets1, datasets2):
-        values1 = []
-        for data1 in datasets1.values():
-            x = tuple(data1.get(attr, d) for attr, d in attrs)
-            values1.append(x)
-        values2 = []
-        for data2 in datasets2.values():
-            x = tuple(data2.get(attr, d) for attr, d in attrs)
-            values2.append(x)
-        for vals2 in permutations(values2):
-            for xi, yi in zip(values1, vals2):
-                if not all(map(lambda x, y, z: z(x, y), xi, yi, op)):
-                    # This is not an isomorphism, go to next permutation.
+        # multiedges is a list across multiedges of lists across attrs of attr values
+        multiedges1 = [[dd.get(a, d) for a, d in attrs] for dd in datasets1.values()]
+        multiedges2 = [[dd.get(a, d) for a, d in attrs] for dd in datasets2.values()]
+        # order of multiedges is not relevant so have to check all permutations
+        for me2_perm in permutations(multiedges2):
+            for eattrs1, eattrs2 in zip(multiedges1, me2_perm):
+                if not all(m(ea1, ea2) for ea1, ea2, m in zip(eattrs1, eattrs2, ops)):
+                    # This is not an isomorphism, break to next permutation.
                     break
             else:
-                # Then we found an isomorphism.
+                # No break! We found an isomorphism.
                 return True
-        else:
-            # Then there are no isomorphisms between the multiedges.
-            return False
+        # No isomorphisms exist between the multiedges.
+        return False
 
     return match
 

--- a/networkx/algorithms/isomorphism/tests/test_match_helpers.py
+++ b/networkx/algorithms/isomorphism/tests/test_match_helpers.py
@@ -1,27 +1,74 @@
 from operator import eq
 
+import pytest
+
 import networkx as nx
 from networkx.algorithms import isomorphism as iso
 
 
 def test_categorical_node_match():
-    nm = iso.categorical_node_match(["x", "y", "z"], [None] * 3)
+    nm = iso.categorical_node_match(["x", "y", "z"], None)
     assert nm({"x": 1, "y": 2, "z": 3}, {"x": 1, "y": 2, "z": 3})
     assert not nm({"x": 1, "y": 2, "z": 2}, {"x": 1, "y": 2, "z": 1})
 
 
+def test_input_length_exceptions():
+    with pytest.raises(ValueError, match="zip.. argument "):
+        iso.categorical_node_match([0, 1, 2], [None])
+    with pytest.raises(ValueError, match="zip.. argument "):
+        iso.categorical_node_match([0, 1, 2], [None] * 4)
+    with pytest.raises(ValueError, match="zip.. argument "):
+        iso.categorical_multiedge_match([0, 1, 2], [None])
+    with pytest.raises(ValueError, match="zip.. argument "):
+        iso.categorical_multiedge_match([0, 1, 2], [None] * 4)
+
+    with pytest.raises(ValueError, match="zip.. argument "):
+        iso.numerical_node_match([0, 1, 2], [None])
+    with pytest.raises(ValueError, match="zip.. argument "):
+        iso.numerical_node_match([0, 1, 2], [None] * 4)
+    with pytest.raises(ValueError, match="zip.. argument "):
+        iso.numerical_multiedge_match([0, 1, 2], [None])
+    with pytest.raises(ValueError, match="zip.. argument "):
+        iso.numerical_multiedge_match([0, 1, 2], [None] * 4)
+
+    # non-lists pass with value spread across attributes
+    iso.generic_node_match([0, 1, 2], None, lambda x: x)
+    iso.generic_node_match("color", None, lambda x: x)
+    iso.generic_node_match("color", [None], [lambda x: x])
+
+    with pytest.raises(ValueError, match="zip.. argument "):
+        iso.generic_node_match([0, 1, 2], [None], [lambda x: x] * 3)
+    with pytest.raises(ValueError, match="zip.. argument "):
+        iso.generic_node_match([0, 1, 2], [None] * 3, [lambda x: x])
+    with pytest.raises(ValueError, match="zip.. argument "):
+        iso.generic_node_match([0, 1, 2], [None] * 4, [lambda x: x] * 3)
+    with pytest.raises(ValueError, match="zip.. argument "):
+        iso.generic_node_match([0, 1, 2], [None] * 3, [lambda x: x] * 4)
+
+    # non-lists pass with value spread across attributes
+    iso.generic_multiedge_match([0, 1, 2], None, lambda x: x)
+    iso.generic_multiedge_match("color", None, lambda x: x)
+    iso.generic_multiedge_match("color", [None], [lambda x: x])
+
+    with pytest.raises(ValueError, match="zip.. argument "):
+        iso.generic_multiedge_match([0, 1, 2], [None], [lambda x: x] * 3)
+    with pytest.raises(ValueError, match="zip.. argument "):
+        iso.generic_multiedge_match([0, 1, 2], [None] * 3, [lambda x: x])
+    with pytest.raises(ValueError, match="zip.. argument "):
+        iso.generic_multiedge_match([0, 1, 2], [None] * 4, [lambda x: x] * 3)
+    with pytest.raises(ValueError, match="zip.. argument "):
+        iso.generic_multiedge_match([0, 1, 2], [None] * 3, [lambda x: x] * 4)
+
+
 class TestGenericMultiEdgeMatch:
     def setup_method(self):
-        self.G1 = nx.MultiDiGraph()
-        self.G2 = nx.MultiDiGraph()
-        self.G3 = nx.MultiDiGraph()
-        self.G4 = nx.MultiDiGraph()
-        attr_dict1 = {"id": "edge1", "minFlow": 0, "maxFlow": 10}
-        attr_dict2 = {"id": "edge2", "minFlow": -3, "maxFlow": 7}
-        attr_dict3 = {"id": "edge3", "minFlow": 13, "maxFlow": 117}
-        attr_dict4 = {"id": "edge4", "minFlow": 13, "maxFlow": 117}
-        attr_dict5 = {"id": "edge5", "minFlow": 8, "maxFlow": 12}
-        attr_dict6 = {"id": "edge6", "minFlow": 8, "maxFlow": 12}
+        self.G = nx.MultiDiGraph()
+        attr_dict1 = {"id": "edge1", "minFlow": 0, "maxFlow": 10, "pos": (0, 10)}
+        attr_dict2 = {"id": "edge2", "minFlow": -3, "maxFlow": 7, "pos": (3, 10)}
+        attr_dict3 = {"id": "edge3", "minFlow": 13, "maxFlow": 117, "pos": (13, 17)}
+        attr_dict4 = {"id": "edge4", "minFlow": 13, "maxFlow": 117, "pos": (13, 17)}
+        attr_dict5 = {"id": "edge5", "minFlow": 8, "maxFlow": 12, "pos": (8, 12)}
+        attr_dict6 = {"id": "edge6", "minFlow": 8, "maxFlow": 12, "pos": (8, 12)}
         for attr_dict in [
             attr_dict1,
             attr_dict2,
@@ -30,7 +77,7 @@ class TestGenericMultiEdgeMatch:
             attr_dict5,
             attr_dict6,
         ]:
-            self.G1.add_edge(1, 2, **attr_dict)
+            self.G.add_edge(1, 2, **attr_dict)
         for attr_dict in [
             attr_dict5,
             attr_dict3,
@@ -39,26 +86,38 @@ class TestGenericMultiEdgeMatch:
             attr_dict4,
             attr_dict2,
         ]:
-            self.G2.add_edge(2, 3, **attr_dict)
+            self.G.add_edge(2, 3, **attr_dict)
         for attr_dict in [attr_dict3, attr_dict5]:
-            self.G3.add_edge(3, 4, **attr_dict)
+            self.G.add_edge(3, 4, **attr_dict)
         for attr_dict in [attr_dict6, attr_dict4]:
-            self.G4.add_edge(4, 5, **attr_dict)
+            self.G.add_edge(4, 5, **attr_dict)
 
     def test_generic_multiedge_match(self):
-        full_match = iso.generic_multiedge_match(
-            ["id", "flowMin", "flowMax"], [None] * 3, [eq] * 3
-        )
-        flow_match = iso.generic_multiedge_match(
-            ["flowMin", "flowMax"], [None] * 2, [eq] * 2
-        )
-        min_flow_match = iso.generic_multiedge_match("flowMin", None, eq)
-        id_match = iso.generic_multiedge_match("id", None, eq)
-        assert flow_match(self.G1[1][2], self.G2[2][3])
-        assert min_flow_match(self.G1[1][2], self.G2[2][3])
-        assert id_match(self.G1[1][2], self.G2[2][3])
-        assert full_match(self.G1[1][2], self.G2[2][3])
-        assert flow_match(self.G3[3][4], self.G4[4][5])
-        assert min_flow_match(self.G3[3][4], self.G4[4][5])
-        assert not id_match(self.G3[3][4], self.G4[4][5])
-        assert not full_match(self.G3[3][4], self.G4[4][5])
+        gmatch = iso.generic_multiedge_match
+        id_match = gmatch("id", None, eq)
+        full_match = gmatch(["id", "flowMin", "flowMax"], None, eq)
+        flow_match = gmatch(["flowMin", "flowMax"], None, eq)
+        flow_matcx = gmatch(["flowMin", "flowMax"], [None] * 2, [eq] * 2)
+        minf_match = gmatch("flowMin", None, eq)
+
+        def all_eq(x, y):
+            return all(a == b for a, b in zip(x, y))
+
+        diffops_id = gmatch(["id", "pos"], None, [eq, all_eq])
+        diffops_fl = gmatch(["pos", "flowMin"], None, [all_eq, eq])
+
+        assert id_match(self.G[1][2], self.G[2][3])
+        assert flow_match(self.G[1][2], self.G[2][3])
+        assert minf_match(self.G[1][2], self.G[2][3])
+        assert full_match(self.G[1][2], self.G[2][3])
+        assert diffops_id(self.G[1][2], self.G[2][3])
+        assert diffops_fl(self.G[1][2], self.G[2][3])
+
+        assert flow_match(self.G[3][4], self.G[4][5])
+        assert flow_matcx(self.G[3][4], self.G[4][5])
+        assert minf_match(self.G[3][4], self.G[4][5])
+        assert diffops_fl(self.G[3][4], self.G[4][5])
+
+        assert not id_match(self.G[3][4], self.G[4][5])
+        assert not full_match(self.G[3][4], self.G[4][5])
+        assert not diffops_id(self.G[3][4], self.G[4][5])

--- a/networkx/algorithms/isomorphism/tests/test_match_helpers.py
+++ b/networkx/algorithms/isomorphism/tests/test_match_helpers.py
@@ -12,6 +12,55 @@ def test_categorical_node_match():
     assert not nm({"x": 1, "y": 2, "z": 2}, {"x": 1, "y": 2, "z": 1})
 
 
+def test_generic_multiedge_match():
+    G = nx.MultiDiGraph()
+
+    ad1 = {"id": "edge1", "minFlow": 0, "maxFlow": 10, "pos": (0, 10)}
+    ad2 = {"id": "edge2", "minFlow": -3, "maxFlow": 7, "pos": (3, 10)}
+    ad3 = {"id": "edge3", "minFlow": 13, "maxFlow": 117, "pos": (13, 17)}
+    ad4 = {"id": "edge4", "minFlow": 13, "maxFlow": 117, "pos": (13, 17)}
+    ad5 = {"id": "edge5", "minFlow": 8, "maxFlow": 12, "pos": (8, 12)}
+    ad6 = {"id": "edge6", "minFlow": 8, "maxFlow": 12, "pos": (8, 12)}
+
+    for attr_dict in [ad1, ad2, ad3, ad4, ad5, ad6]:
+        G.add_edge(1, 2, **attr_dict)
+    for attr_dict in [ad5, ad3, ad6, ad1, ad4, ad2]:
+        G.add_edge(2, 3, **attr_dict)
+    for attr_dict in [ad3, ad5]:
+        G.add_edge(3, 4, **attr_dict)
+    for attr_dict in [ad6, ad4]:
+        G.add_edge(4, 5, **attr_dict)
+
+    gmatch = iso.generic_multiedge_match
+    id_match = gmatch("id", None, eq)
+    full_match = gmatch(["id", "flowMin", "flowMax"], None, eq)
+    flow_match = gmatch(["flowMin", "flowMax"], None, eq)
+    flow_matcx = gmatch(["flowMin", "flowMax"], [None] * 2, [eq] * 2)
+    minf_match = gmatch("flowMin", None, eq)
+
+    def all_eq(x, y):
+        return all(a == b for a, b in zip(x, y))
+
+    diffops_id = gmatch(["id", "pos"], None, [eq, all_eq])
+    diffops_fl = gmatch(["pos", "flowMin"], None, [all_eq, eq])
+
+    assert id_match(G[1][2], G[2][3])
+    assert flow_match(G[1][2], G[2][3])
+    assert minf_match(G[1][2], G[2][3])
+    assert full_match(G[1][2], G[2][3])
+    assert diffops_id(G[1][2], G[2][3])
+    assert diffops_fl(G[1][2], G[2][3])
+
+    assert flow_match(G[3][4], G[4][5])
+    assert flow_matcx(G[3][4], G[4][5])
+    assert minf_match(G[3][4], G[4][5])
+    assert diffops_fl(G[3][4], G[4][5])
+
+    assert not id_match(G[3][4], G[4][5])
+    assert not full_match(G[3][4], G[4][5])
+    assert not diffops_id(G[3][4], G[4][5])
+
+
 def test_input_length_exceptions():
     with pytest.raises(ValueError, match="zip.. argument "):
         iso.categorical_node_match([0, 1, 2], [None])
@@ -58,66 +107,3 @@ def test_input_length_exceptions():
         iso.generic_multiedge_match([0, 1, 2], [None] * 4, [lambda x: x] * 3)
     with pytest.raises(ValueError, match="zip.. argument "):
         iso.generic_multiedge_match([0, 1, 2], [None] * 3, [lambda x: x] * 4)
-
-
-class TestGenericMultiEdgeMatch:
-    def setup_method(self):
-        self.G = nx.MultiDiGraph()
-        attr_dict1 = {"id": "edge1", "minFlow": 0, "maxFlow": 10, "pos": (0, 10)}
-        attr_dict2 = {"id": "edge2", "minFlow": -3, "maxFlow": 7, "pos": (3, 10)}
-        attr_dict3 = {"id": "edge3", "minFlow": 13, "maxFlow": 117, "pos": (13, 17)}
-        attr_dict4 = {"id": "edge4", "minFlow": 13, "maxFlow": 117, "pos": (13, 17)}
-        attr_dict5 = {"id": "edge5", "minFlow": 8, "maxFlow": 12, "pos": (8, 12)}
-        attr_dict6 = {"id": "edge6", "minFlow": 8, "maxFlow": 12, "pos": (8, 12)}
-        for attr_dict in [
-            attr_dict1,
-            attr_dict2,
-            attr_dict3,
-            attr_dict4,
-            attr_dict5,
-            attr_dict6,
-        ]:
-            self.G.add_edge(1, 2, **attr_dict)
-        for attr_dict in [
-            attr_dict5,
-            attr_dict3,
-            attr_dict6,
-            attr_dict1,
-            attr_dict4,
-            attr_dict2,
-        ]:
-            self.G.add_edge(2, 3, **attr_dict)
-        for attr_dict in [attr_dict3, attr_dict5]:
-            self.G.add_edge(3, 4, **attr_dict)
-        for attr_dict in [attr_dict6, attr_dict4]:
-            self.G.add_edge(4, 5, **attr_dict)
-
-    def test_generic_multiedge_match(self):
-        gmatch = iso.generic_multiedge_match
-        id_match = gmatch("id", None, eq)
-        full_match = gmatch(["id", "flowMin", "flowMax"], None, eq)
-        flow_match = gmatch(["flowMin", "flowMax"], None, eq)
-        flow_matcx = gmatch(["flowMin", "flowMax"], [None] * 2, [eq] * 2)
-        minf_match = gmatch("flowMin", None, eq)
-
-        def all_eq(x, y):
-            return all(a == b for a, b in zip(x, y))
-
-        diffops_id = gmatch(["id", "pos"], None, [eq, all_eq])
-        diffops_fl = gmatch(["pos", "flowMin"], None, [all_eq, eq])
-
-        assert id_match(self.G[1][2], self.G[2][3])
-        assert flow_match(self.G[1][2], self.G[2][3])
-        assert minf_match(self.G[1][2], self.G[2][3])
-        assert full_match(self.G[1][2], self.G[2][3])
-        assert diffops_id(self.G[1][2], self.G[2][3])
-        assert diffops_fl(self.G[1][2], self.G[2][3])
-
-        assert flow_match(self.G[3][4], self.G[4][5])
-        assert flow_matcx(self.G[3][4], self.G[4][5])
-        assert minf_match(self.G[3][4], self.G[4][5])
-        assert diffops_fl(self.G[3][4], self.G[4][5])
-
-        assert not id_match(self.G[3][4], self.G[4][5])
-        assert not full_match(self.G[3][4], self.G[4][5])
-        assert not diffops_id(self.G[3][4], self.G[4][5])


### PR DESCRIPTION
The docstrings for the match helper functions (`numerical_node_match`, etc) say that inputs can be singular or a list. But they don't always do that. This PR adds the code needed to allow that, adds tests to check that it works and what errors might arise, updates the doc-strings and rewrites the `generic_multiedge_match` function for readability.

This was motivated by comments in #8738 that indicated that list inputs with different lengths were leading to `zip` truncation. So adding the `strict=True` kwarg to `zip` idioms is desired and implemented here. The code also didn't handle singular and list versions of the input, so that was added too.

