### PR TITLE
docs: document GraphMatcher classes

### DIFF
--- a/doc/reference/algorithms/isomorphism.vf2.rst
+++ b/doc/reference/algorithms/isomorphism.vf2.rst
@@ -10,7 +10,7 @@ Graph Matcher
 -------------
 .. currentmodule:: networkx.algorithms.isomorphism
 
-.. autosummary::
+.. autoclass:: GraphMatcher`n`n.. autosummary::
    :toctree: generated/
 
     GraphMatcher.__init__
@@ -31,7 +31,7 @@ DiGraph Matcher
 ---------------
 .. currentmodule:: networkx.algorithms.isomorphism
 
-.. autosummary::
+.. autoclass:: DiGraphMatcher`n`n.. autosummary::
    :toctree: generated/
 
     DiGraphMatcher.__init__

--- a/doc/reference/algorithms/isomorphism.vf2.rst
+++ b/doc/reference/algorithms/isomorphism.vf2.rst
@@ -10,7 +10,9 @@ Graph Matcher
 -------------
 .. currentmodule:: networkx.algorithms.isomorphism
 
-.. autoclass:: GraphMatcher`n`n.. autosummary::
+.. autoclass:: GraphMatcher
+
+.. autosummary::
    :toctree: generated/
 
     GraphMatcher.__init__
@@ -31,7 +33,9 @@ DiGraph Matcher
 ---------------
 .. currentmodule:: networkx.algorithms.isomorphism
 
-.. autoclass:: DiGraphMatcher`n`n.. autosummary::
+.. autoclass:: DiGraphMatcher
+
+.. autosummary::
    :toctree: generated/
 
     DiGraphMatcher.__init__


### PR DESCRIPTION
## Summary

- add class-level autodoc entries for `GraphMatcher` and `DiGraphMatcher`
- keep the existing method summaries unchanged

Issue: #3239

This makes the matcher classes addressable in the generated API inventory.