### PR TITLE
Clear the dispatch cache in `remove_{node,edge}_attributes`

### DIFF
--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -780,6 +780,8 @@ def remove_node_attributes(G, *attr_names, nbunch=None):
     >>> nx.get_node_attributes(G, "color")
     {}
     """
+    if not attr_names:
+        return
 
     if nbunch is None:
         nbunch = G.nodes()
@@ -997,6 +999,9 @@ def remove_edge_attributes(G, *attr_names, ebunch=None):
     >>> nx.get_edge_attributes(G, "weight")
     {}
     """
+    if not attr_names:
+        return
+
     if ebunch is None:
         ebunch = G.edges(keys=True) if G.is_multigraph() else G.edges()
 

--- a/networkx/classes/function.py
+++ b/networkx/classes/function.py
@@ -791,6 +791,7 @@ def remove_node_attributes(G, *attr_names, nbunch=None):
                     del d[attr]
                 except KeyError:
                     pass
+    nx._clear_cache(G)
 
 
 @nx._dispatchable(preserve_edge_attrs=True, mutates_input=True)
@@ -1009,6 +1010,7 @@ def remove_edge_attributes(G, *attr_names, ebunch=None):
                     del d[attr]
                 except KeyError:
                     pass
+    nx._clear_cache(G)
 
 
 def all_neighbors(graph, node):

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -825,6 +825,20 @@ def test_remove_edge_attributes(graph_type):
     assert other_attr in G[1][2] and third_attr in G[1][2]
 
 
+@pytest.mark.parametrize(
+    "remove_fn", (nx.remove_node_attributes, nx.remove_edge_attributes)
+)
+def test_remove_attributes_clears_cache(remove_fn):
+    #  `remove_{node,edge}_attributes` mutate the graph, so, like their
+    # `set_*` siblings, they must clear ``G.__networkx_cache__``
+    G = nx.path_graph(3)
+    G.add_node(0, color="blue")
+    nx.set_edge_attributes(G, {(u, v): u + v for u, v in G.edges()}, name="weight")
+    G.__networkx_cache__["backends"] = {"some_backend": {"key": "cached-conversion"}}
+    remove_fn(G, "weight" if remove_fn is nx.remove_edge_attributes else "color")
+    assert G.__networkx_cache__ == {}
+
+
 @pytest.mark.parametrize("graph_type", (nx.MultiGraph, nx.MultiDiGraph))
 def test_remove_multi_edge_attributes(graph_type):
     # Test removing single attribute

--- a/networkx/classes/tests/test_function.py
+++ b/networkx/classes/tests/test_function.py
@@ -835,6 +835,10 @@ def test_remove_attributes_clears_cache(remove_fn):
     G.add_node(0, color="blue")
     nx.set_edge_attributes(G, {(u, v): u + v for u, v in G.edges()}, name="weight")
     G.__networkx_cache__["backends"] = {"some_backend": {"key": "cached-conversion"}}
+
+    remove_fn(G)  # No attr specified. Nothing to do, so don't clear cache
+    assert G.__networkx_cache__ != {}
+
     remove_fn(G, "weight" if remove_fn is nx.remove_edge_attributes else "color")
     assert G.__networkx_cache__ == {}
 


### PR DESCRIPTION
These functions mutate the graph, so the cache should be cleared