### PR TITLE
Fix "accidentally quadratic" use of list as queue in `full_rary_tree`

### DIFF
--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -12,7 +12,6 @@ in this module return a Graph class (i.e. a simple, undirected graph).
 
 import itertools
 import numbers
-from collections import deque
 
 import networkx as nx
 from networkx.classes import Graph
@@ -46,24 +45,6 @@ __all__ = [
 # -------------------------------------------------------------------
 #   Some Classic Graphs
 # -------------------------------------------------------------------
-
-
-def _tree_edges(n, r):
-    if n == 0:
-        return
-    # helper function for trees
-    # yields edges in rooted tree at 0 with n nodes and branching ratio r
-    nodes = iter(range(n))
-    parents = deque([next(nodes)])  # stack of max length r
-    while parents:
-        source = parents.popleft()
-        for i in range(r):
-            try:
-                target = next(nodes)
-                parents.append(target)
-                yield source, target
-            except StopIteration:
-                break
 
 
 @nx._dispatchable(graphs=None, returns_graph=True)
@@ -100,7 +81,10 @@ def full_rary_tree(r, n, create_using=None):
            James Andrew Storer,  Birkhauser Boston 2001, (page 225).
     """
     G = empty_graph(n, create_using)
-    G.add_edges_from(_tree_edges(n, r))
+    if r > 0:
+        # Nodes are labeled in breadth-first order from the root, so the parent
+        # of node `child` is simply ``(child - 1) // r``.
+        G.add_edges_from(((child - 1) // r, child) for child in range(1, n))
     return G
 
 

--- a/networkx/generators/classic.py
+++ b/networkx/generators/classic.py
@@ -12,6 +12,7 @@ in this module return a Graph class (i.e. a simple, undirected graph).
 
 import itertools
 import numbers
+from collections import deque
 
 import networkx as nx
 from networkx.classes import Graph
@@ -53,9 +54,9 @@ def _tree_edges(n, r):
     # helper function for trees
     # yields edges in rooted tree at 0 with n nodes and branching ratio r
     nodes = iter(range(n))
-    parents = [next(nodes)]  # stack of max length r
+    parents = deque([next(nodes)])  # stack of max length r
     while parents:
-        source = parents.pop(0)
+        source = parents.popleft()
         for i in range(r):
             try:
                 target = next(nodes)

--- a/networkx/generators/tests/test_classic.py
+++ b/networkx/generators/tests/test_classic.py
@@ -82,6 +82,19 @@ class TestGeneratorClassic:
         t = nx.full_rary_tree(3, 20)
         assert t.order() == 20
 
+    def test_full_rary_tree_edges(self):
+        # nodes are labeled in breadth-first order from the root
+        t = nx.full_rary_tree(3, 8, create_using=nx.DiGraph)
+        assert list(t.edges) == [
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (1, 4),
+            (1, 5),
+            (1, 6),
+            (2, 7),
+        ]
+
     def test_barbell_graph(self):
         # number of nodes = 2*m1 + m2 (2 m1-complete graphs + m2-path + 2 edges)
         # number of edges = 2*(nx.number_of_edges(m1-complete graph) + m2 + 1


### PR DESCRIPTION
Using list `pop(0)` is O(N), but queue `popleft()` is O(1). Using the queue scales *much* better, because using the list was "accidentally quadratic".