### PR TITLE
BUG: reverse the map returned by vf2pp functions

### DIFF
--- a/networkx/algorithms/isomorphism/tests/test_common.py
+++ b/networkx/algorithms/isomorphism/tests/test_common.py
@@ -237,6 +237,7 @@ mono_funcs = {
 morphism_funcs = is_funcs | SG_funcs | mono_funcs
 
 is_morphic_funcs = [pytest.param(fn[0], id=id) for id, fn in morphism_funcs.items()]
+mapping_funcs = [pytest.param(fn[1], id=id) for id, fn in morphism_funcs.items()]
 mono_iters = [pytest.param(fn[1], id=id) for id, fn in mono_funcs.items()]
 morphic_and_mapping = [pytest.param(*fns, id=id) for id, fns in morphism_funcs.items()]
 
@@ -502,6 +503,16 @@ solo_graphs = [
 
 #### Test Functions
 ## Self-Isomorphism (Symmetry) tests
+
+
+@pytest.mark.parametrize("morphism", mapping_funcs)
+def test_graph_input_order(morphism):
+    # see gh-8810
+    G = nx.Graph(["eh"])
+    nx.add_path(G, "abcdefg")
+    H = nx.relabel_nodes(G, {a: i for i, a in enumerate(G)})
+
+    assert list(morphism(G, H)) == [dict(zip(G, H))]
 
 
 @pytest.mark.parametrize("Gclass", graph_classes)

--- a/networkx/algorithms/isomorphism/tests/test_vf2pp.py
+++ b/networkx/algorithms/isomorphism/tests/test_vf2pp.py
@@ -3,7 +3,22 @@ import itertools as it
 import pytest
 
 import networkx as nx
-from networkx import vf2pp_all_isomorphisms, vf2pp_is_isomorphic, vf2pp_isomorphism
+from networkx import vf2pp_all_isomorphisms as _all_isomorphisms
+from networkx import vf2pp_is_isomorphic
+from networkx import vf2pp_isomorphism as _isomorphism
+
+
+# Switch order of FG and SG input for vf2_isomorphism and vf2pp_all_isomorphisms
+# This satisfies backward compatibility. These tests are forward compatible -- i.e.
+# they match what vf2 and ismags do. But not what vf2pp used to do for isomorphisms
+# The difference should be gone once we have a unified API.
+def vf2pp_all_isomorphisms(FG, SG, node_label=None, default_label=None):
+    yield from _all_isomorphisms(SG, FG, node_label, default_label)
+
+
+def vf2pp_isomorphism(FG, SG, node_label=None, default_label=None):
+    return _isomorphism(SG, FG, node_label, default_label)
+
 
 labels_same = ["blue"]
 

--- a/networkx/algorithms/isomorphism/tests/test_vf2pp.py
+++ b/networkx/algorithms/isomorphism/tests/test_vf2pp.py
@@ -3,22 +3,7 @@ import itertools as it
 import pytest
 
 import networkx as nx
-from networkx import vf2pp_all_isomorphisms as _all_isomorphisms
-from networkx import vf2pp_is_isomorphic
-from networkx import vf2pp_isomorphism as _isomorphism
-
-
-# Switch order of FG and SG input for vf2_isomorphism and vf2pp_all_isomorphisms
-# This satisfies backward compatibility. These tests are forward compatible -- i.e.
-# they match what vf2 and ismags do. But not what vf2pp used to do for isomorphisms
-# The difference should be gone once we have a unified API.
-def vf2pp_all_isomorphisms(FG, SG, node_label=None, default_label=None):
-    yield from _all_isomorphisms(SG, FG, node_label, default_label)
-
-
-def vf2pp_isomorphism(FG, SG, node_label=None, default_label=None):
-    return _isomorphism(SG, FG, node_label, default_label)
-
+from networkx import vf2pp_all_isomorphisms, vf2pp_is_isomorphic, vf2pp_isomorphism
 
 labels_same = ["blue"]
 
@@ -162,7 +147,7 @@ class TestAllGraphTypesEdgeCases:
 
 class TestGraphISOVF2pp:
     def test_custom_graph1_same_labels(self):
-        SG = nx.Graph()
+        FG = nx.Graph()
 
         mapped = {1: "A", 2: "B", 3: "C", 4: "D", 5: "Z", 6: "E"}
         edges1 = [(1, 2), (1, 3), (1, 4), (2, 3), (2, 6), (3, 4), (5, 1), (5, 2)]
@@ -172,8 +157,8 @@ class TestGraphISOVF2pp:
         # |     | |/  | |/
         # 6     6 7   X E
 
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
 
         nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_many))), "label")
         nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_many))), "label")
@@ -184,28 +169,28 @@ class TestGraphISOVF2pp:
         assert vf2pp_isomorphism(FG, SG, node_label="label") == mapped
 
         # Add edge making SG symmetrical
-        SG.add_edge(3, 7)
-        SG.nodes[7]["label"] = "blue"
+        FG.add_edge(3, 7)
+        FG.nodes[7]["label"] = "blue"
         assert vf2pp_isomorphism(FG, SG, node_label="label") is None
 
-        all_self_mappings = list(vf2pp_all_isomorphisms(SG, SG))
+        all_self_mappings = list(vf2pp_all_isomorphisms(FG, FG))
         assert len(all_self_mappings) == 2
         # check that one of the mappings is not the identity for node 2
         assert sum(1 for m in all_self_mappings if m[2] == 2) == 1
 
         # Make FG isomorphic to SG
-        FG.add_edges_from([(mapped[3], "X"), (mapped[6], mapped[5])])
-        SG.add_edge(4, 7)
-        FG.nodes["X"]["label"] = "blue"
+        SG.add_edges_from([(mapped[3], "X"), (mapped[6], mapped[5])])
+        FG.add_edge(4, 7)
+        SG.nodes["X"]["label"] = "blue"
         assert vf2pp_isomorphism(FG, SG, node_label="label")
 
         # Re-structure maintaining isomorphism
-        SG.remove_edges_from([(1, 4), (1, 3)])
-        FG.remove_edges_from([(mapped[1], mapped[5]), (mapped[1], mapped[2])])
+        FG.remove_edges_from([(1, 4), (1, 3)])
+        SG.remove_edges_from([(mapped[1], mapped[5]), (mapped[1], mapped[2])])
         assert vf2pp_isomorphism(FG, SG, node_label="label")
 
     def test_custom_graph2_same_labels(self):
-        SG = nx.Graph()
+        FG = nx.Graph()
 
         mapped = {1: "A", 2: "C", 3: "D", 4: "E", 5: "G", 7: "B", 6: "F"}
         edges1 = [(1, 2), (1, 5), (5, 6), (2, 3), (2, 4), (3, 4), (4, 5), (2, 7)]
@@ -215,66 +200,66 @@ class TestGraphISOVF2pp:
         #  /|/
         # 7 3
 
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
         nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_same))), "label")
+        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
 
         assert vf2pp_isomorphism(FG, SG, node_label="label")
 
         # Obtain two isomorphic subgraphs from the graph
-        FG.remove_edge(mapped[1], mapped[2])
-        FG.add_edge(mapped[1], mapped[4])
-        SH = nx.Graph(SG.subgraph([2, 3, 4, 7]))
-        FH = nx.Graph(FG.subgraph([mapped[1], mapped[4], mapped[5], mapped[6]]))
+        SG.remove_edge(mapped[1], mapped[2])
+        SG.add_edge(mapped[1], mapped[4])
+        FH = nx.Graph(FG.subgraph([2, 3, 4, 7]))
+        SH = nx.Graph(SG.subgraph([mapped[1], mapped[4], mapped[5], mapped[6]]))
         assert vf2pp_isomorphism(FH, SH, node_label="label")
 
         # Add edges maintaining isomorphism
-        SH.add_edges_from([(3, 7), (4, 7)])
-        FH.add_edges_from([(mapped[1], mapped[6]), (mapped[4], mapped[6])])
+        FH.add_edges_from([(3, 7), (4, 7)])
+        SH.add_edges_from([(mapped[1], mapped[6]), (mapped[4], mapped[6])])
         assert vf2pp_isomorphism(FH, SH, node_label="label")
 
     def test_custom_graph2_different_labels(self):
-        SG = nx.Graph()
+        FG = nx.Graph()
 
         mapped = {1: "A", 2: "C", 3: "D", 4: "E", 5: "G", 7: "B", 6: "F"}
         edges1 = [(1, 2), (1, 5), (5, 6), (2, 3), (2, 4), (3, 4), (4, 5), (2, 7)]
 
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_many))), "label")
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
+        nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_many))), "label")
         nx.set_node_attributes(
-            FG,
-            dict(zip([mapped[n] for n in SG], it.cycle(labels_many))),
+            SG,
+            dict(zip([mapped[n] for n in FG], it.cycle(labels_many))),
             "label",
         )
 
         # Adding new nodes
-        SG.add_node(0)
-        FG.add_node("Z")
-        SG.nodes[0]["label"] = SG.nodes[1]["label"]
-        FG.nodes["Z"]["label"] = SG.nodes[1]["label"]
+        FG.add_node(0)
+        SG.add_node("Z")
+        FG.nodes[0]["label"] = FG.nodes[1]["label"]
+        SG.nodes["Z"]["label"] = FG.nodes[1]["label"]
         mapped.update({0: "Z"})
 
         assert vf2pp_isomorphism(FG, SG, node_label="label") == mapped
 
         # Change the color of one of the nodes
-        FG.nodes["Z"]["label"] = SG.nodes[2]["label"]
+        SG.nodes["Z"]["label"] = FG.nodes[2]["label"]
         assert vf2pp_isomorphism(FG, SG, node_label="label") is None
 
         # Add an extra edge
-        SG.nodes[0]["label"] = "blue"
-        FG.nodes["Z"]["label"] = "blue"
-        SG.add_edge(0, 1)
+        FG.nodes[0]["label"] = "blue"
+        SG.nodes["Z"]["label"] = "blue"
+        FG.add_edge(0, 1)
 
         assert vf2pp_isomorphism(FG, SG, node_label="label") is None
 
         # Add extra edge to both
-        FG.add_edge("Z", "A")
+        SG.add_edge("Z", "A")
         assert vf2pp_isomorphism(FG, SG, node_label="label") == mapped
 
     def test_custom_graph3_same_labels(self):
-        SG = nx.Graph()
+        FG = nx.Graph()
 
         mapped = {1: 9, 2: 8, 3: 7, 4: 6, 5: 3, 8: 5, 9: 4, 7: 1, 6: 2}
         #        3---4
@@ -298,60 +283,60 @@ class TestGraphISOVF2pp:
             (6, 7),
             (5, 2),
         ]
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
         nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_same))), "label")
+        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
         assert vf2pp_isomorphism(FG, SG, node_label="label")
 
         # Connect nodes maintaining symmetry
-        SG.add_edges_from([(6, 9), (7, 8)])
-        FG.add_edges_from([(mapped[6], mapped[8]), (mapped[7], mapped[9])])
+        FG.add_edges_from([(6, 9), (7, 8)])
+        SG.add_edges_from([(mapped[6], mapped[8]), (mapped[7], mapped[9])])
         assert vf2pp_isomorphism(FG, SG, node_label="label") is None
 
         # Make isomorphic
-        SG.add_edges_from([(6, 8), (7, 9)])
-        FG.add_edges_from([(mapped[6], mapped[9]), (mapped[7], mapped[8])])
+        FG.add_edges_from([(6, 8), (7, 9)])
+        SG.add_edges_from([(mapped[6], mapped[9]), (mapped[7], mapped[8])])
         assert vf2pp_isomorphism(FG, SG, node_label="label")
 
         # Connect more nodes
-        SG.add_edges_from([(2, 7), (3, 6)])
-        FG.add_edges_from([(mapped[2], mapped[7]), (mapped[3], mapped[6])])
-        SG.add_node(10)
-        FG.add_node("Z")
-        SG.nodes[10]["label"] = "blue"
-        FG.nodes["Z"]["label"] = "blue"
+        FG.add_edges_from([(2, 7), (3, 6)])
+        SG.add_edges_from([(mapped[2], mapped[7]), (mapped[3], mapped[6])])
+        FG.add_node(10)
+        SG.add_node("Z")
+        FG.nodes[10]["label"] = "blue"
+        SG.nodes["Z"]["label"] = "blue"
 
         assert vf2pp_isomorphism(FG, SG, node_label="label")
 
         # Connect the newly added node, to opposite sides of the graph
-        SG.add_edges_from([(10, 1), (10, 5), (10, 8)])
-        FG.add_edges_from([("Z", mapped[1]), ("Z", mapped[4]), ("Z", mapped[9])])
+        FG.add_edges_from([(10, 1), (10, 5), (10, 8)])
+        SG.add_edges_from([("Z", mapped[1]), ("Z", mapped[4]), ("Z", mapped[9])])
         assert vf2pp_isomorphism(FG, SG, node_label="label")
 
         # Get two subgraphs that are not isomorphic but are easy to make
-        SH = nx.Graph(SG.subgraph([2, 3, 4, 5, 6, 7, 10]))
-        FH = nx.Graph(
-            FG.subgraph(
+        FH = nx.Graph(FG.subgraph([2, 3, 4, 5, 6, 7, 10]))
+        SH = nx.Graph(
+            SG.subgraph(
                 [mapped[4], mapped[5], mapped[6], mapped[7], mapped[8], mapped[9], "Z"]
             )
         )
         assert vf2pp_isomorphism(FH, SH, node_label="label") is None
 
         # Restructure both to make them isomorphic
-        SH.add_edges_from([(10, 2), (10, 6), (3, 6), (2, 7), (2, 6), (3, 7)])
-        FH.add_edges_from(
+        FH.add_edges_from([(10, 2), (10, 6), (3, 6), (2, 7), (2, 6), (3, 7)])
+        SH.add_edges_from(
             [("Z", mapped[7]), (mapped[6], mapped[9]), (mapped[7], mapped[8])]
         )
         assert vf2pp_isomorphism(FH, SH, node_label="label")
 
         # Add edges with opposite direction in each Graph
-        SH.add_edge(3, 5)
-        FH.add_edge(mapped[5], mapped[7])
+        FH.add_edge(3, 5)
+        SH.add_edge(mapped[5], mapped[7])
         assert vf2pp_isomorphism(FH, SH, node_label="label") is None
 
     def test_custom_graph3_different_labels(self):
-        SG = nx.Graph()
+        FG = nx.Graph()
 
         mapped = {1: 9, 2: 8, 3: 7, 4: 6, 5: 3, 8: 5, 9: 4, 7: 1, 6: 2}
         edges1 = [
@@ -368,50 +353,50 @@ class TestGraphISOVF2pp:
             (6, 7),
             (5, 2),
         ]
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_many))), "label")
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
+        nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_many))), "label")
         nx.set_node_attributes(
-            FG,
-            dict(zip([mapped[n] for n in SG], it.cycle(labels_many))),
+            SG,
+            dict(zip([mapped[n] for n in FG], it.cycle(labels_many))),
             "label",
         )
         assert vf2pp_isomorphism(FG, SG, node_label="label") == mapped
 
-        # Add extra edge to SG
-        SG.add_edge(1, 7)
+        # Add extra edge to FG
+        FG.add_edge(1, 7)
         assert vf2pp_isomorphism(FG, SG, node_label="label") is None
 
-        # Compensate in FG
-        FG.add_edge(9, 1)
+        # Compensate in SG
+        SG.add_edge(9, 1)
         assert vf2pp_isomorphism(FG, SG, node_label="label") == mapped
 
         # Add extra node
-        SG.add_node("A")
-        FG.add_node("K")
-        SG.nodes["A"]["label"] = "green"
-        FG.nodes["K"]["label"] = "green"
+        FG.add_node("A")
+        SG.add_node("K")
+        FG.nodes["A"]["label"] = "green"
+        SG.nodes["K"]["label"] = "green"
         mapped.update({"A": "K"})
 
         assert vf2pp_isomorphism(FG, SG, node_label="label") == mapped
 
         # Connect A to one side of SG and K to the opposite
-        SG.add_edge("A", 6)
-        FG.add_edge("K", 5)
+        FG.add_edge("A", 6)
+        SG.add_edge("K", 5)
         assert vf2pp_isomorphism(FG, SG, node_label="label") is None
 
         # Make the graphs symmetrical
-        SG.add_edge(1, 5)
-        SG.add_edge(2, 9)
-        FG.add_edge(9, 3)
-        FG.add_edge(8, 4)
+        FG.add_edge(1, 5)
+        FG.add_edge(2, 9)
+        SG.add_edge(9, 3)
+        SG.add_edge(8, 4)
         assert vf2pp_isomorphism(FG, SG, node_label="label") is None
 
         # Assign same colors so the two opposite sides are identical
-        for node in SG.nodes():
+        for node in FG.nodes():
             color = "red"
-            SG.nodes[node]["label"] = color
-            FG.nodes[mapped[node]]["label"] = color
+            FG.nodes[node]["label"] = color
+            SG.nodes[mapped[node]]["label"] = color
 
         assert vf2pp_isomorphism(FG, SG, node_label="label")
 
@@ -421,7 +406,7 @@ class TestGraphISOVF2pp:
         #    7-8 6 5        13
         #       \ /
         #        9
-        SG = nx.Graph()
+        FG = nx.Graph()
         edges1 = [
             (1, 2),
             (2, 3),
@@ -455,18 +440,18 @@ class TestGraphISOVF2pp:
             13: "e",
         }
 
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_many))), "label")
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
+        nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_many))), "label")
         nx.set_node_attributes(
-            FG,
-            dict(zip([mapped[n] for n in SG], it.cycle(labels_many))),
+            SG,
+            dict(zip([mapped[n] for n in FG], it.cycle(labels_many))),
             "label",
         )
         assert vf2pp_isomorphism(FG, SG, node_label="label") == mapped
 
     def test_custom_graph4_same_labels(self):
-        SG = nx.Graph()
+        FG = nx.Graph()
         edges1 = [
             (1, 2),
             (2, 3),
@@ -500,51 +485,51 @@ class TestGraphISOVF2pp:
             13: "e",
         }
 
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
         nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_same))), "label")
+        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
         assert vf2pp_isomorphism(FG, SG, node_label="label")
 
-        all_self_mappings = list(vf2pp_all_isomorphisms(SG, SG))
+        all_self_mappings = list(vf2pp_all_isomorphisms(FG, FG))
         assert len(all_self_mappings) == 2
         # check that one of the mappings is not the identity for node 2
         assert sum(1 for m in all_self_mappings if m[12] == 12) == 1
 
         # Add nodes of different label
-        SG.add_node(0)
-        FG.add_node("z")
-        SG.nodes[0]["label"] = "green"
-        FG.nodes["z"]["label"] = "blue"
+        FG.add_node(0)
+        SG.add_node("z")
+        FG.nodes[0]["label"] = "green"
+        SG.nodes["z"]["label"] = "blue"
 
         assert vf2pp_isomorphism(FG, SG, node_label="label") is None
 
         # Make the labels identical
-        FG.nodes["z"]["label"] = "green"
+        SG.nodes["z"]["label"] = "green"
         assert vf2pp_isomorphism(FG, SG, node_label="label")
 
         # Change the structure of the graphs, keeping them isomorphic
-        SG.add_edge(2, 5)
-        FG.remove_edge("i", "l")
-        FG.add_edge("g", "l")
-        FG.add_edge("m", "f")
+        FG.add_edge(2, 5)
+        SG.remove_edge("i", "l")
+        SG.add_edge("g", "l")
+        SG.add_edge("m", "f")
         assert vf2pp_isomorphism(FG, SG, node_label="label")
 
         # Change the structure of the disconnected sub-graph, keeping it isomorphic
-        SG.remove_node(13)
-        FG.remove_node("d")
+        FG.remove_node(13)
+        SG.remove_node("d")
         assert vf2pp_isomorphism(FG, SG, node_label="label")
 
         # Connect the newly added node to the disconnected graph, which now is just a path of size 3
-        SG.add_edge(0, 10)
-        FG.add_edge("e", "z")
+        FG.add_edge(0, 10)
+        SG.add_edge("e", "z")
         assert vf2pp_isomorphism(FG, SG, node_label="label")
 
         # Connect the two disconnected sub-graphs, forming a single graph
-        SG.add_edge(11, 3)
-        SG.add_edge(0, 8)
-        FG.add_edge("a", "l")
-        FG.add_edge("z", "j")
+        FG.add_edge(11, 3)
+        FG.add_edge(0, 8)
+        SG.add_edge("a", "l")
+        SG.add_edge("z", "j")
         assert vf2pp_isomorphism(FG, SG, node_label="label")
 
     def test_custom_graph5_same_labels(self):
@@ -558,7 +543,7 @@ class TestGraphISOVF2pp:
         #    \ 7 /
         #     \|/
         #      8
-        SG = nx.Graph()
+        FG = nx.Graph()
         edges1 = [
             (1, 5),
             (1, 2),
@@ -575,20 +560,20 @@ class TestGraphISOVF2pp:
         ]
         mapped = {1: "a", 2: "h", 3: "d", 4: "i", 5: "g", 6: "b", 7: "j", 8: "c"}
 
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
         nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_same))), "label")
+        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
         assert vf2pp_isomorphism(FG, SG, node_label="label")
 
-        all_self_mappings = list(vf2pp_all_isomorphisms(SG, SG))
+        all_self_mappings = list(vf2pp_all_isomorphisms(FG, FG))
         assert len(all_self_mappings) == 48
         # check that one of the mappings is not the identity for node 2
-        assert all(sum(1 for m in all_self_mappings if m[u] == u) == 6 for u in SG)
+        assert all(sum(1 for m in all_self_mappings if m[u] == u) == 6 for u in FG)
 
         # Add different edges in each graph, maintaining symmetry
-        SG.add_edges_from([(3, 6), (2, 7), (2, 5), (1, 3), (4, 7), (6, 8)])
-        FG.add_edges_from(
+        FG.add_edges_from([(3, 6), (2, 7), (2, 5), (1, 3), (4, 7), (6, 8)])
+        SG.add_edges_from(
             [
                 (mapped[6], mapped[3]),
                 (mapped[2], mapped[7]),
@@ -601,26 +586,26 @@ class TestGraphISOVF2pp:
         assert vf2pp_isomorphism(FG, SG, node_label="label")
 
         # Obtain two different but isomorphic subgraphs from SG and FG
-        SH = nx.Graph(SG.subgraph([1, 5, 8, 6, 7, 3]))
-        FH = nx.Graph(
-            FG.subgraph(
+        FH = nx.Graph(FG.subgraph([1, 5, 8, 6, 7, 3]))
+        SH = nx.Graph(
+            SG.subgraph(
                 [mapped[1], mapped[4], mapped[8], mapped[7], mapped[3], mapped[5]]
             )
         )
         assert vf2pp_isomorphism(FH, SH, node_label="label")
 
         # Delete corresponding node from the two graphs
-        SH.remove_node(8)
-        FH.remove_node(mapped[7])
+        FH.remove_node(8)
+        SH.remove_node(mapped[7])
         assert vf2pp_isomorphism(FH, SH, node_label="label")
 
         # Re-orient, maintaining isomorphism
-        SH.add_edge(1, 6)
-        SH.remove_edge(3, 6)
+        FH.add_edge(1, 6)
+        FH.remove_edge(3, 6)
         assert vf2pp_isomorphism(FH, SH, node_label="label")
 
     def test_custom_graph5_different_labels(self):
-        SG = nx.Graph()
+        FG = nx.Graph()
         edges1 = [
             (1, 5),
             (1, 2),
@@ -637,71 +622,71 @@ class TestGraphISOVF2pp:
         ]
         mapped = {1: "a", 2: "h", 3: "d", 4: "i", 5: "g", 6: "b", 7: "j", 8: "c"}
 
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
 
         colors = ["red", "blue", "grey", "none", "brown", "solarized", "yellow", "pink"]
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_many))), "label")
+        nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_many))), "label")
         nx.set_node_attributes(
-            FG,
-            dict(zip([mapped[n] for n in SG], it.cycle(labels_many))),
+            SG,
+            dict(zip([mapped[n] for n in FG], it.cycle(labels_many))),
             "label",
         )
         assert vf2pp_isomorphism(FG, SG, node_label="label") == mapped
 
         # Assign different colors to matching nodes
         c = 0
-        for node in SG.nodes():
+        for node in FG.nodes():
             color1 = colors[c]
             color2 = colors[(c + 3) % len(colors)]
-            SG.nodes[node]["label"] = color1
-            FG.nodes[mapped[node]]["label"] = color2
+            FG.nodes[node]["label"] = color1
+            SG.nodes[mapped[node]]["label"] = color2
             c += 1
 
         assert vf2pp_isomorphism(FG, SG, node_label="label") is None
 
         # Get symmetrical sub-graphs of SG,FG and compare them
-        SH = SG.subgraph([1, 5])
-        FH = FG.subgraph(["i", "c"])
+        FH = FG.subgraph([1, 5])
+        SH = SG.subgraph(["i", "c"])
         c = 0
-        for node1, node2 in zip(SH.nodes(), FH.nodes()):
-            SH.nodes[node1]["label"] = "red"
-            FH.nodes[node2]["label"] = "red"
+        for node1, node2 in zip(FH.nodes(), SH.nodes()):
+            FH.nodes[node1]["label"] = "red"
+            SH.nodes[node2]["label"] = "red"
             c += 1
 
         assert vf2pp_isomorphism(FH, SH, node_label="label")
 
     def test_disconnected_graph_all_same_labels(self):
-        SG = nx.Graph()
-        SG.add_nodes_from(list(range(10)))
+        FG = nx.Graph()
+        FG.add_nodes_from(list(range(10)))
 
         mapped = {0: 9, 1: 8, 2: 7, 3: 6, 4: 5, 5: 4, 6: 3, 7: 2, 8: 1, 9: 0}
-        FG = nx.relabel_nodes(SG, mapped)
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
+        SG = nx.relabel_nodes(FG, mapped)
         nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_same))), "label")
+        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
         assert vf2pp_isomorphism(FG, SG, node_label="label")
 
     def test_disconnected_graph_all_different_labels(self):
-        SG = nx.Graph()
-        SG.add_nodes_from(list(range(10)))
+        FG = nx.Graph()
+        FG.add_nodes_from(list(range(10)))
 
         mapped = {0: 9, 1: 8, 2: 7, 3: 6, 4: 5, 5: 4, 6: 3, 7: 2, 8: 1, 9: 0}
-        FG = nx.relabel_nodes(SG, mapped)
+        SG = nx.relabel_nodes(FG, mapped)
 
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_many))), "label")
+        nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_many))), "label")
         nx.set_node_attributes(
-            FG,
-            dict(zip([mapped[n] for n in SG], it.cycle(labels_many))),
+            SG,
+            dict(zip([mapped[n] for n in FG], it.cycle(labels_many))),
             "label",
         )
         assert vf2pp_isomorphism(FG, SG, node_label="label") == mapped
 
     def test_disconnected_graph_some_same_labels(self):
-        SG = nx.Graph()
-        SG.add_nodes_from(list(range(10)))
+        FG = nx.Graph()
+        FG.add_nodes_from(list(range(10)))
 
         mapped = {0: 9, 1: 8, 2: 7, 3: 6, 4: 5, 5: 4, 6: 3, 7: 2, 8: 1, 9: 0}
-        FG = nx.relabel_nodes(SG, mapped)
+        SG = nx.relabel_nodes(FG, mapped)
 
         colors = [
             "white",
@@ -726,7 +711,7 @@ class TestGraphISOVF2pp:
 
 class TestMultiGraphISOVF2pp:
     def test_custom_multigraph1_same_labels(self):
-        SG = nx.MultiGraph()
+        FG = nx.MultiGraph()
 
         mapped = {1: "A", 2: "B", 3: "C", 4: "D", 5: "Z", 6: "E"}
         edges1 = [
@@ -746,40 +731,40 @@ class TestMultiGraphISOVF2pp:
             (5, 2),
         ]
 
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
 
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
         nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_same))), "label")
+        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
         # Transfer the 2-clique to the right side of SG
-        SG.remove_edges_from([(2, 6), (2, 6)])
-        SG.add_edges_from([(3, 6), (3, 6)])
+        FG.remove_edges_from([(2, 6), (2, 6)])
+        FG.add_edges_from([(3, 6), (3, 6)])
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert not m
 
         # Delete an edges, making them symmetrical, so the position of the 2-clique doesn't matter
-        FG.remove_edge(mapped[1], mapped[4])
-        SG.remove_edge(1, 4)
+        SG.remove_edge(mapped[1], mapped[4])
+        FG.remove_edge(1, 4)
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
         # Add self-loops
-        SG.add_edges_from([(5, 5), (5, 5), (1, 1)])
+        FG.add_edges_from([(5, 5), (5, 5), (1, 1)])
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert not m
 
         # Compensate in FG
-        FG.add_edges_from(
+        SG.add_edges_from(
             [(mapped[1], mapped[1]), (mapped[4], mapped[4]), (mapped[4], mapped[4])]
         )
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
     def test_custom_multigraph1_different_labels(self):
-        SG = nx.MultiGraph()
+        FG = nx.MultiGraph()
 
         mapped = {1: "A", 2: "B", 3: "C", 4: "D", 5: "Z", 6: "E"}
         edges1 = [
@@ -799,13 +784,13 @@ class TestMultiGraphISOVF2pp:
             (5, 2),
         ]
 
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
 
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_many))), "label")
+        nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_many))), "label")
         nx.set_node_attributes(
-            FG,
-            dict(zip([mapped[n] for n in SG], it.cycle(labels_many))),
+            SG,
+            dict(zip([mapped[n] for n in FG], it.cycle(labels_many))),
             "label",
         )
         m = vf2pp_isomorphism(FG, SG, node_label="label")
@@ -813,31 +798,31 @@ class TestMultiGraphISOVF2pp:
         assert m == mapped
 
         # Re-structure SG, maintaining the degree sequence
-        SG.remove_edge(1, 4)
-        SG.add_edge(1, 5)
+        FG.remove_edge(1, 4)
+        FG.add_edge(1, 5)
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert not m
 
         # Restructure FG, making it isomorphic to SG
-        FG.remove_edge("A", "D")
-        FG.add_edge("A", "Z")
+        SG.remove_edge("A", "D")
+        SG.add_edge("A", "Z")
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
         assert m == mapped
 
         # Add edge from node to itself
-        SG.add_edges_from([(6, 6), (6, 6), (6, 6)])
+        FG.add_edges_from([(6, 6), (6, 6), (6, 6)])
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert not m
 
         # Same for FG
-        FG.add_edges_from([("E", "E"), ("E", "E"), ("E", "E")])
+        SG.add_edges_from([("E", "E"), ("E", "E"), ("E", "E")])
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
         assert m == mapped
 
     def test_custom_multigraph2_same_labels(self):
-        SG = nx.MultiGraph()
+        FG = nx.MultiGraph()
 
         mapped = {1: "A", 2: "C", 3: "D", 4: "E", 5: "G", 7: "B", 6: "F"}
         edges1 = [
@@ -860,49 +845,49 @@ class TestMultiGraphISOVF2pp:
             (2, 7),
         ]
 
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
 
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
         nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_same))), "label")
+        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
         # Obtain two non-isomorphic subgraphs from the graph
-        FG.add_edge(mapped[1], mapped[4])
-        SH = nx.MultiGraph(SG.subgraph([2, 3, 4, 7]))
-        FH = nx.MultiGraph(FG.subgraph([mapped[1], mapped[4], mapped[5], mapped[6]]))
+        SG.add_edge(mapped[1], mapped[4])
+        FH = nx.MultiGraph(FG.subgraph([2, 3, 4, 7]))
+        SH = nx.MultiGraph(SG.subgraph([mapped[1], mapped[4], mapped[5], mapped[6]]))
 
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         assert not m
 
         # Make them isomorphic
-        SH.remove_edge(3, 4)
-        SH.add_edges_from([(2, 3), (2, 4), (2, 4)])
-        FH.add_edges_from([(mapped[5], mapped[6]), (mapped[5], mapped[6])])
+        FH.remove_edge(3, 4)
+        FH.add_edges_from([(2, 3), (2, 4), (2, 4)])
+        SH.add_edges_from([(mapped[5], mapped[6]), (mapped[5], mapped[6])])
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         assert m
 
         # Remove triangle edge
-        SH.remove_edges_from([(2, 3), (2, 3), (2, 3)])
-        FH.remove_edges_from([(mapped[5], mapped[4])] * 3)
+        FH.remove_edges_from([(2, 3), (2, 3), (2, 3)])
+        SH.remove_edges_from([(mapped[5], mapped[4])] * 3)
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         assert m
 
         # Change the edge orientation such that SH is rotated FH
-        SH.remove_edges_from([(2, 7), (2, 7)])
-        SH.add_edges_from([(3, 4), (3, 4)])
+        FH.remove_edges_from([(2, 7), (2, 7)])
+        FH.add_edges_from([(3, 4), (3, 4)])
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         assert m
 
         # Add extra edges maintaining degree sequence, but in a non-symmetrical manner
-        FH.add_edge(mapped[5], mapped[1])
-        SH.add_edge(3, 4)
+        SH.add_edge(mapped[5], mapped[1])
+        FH.add_edge(3, 4)
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         assert not m
 
     def test_custom_multigraph2_different_labels(self):
-        SG = nx.MultiGraph()
+        FG = nx.MultiGraph()
 
         mapped = {1: "A", 2: "C", 3: "D", 4: "E", 5: "G", 7: "B", 6: "F"}
         edges1 = [
@@ -925,13 +910,13 @@ class TestMultiGraphISOVF2pp:
             (2, 7),
         ]
 
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
 
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_many))), "label")
+        nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_many))), "label")
         nx.set_node_attributes(
-            FG,
-            dict(zip([mapped[n] for n in SG], it.cycle(labels_many))),
+            SG,
+            dict(zip([mapped[n] for n in FG], it.cycle(labels_many))),
             "label",
         )
         m = vf2pp_isomorphism(FG, SG, node_label="label")
@@ -939,35 +924,35 @@ class TestMultiGraphISOVF2pp:
         assert m == mapped
 
         # Re-structure SG
-        SG.remove_edge(2, 7)
-        SG.add_edge(5, 6)
+        FG.remove_edge(2, 7)
+        FG.add_edge(5, 6)
 
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert not m
 
         # Same for FG
-        FG.remove_edge("B", "C")
-        FG.add_edge("G", "F")
+        SG.remove_edge("B", "C")
+        SG.add_edge("G", "F")
 
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
         assert m == mapped
 
         # Delete node from SG and FG, keeping them isomorphic
-        SG.remove_node(3)
-        FG.remove_node("D")
+        FG.remove_node(3)
+        SG.remove_node("D")
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
         # Change SG edges
-        SG.remove_edge(1, 2)
-        SG.remove_edge(2, 7)
+        FG.remove_edge(1, 2)
+        FG.remove_edge(2, 7)
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert not m
 
         # Make FG identical to SG, but with different edge orientation and different labels
-        FG.add_edges_from([("A", "C"), ("C", "E"), ("C", "E")])
-        FG.remove_edges_from(
+        SG.add_edges_from([("A", "C"), ("C", "E"), ("C", "E")])
+        SG.remove_edges_from(
             [("A", "G"), ("A", "G"), ("F", "G"), ("E", "G"), ("E", "G")]
         )
 
@@ -975,15 +960,15 @@ class TestMultiGraphISOVF2pp:
         assert not m
 
         # Make all labels the same, so SG and FG are also isomorphic
-        for n1, n2 in zip(SG.nodes(), FG.nodes()):
-            SG.nodes[n1]["label"] = "blue"
-            FG.nodes[n2]["label"] = "blue"
+        for n1, n2 in zip(FG.nodes(), SG.nodes()):
+            FG.nodes[n1]["label"] = "blue"
+            SG.nodes[n2]["label"] = "blue"
 
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
     def test_custom_multigraph3_same_labels(self):
-        SG = nx.MultiGraph()
+        FG = nx.MultiGraph()
 
         mapped = {1: 9, 2: 8, 3: 7, 4: 6, 5: 3, 8: 5, 9: 4, 7: 1, 6: 2}
         edges1 = [
@@ -1008,17 +993,17 @@ class TestMultiGraphISOVF2pp:
             (6, 7),
             (5, 2),
         ]
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
 
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
         nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_same))), "label")
+        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
         # Connect nodes maintaining symmetry
-        SG.add_edges_from([(6, 9), (7, 8), (5, 8), (4, 9), (4, 9)])
-        FG.add_edges_from(
+        FG.add_edges_from([(6, 9), (7, 8), (5, 8), (4, 9), (4, 9)])
+        SG.add_edges_from(
             [
                 (mapped[6], mapped[8]),
                 (mapped[7], mapped[9]),
@@ -1031,8 +1016,8 @@ class TestMultiGraphISOVF2pp:
         assert not m
 
         # Make isomorphic
-        SG.add_edges_from([(6, 8), (6, 8), (7, 9), (7, 9), (7, 9)])
-        FG.add_edges_from(
+        FG.add_edges_from([(6, 8), (6, 8), (7, 9), (7, 9), (7, 9)])
+        SG.add_edges_from(
             [
                 (mapped[6], mapped[8]),
                 (mapped[6], mapped[9]),
@@ -1045,8 +1030,8 @@ class TestMultiGraphISOVF2pp:
         assert m
 
         # Connect more nodes
-        SG.add_edges_from([(2, 7), (2, 7), (3, 6), (3, 6)])
-        FG.add_edges_from(
+        FG.add_edges_from([(2, 7), (2, 7), (3, 6), (3, 6)])
+        SG.add_edges_from(
             [
                 (mapped[2], mapped[7]),
                 (mapped[2], mapped[7]),
@@ -1054,17 +1039,17 @@ class TestMultiGraphISOVF2pp:
                 (mapped[3], mapped[6]),
             ]
         )
-        SG.add_node(10)
-        FG.add_node("Z")
-        SG.nodes[10]["label"] = "blue"
-        FG.nodes["Z"]["label"] = "blue"
+        FG.add_node(10)
+        SG.add_node("Z")
+        FG.nodes[10]["label"] = "blue"
+        SG.nodes["Z"]["label"] = "blue"
 
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
         # Connect the newly added node, to opposite sides of the graph
-        SG.add_edges_from([(10, 1), (10, 5), (10, 8), (10, 10), (10, 10)])
-        FG.add_edges_from(
+        FG.add_edges_from([(10, 1), (10, 5), (10, 8), (10, 10), (10, 10)])
+        SG.add_edges_from(
             [
                 ("Z", mapped[1]),
                 ("Z", mapped[4]),
@@ -1078,8 +1063,8 @@ class TestMultiGraphISOVF2pp:
 
         # We connected the new node to opposite sides, so SG must be symmetrical
         # to FG. Re-structure them to be so
-        SG.remove_edges_from([(1, 3), (4, 9), (4, 9), (7, 9)])
-        FG.remove_edges_from(
+        FG.remove_edges_from([(1, 3), (4, 9), (4, 9), (7, 9)])
+        SG.remove_edges_from(
             [
                 (mapped[1], mapped[3]),
                 (mapped[4], mapped[9]),
@@ -1091,9 +1076,9 @@ class TestMultiGraphISOVF2pp:
         assert m
 
         # Get two subgraphs that are not isomorphic but are easy to make
-        SH = nx.Graph(SG.subgraph([2, 3, 4, 5, 6, 7, 10]))
-        FH = nx.Graph(
-            FG.subgraph(
+        FH = nx.Graph(FG.subgraph([2, 3, 4, 5, 6, 7, 10]))
+        SH = nx.Graph(
+            SG.subgraph(
                 [mapped[4], mapped[5], mapped[6], mapped[7], mapped[8], mapped[9], "Z"]
             )
         )
@@ -1102,25 +1087,25 @@ class TestMultiGraphISOVF2pp:
         assert not m
 
         # Restructure both to make them isomorphic
-        SH.add_edges_from([(10, 2), (10, 6), (3, 6), (2, 7), (2, 6), (3, 7)])
-        FH.add_edges_from(
+        FH.add_edges_from([(10, 2), (10, 6), (3, 6), (2, 7), (2, 6), (3, 7)])
+        SH.add_edges_from(
             [("Z", mapped[7]), (mapped[6], mapped[9]), (mapped[7], mapped[8])]
         )
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         assert m
 
         # Remove one self-loop in FH
-        FH.remove_edge("Z", "Z")
+        SH.remove_edge("Z", "Z")
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         assert not m
 
         # Compensate in SH
-        SH.remove_edge(10, 10)
+        FH.remove_edge(10, 10)
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         assert m
 
     def test_custom_multigraph3_different_labels(self):
-        SG = nx.MultiGraph()
+        FG = nx.MultiGraph()
 
         mapped = {1: 9, 2: 8, 3: 7, 4: 6, 5: 3, 8: 5, 9: 4, 7: 1, 6: 2}
         edges1 = [
@@ -1146,13 +1131,13 @@ class TestMultiGraphISOVF2pp:
             (5, 2),
         ]
 
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
 
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_many))), "label")
+        nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_many))), "label")
         nx.set_node_attributes(
-            FG,
-            dict(zip([mapped[n] for n in SG], it.cycle(labels_many))),
+            SG,
+            dict(zip([mapped[n] for n in FG], it.cycle(labels_many))),
             "label",
         )
         m = vf2pp_isomorphism(FG, SG, node_label="label")
@@ -1160,65 +1145,65 @@ class TestMultiGraphISOVF2pp:
         assert m == mapped
 
         # Delete edge maintaining isomorphism
-        SG.remove_edge(4, 9)
-        FG.remove_edge(4, 6)
+        FG.remove_edge(4, 9)
+        SG.remove_edge(4, 6)
 
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
         assert m == mapped
 
         # Change edge orientation such that SG mirrors FG
-        SG.add_edges_from([(4, 9), (1, 2), (1, 2)])
-        SG.remove_edges_from([(1, 3), (1, 3)])
-        FG.add_edges_from([(3, 5), (7, 9)])
-        FG.remove_edge(8, 9)
+        FG.add_edges_from([(4, 9), (1, 2), (1, 2)])
+        FG.remove_edges_from([(1, 3), (1, 3)])
+        SG.add_edges_from([(3, 5), (7, 9)])
+        SG.remove_edge(8, 9)
 
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert not m
 
         # Make all labels the same, so SG and FG are also isomorphic
-        for n1, n2 in zip(SG.nodes(), FG.nodes()):
-            SG.nodes[n1]["label"] = "blue"
-            FG.nodes[n2]["label"] = "blue"
+        for n1, n2 in zip(FG.nodes(), SG.nodes()):
+            FG.nodes[n1]["label"] = "blue"
+            SG.nodes[n2]["label"] = "blue"
 
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
-        SG.add_node(10)
-        FG.add_node("Z")
-        SG.nodes[10]["label"] = "green"
-        FG.nodes["Z"]["label"] = "green"
+        FG.add_node(10)
+        SG.add_node("Z")
+        FG.nodes[10]["label"] = "green"
+        SG.nodes["Z"]["label"] = "green"
 
         # Add different number of edges between the new nodes and themselves
-        SG.add_edges_from([(10, 10), (10, 10)])
-        FG.add_edges_from([("Z", "Z")])
+        FG.add_edges_from([(10, 10), (10, 10)])
+        SG.add_edges_from([("Z", "Z")])
 
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert not m
 
         # Make the number of self-edges equal
-        SG.remove_edge(10, 10)
+        SG.add_edges_from([("Z", "Z")])
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
         # Connect the new node to the graph
-        SG.add_edges_from([(10, 3), (10, 4)])
-        FG.add_edges_from([("Z", 8), ("Z", 3)])
+        FG.add_edges_from([(10, 3), (10, 4)])
+        SG.add_edges_from([("Z", 8), ("Z", 3)])
 
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
         # Remove central node
-        SG.remove_node(4)
-        FG.remove_node(3)
-        SG.add_edges_from([(5, 6), (5, 6), (5, 7)])
-        FG.add_edges_from([(1, 6), (1, 6), (6, 2)])
+        FG.remove_node(4)
+        SG.remove_node(3)
+        FG.add_edges_from([(5, 6), (5, 6), (5, 7)])
+        SG.add_edges_from([(1, 6), (1, 6), (6, 2)])
 
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
     def test_custom_multigraph4_same_labels(self):
-        SG = nx.MultiGraph()
+        FG = nx.MultiGraph()
         edges1 = [
             (1, 2),
             (1, 2),
@@ -1266,24 +1251,24 @@ class TestMultiGraphISOVF2pp:
             13: "e",
         }
 
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
 
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
         nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_same))), "label")
+        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
         # Add extra but corresponding edges to both graphs
-        SG.add_edges_from([(2, 2), (2, 3), (2, 8), (3, 4)])
-        FG.add_edges_from([("m", "m"), ("m", "l"), ("m", "h"), ("l", "j")])
+        FG.add_edges_from([(2, 2), (2, 3), (2, 8), (3, 4)])
+        SG.add_edges_from([("m", "m"), ("m", "l"), ("m", "h"), ("l", "j")])
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
         # Obtain subgraphs
-        SH = nx.MultiGraph(SG.subgraph([2, 3, 4, 6, 10, 11, 12, 13]))
-        FH = nx.MultiGraph(
-            FG.subgraph(
+        FH = nx.MultiGraph(FG.subgraph([2, 3, 4, 6, 10, 11, 12, 13]))
+        SH = nx.MultiGraph(
+            SG.subgraph(
                 [
                     mapped[2],
                     mapped[3],
@@ -1301,33 +1286,33 @@ class TestMultiGraphISOVF2pp:
         assert not m
 
         # Make them isomorphic
-        FH.remove_edges_from(
+        SH.remove_edges_from(
             [(mapped[3], mapped[2]), (mapped[9], mapped[8]), (mapped[2], mapped[2])]
         )
-        FH.add_edges_from([(mapped[9], mapped[9]), (mapped[2], mapped[8])])
+        SH.add_edges_from([(mapped[9], mapped[9]), (mapped[2], mapped[8])])
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         assert m
 
         # Re-structure the disconnected sub-graph
-        SH.remove_node(12)
-        FH.remove_node(mapped[12])
-        SH.add_edge(13, 13)
-        FH.add_edge(mapped[13], mapped[13])
+        FH.remove_node(12)
+        SH.remove_node(mapped[12])
+        FH.add_edge(13, 13)
+        SH.add_edge(mapped[13], mapped[13])
 
         # Connect the two disconnected components, forming a single graph
-        SH.add_edges_from([(3, 13), (6, 11)])
-        FH.add_edges_from([(mapped[8], mapped[10]), (mapped[2], mapped[11])])
+        FH.add_edges_from([(3, 13), (6, 11)])
+        SH.add_edges_from([(mapped[8], mapped[10]), (mapped[2], mapped[11])])
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         assert m
 
         # Change orientation of self-loops in one graph, maintaining the degree sequence
-        SH.remove_edges_from([(2, 2), (3, 6)])
-        SH.add_edges_from([(6, 6), (2, 3)])
+        FH.remove_edges_from([(2, 2), (3, 6)])
+        FH.add_edges_from([(6, 6), (2, 3)])
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         assert not m
 
     def test_custom_multigraph4_different_labels(self):
-        SG = nx.MultiGraph()
+        FG = nx.MultiGraph()
         edges1 = [
             (1, 2),
             (1, 2),
@@ -1372,79 +1357,79 @@ class TestMultiGraphISOVF2pp:
             13: "e",
         }
 
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
 
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_many))), "label")
+        nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_many))), "label")
         nx.set_node_attributes(
-            FG,
-            dict(zip([mapped[n] for n in SG], it.cycle(labels_many))),
+            SG,
+            dict(zip([mapped[n] for n in FG], it.cycle(labels_many))),
             "label",
         )
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m == mapped
 
         # Add extra but corresponding edges to both graphs
-        SG.add_edges_from([(2, 2), (2, 3), (2, 8), (3, 4)])
-        FG.add_edges_from([("m", "m"), ("m", "l"), ("m", "h"), ("l", "j")])
+        FG.add_edges_from([(2, 2), (2, 3), (2, 8), (3, 4)])
+        SG.add_edges_from([("m", "m"), ("m", "l"), ("m", "h"), ("l", "j")])
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m == mapped
 
         # Obtain isomorphic subgraphs
-        SH = nx.MultiGraph(SG.subgraph([2, 3, 4, 6]))
-        FH = nx.MultiGraph(FG.subgraph(["m", "l", "j", "i"]))
+        FH = nx.MultiGraph(FG.subgraph([2, 3, 4, 6]))
+        SH = nx.MultiGraph(SG.subgraph(["m", "l", "j", "i"]))
 
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         assert m
 
         # Delete the 3-clique, keeping only the path-graph. Also, SH mirrors FH
-        SH.remove_node(4)
-        FH.remove_node("j")
-        SH.remove_edges_from([(2, 2), (2, 3), (6, 6)])
-        FH.remove_edges_from([("l", "i"), ("m", "m"), ("m", "m")])
+        FH.remove_node(4)
+        SH.remove_node("j")
+        FH.remove_edges_from([(2, 2), (2, 3), (6, 6)])
+        SH.remove_edges_from([("l", "i"), ("m", "m"), ("m", "m")])
 
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         assert not m
 
         # Assign the same labels so that mirroring means isomorphic
-        for n1, n2 in zip(SH.nodes(), FH.nodes()):
-            SH.nodes[n1]["label"] = "red"
-            FH.nodes[n2]["label"] = "red"
+        for n1, n2 in zip(FH.nodes(), SH.nodes()):
+            FH.nodes[n1]["label"] = "red"
+            SH.nodes[n2]["label"] = "red"
 
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         assert m
 
         # Leave only one node with self-loop
-        SH.remove_nodes_from([3, 6])
-        FH.remove_nodes_from(["m", "l"])
+        FH.remove_nodes_from([3, 6])
+        SH.remove_nodes_from(["m", "l"])
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         assert m
 
         # Remove one self-loop from SH
-        SH.remove_edge(2, 2)
+        FH.remove_edge(2, 2)
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         assert not m
 
         # Same for FH
-        FH.remove_edge("i", "i")
+        SH.remove_edge("i", "i")
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         assert m
 
         # Compose SH with the disconnected sub-graph of SG. Same for FH
-        SHG = nx.compose(SH, nx.MultiGraph(SG.subgraph([10, 11, 12, 13])))
-        FHG = nx.compose(FH, nx.MultiGraph(FG.subgraph(["a", "b", "d", "e"])))
+        FHG = nx.compose(FH, nx.MultiGraph(FG.subgraph([10, 11, 12, 13])))
+        SHG = nx.compose(SH, nx.MultiGraph(SG.subgraph(["a", "b", "d", "e"])))
 
         m = vf2pp_isomorphism(FH, SH, node_label="label")
         m = vf2pp_isomorphism(FHG, SHG, node_label="label")
         assert m
 
         # Connect the two components. Also test selfloops
-        SHG.add_edges_from([(13, 13), (13, 13), (2, 13)])
-        FHG.add_edges_from([("e", "e"), ("i", "e")])
+        FHG.add_edges_from([(13, 13), (13, 13), (2, 13)])
+        SHG.add_edges_from([("e", "e"), ("i", "e")])
         m = vf2pp_isomorphism(FHG, SHG, node_label="label")
         assert not m
 
-        FHG.add_edges_from([("e", "e")])
+        SHG.add_edges_from([("e", "e")])
         m = vf2pp_isomorphism(FHG, SHG, node_label="label")
         assert m
 
@@ -1459,7 +1444,7 @@ class TestMultiGraphISOVF2pp:
         #    \ 7 /
         #     \|/
         #      8
-        SG = nx.MultiGraph()
+        FG = nx.MultiGraph()
         edges1 = [
             (1, 5),
             (1, 2),
@@ -1476,19 +1461,19 @@ class TestMultiGraphISOVF2pp:
         ]
         mapped = {1: "a", 2: "h", 3: "d", 4: "i", 5: "g", 6: "b", 7: "j", 8: "c"}
 
-        SG.add_edges_from(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
+        FG.add_edges_from(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
         nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_same))), "label")
+        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
 
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
         # Add multiple edges and self-loops, maintaining isomorphism
-        SG.add_edges_from(
+        FG.add_edges_from(
             [(1, 2), (1, 2), (3, 7), (8, 8), (8, 8), (7, 8), (2, 3), (5, 6)]
         )
-        FG.add_edges_from(
+        SG.add_edges_from(
             [
                 ("a", "h"),
                 ("a", "h"),
@@ -1508,7 +1493,7 @@ class TestMultiGraphISOVF2pp:
         assert m
 
         # Make FG to be the rotated SG
-        FG.remove_edges_from(
+        SG.remove_edges_from(
             [
                 ("a", "h"),
                 ("a", "h"),
@@ -1520,7 +1505,7 @@ class TestMultiGraphISOVF2pp:
                 ("g", "b"),
             ]
         )
-        FG.add_edges_from(
+        SG.add_edges_from(
             [
                 ("d", "i"),
                 ("a", "h"),
@@ -1537,51 +1522,51 @@ class TestMultiGraphISOVF2pp:
         assert m
 
     def test_disconnected_multigraph_all_same_labels(self):
-        SG = nx.MultiGraph()
-        SG.add_nodes_from(list(range(10)))
-        SG.add_edges_from([(i, i) for i in range(10)])
+        FG = nx.MultiGraph()
+        FG.add_nodes_from(list(range(10)))
+        FG.add_edges_from([(i, i) for i in range(10)])
 
         mapped = {0: 9, 1: 8, 2: 7, 3: 6, 4: 5, 5: 4, 6: 3, 7: 2, 8: 1, 9: 0}
-        FG = nx.relabel_nodes(SG, mapped)
+        SG = nx.relabel_nodes(FG, mapped)
 
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
         nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_same))), "label")
+        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_same))), "label")
 
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
         # Add self-loops to non-mapped nodes. Should be the same, as the graph is disconnected.
-        SG.add_edges_from([(i, i) for i in range(5, 8)] * 3)
+        FG.add_edges_from([(i, i) for i in range(5, 8)] * 3)
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert not m
 
         # Compensate in FG
-        FG.add_edges_from([(i, i) for i in range(3)] * 3)
+        SG.add_edges_from([(i, i) for i in range(3)] * 3)
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
         # Add one more self-loop in FG
-        FG.add_edges_from([(0, 0), (1, 1), (1, 1)])
+        SG.add_edges_from([(0, 0), (1, 1), (1, 1)])
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert not m
 
         # Compensate in SG
-        SG.add_edges_from([(5, 5), (7, 7), (7, 7)])
+        FG.add_edges_from([(5, 5), (7, 7), (7, 7)])
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
     def test_disconnected_multigraph_all_different_labels(self):
-        SG = nx.MultiGraph()
-        SG.add_nodes_from(list(range(10)))
-        SG.add_edges_from([(i, i) for i in range(10)])
+        FG = nx.MultiGraph()
+        FG.add_nodes_from(list(range(10)))
+        FG.add_edges_from([(i, i) for i in range(10)])
 
         mapped = {0: 9, 1: 8, 2: 7, 3: 6, 4: 5, 5: 4, 6: 3, 7: 2, 8: 1, 9: 0}
-        FG = nx.relabel_nodes(SG, mapped)
+        SG = nx.relabel_nodes(FG, mapped)
 
-        nx.set_node_attributes(SG, dict(zip(SG, it.cycle(labels_many))), "label")
+        nx.set_node_attributes(FG, dict(zip(FG, it.cycle(labels_many))), "label")
         nx.set_node_attributes(
-            FG,
-            dict(zip([mapped[n] for n in SG], it.cycle(labels_many))),
+            SG,
+            dict(zip([mapped[n] for n in FG], it.cycle(labels_many))),
             "label",
         )
         m = vf2pp_isomorphism(FG, SG, node_label="label")
@@ -1589,22 +1574,22 @@ class TestMultiGraphISOVF2pp:
         assert m == mapped
 
         # Add self-loops to non-mapped nodes. Now it is not the same, as there are different labels
-        SG.add_edges_from([(i, i) for i in range(5, 8)] * 3)
+        FG.add_edges_from([(i, i) for i in range(5, 8)] * 3)
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert not m
 
         # Add self-loops to non mapped nodes in FG as well
-        FG.add_edges_from([(mapped[i], mapped[i]) for i in range(3)] * 7)
+        SG.add_edges_from([(mapped[i], mapped[i]) for i in range(3)] * 7)
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert not m
 
         # Add self-loops to mapped nodes in FG
-        FG.add_edges_from([(mapped[i], mapped[i]) for i in range(5, 8)] * 3)
+        SG.add_edges_from([(mapped[i], mapped[i]) for i in range(5, 8)] * 3)
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert not m
 
         # Add self-loops to SG so that they are even in both graphs
-        SG.add_edges_from([(i, i) for i in range(3)] * 7)
+        FG.add_edges_from([(i, i) for i in range(3)] * 7)
         m = vf2pp_isomorphism(FG, SG, node_label="label")
         assert m
 
@@ -1627,14 +1612,14 @@ class TestDiGraphISOVF2pp:
         ]
         mapped = {1: "a", 2: "h", 3: "d", 4: "i", 5: "g", 6: "b", 7: "j", 8: "c"}
 
-        SG = nx.DiGraph(edges1)
-        FG = nx.relabel_nodes(SG, mapped)
+        FG = nx.DiGraph(edges1)
+        SG = nx.relabel_nodes(FG, mapped)
 
         assert vf2pp_isomorphism(FG, SG) == mapped
 
         # Change the direction of an edge
-        SG.remove_edge(1, 5)
-        SG.add_edge(5, 1)
+        FG.remove_edge(1, 5)
+        FG.add_edge(5, 1)
         assert vf2pp_isomorphism(FG, SG) is None
 
     def test_non_isomorphic_same_degree_sequence(self):
@@ -1673,8 +1658,8 @@ class TestDiGraphISOVF2pp:
             (3, 7),
         ]
 
-        SG = nx.DiGraph(edges1)
-        FG = nx.DiGraph(edges2)
+        FG = nx.DiGraph(edges1)
+        SG = nx.DiGraph(edges2)
         assert vf2pp_isomorphism(FG, SG) is None
 
 

--- a/networkx/algorithms/isomorphism/vf2pp.py
+++ b/networkx/algorithms/isomorphism/vf2pp.py
@@ -18,14 +18,14 @@ is isomorphic to an induced subgraph of the other graph.
 `vf2pp_subgraph_isomorphism`: obtain the node isomorphism mapping between a
 specified graph and any induced subgraph of the other graph, if possible.
 `vf2pp_all_subgraph_isomorphisms`: generate all possible isomorphism mappings
-between the specified induced subgraph and the graph.
+between the full graph and the specified induced subgraph.
 
-`vf2pp_is_monomorphic`: check whether two graphs are monomorphic. That is,
-the node and edge sets of one are subsets of the other's node and edge sets.
-`vf2pp_monomorphism`: obtain the node monomorphism mapping between a
-specified graph and any subgraph of the other graph, if possible.
+`vf2pp_is_monomorphic`: check whether two graphs are monomorphic. That is, the node
+and edge sets of the subgraph are subsets of the full graph's node and edge sets.
+`vf2pp_monomorphism`: obtain the node monomorphism mapping from the full graph to
+the specified subgraph if possible.
 `vf2pp_all_monomorphisms`: generate all possible monomorphism mappings
-between the specified subgraph and the graph.
+between the graph and the specified subgraph.
 
 Introduction
 ------------
@@ -183,7 +183,7 @@ _StateInfo = collections.namedtuple(
 
 @nx._dispatchable(graphs={"FG": 0, "SG": 1}, node_attrs={"node_label": "default_label"})
 def vf2pp_isomorphism(FG, SG, node_label=None, default_label=None):
-    """Return an isomorphic mapping between `SG` and `FG` if it exists.
+    """Return an isomorphic mapping between `FG` and `SG` if it exists.
 
     Parameters
     ----------
@@ -245,7 +245,7 @@ def vf2pp_is_isomorphic(FG, SG, node_label=None, default_label=None):
 
 @nx._dispatchable(graphs={"FG": 0, "SG": 1}, node_attrs={"node_label": "default_label"})
 def vf2pp_all_isomorphisms(FG, SG, node_label=None, default_label=None):
-    """Yields all the possible mappings between SG and FG.
+    """Yields all the possible mappings between FG and SG.
 
     Parameters
     ----------
@@ -265,14 +265,14 @@ def vf2pp_all_isomorphisms(FG, SG, node_label=None, default_label=None):
     Yields
     ------
     dict
-        Isomorphic mapping between the nodes in `SG` and `FG`.
+        Isomorphic mapping between the nodes in `FG` and `SG`.
     """
     yield from _all_morphisms(FG, SG, node_label, default_label, PT="ISO")
 
 
 @nx._dispatchable(graphs={"FG": 0, "SG": 1}, node_attrs={"node_label": "default_label"})
 def vf2pp_subgraph_isomorphism(FG, SG, node_label=None, default_label=None):
-    """Return an isomorphic mapping between nodes of `SG` and `FG` if it exists.
+    """Return an isomorphic mapping between nodes of `FG` and `SG` if it exists.
 
     Parameters
     ----------
@@ -335,7 +335,7 @@ def vf2pp_subgraph_is_isomorphic(FG, SG, node_label=None, default_label=None):
 
 @nx._dispatchable(graphs={"FG": 0, "SG": 1}, node_attrs={"node_label": "default_label"})
 def vf2pp_all_subgraph_isomorphisms(FG, SG, node_label=None, default_label=None):
-    """Yields all the possible subgraph isomorphisms between SG and FG.
+    """Yields all the possible subgraph isomorphisms between FG and SG.
 
     Parameters
     ----------
@@ -362,7 +362,7 @@ def vf2pp_all_subgraph_isomorphisms(FG, SG, node_label=None, default_label=None)
 
 @nx._dispatchable(graphs={"FG": 0, "SG": 1}, node_attrs={"node_label": "default_label"})
 def vf2pp_monomorphism(FG, SG, node_label=None, default_label=None):
-    """Return a monomorphic mapping between `SG` and `FG` if it exists.
+    """Return a monomorphic mapping between `FG` and `SG` if it exists.
 
     Parameters
     ----------
@@ -424,13 +424,12 @@ def vf2pp_is_monomorphic(FG, SG, node_label=None, default_label=None):
 
 @nx._dispatchable(graphs={"FG": 0, "SG": 1}, node_attrs={"node_label": "default_label"})
 def vf2pp_all_monomorphisms(FG, SG, node_label=None, default_label=None):
-    """Yields all the possible monomorphisms between nodes of SG and FG.
+    """Yields all the possible monomorphisms between nodes of FG and SG.
 
-    A monomorphism means that edges between two nodes in SG must connect the
-    image nodes of those two nodes in FG, but that edges in FG do not have
-    to have pre-image edges in SG. The mapping is injective not bijective.
-    The mapped nodes have to maintain the SG connections, but not the SG
-    disconnections. Maintaining edges and non-edges is provided by the
+    A monomorphism is an injective version of an isomorphism. If two nodes in SG
+    are connected by an edge, the pre-image nodes in FG must also be connected.
+    But two mapped nodes connected by an edge in FG may not have an edge in SG.
+    Maintaining both edges and non-edges (an induced subgraph) is provided by
     subgraph isomorphism functions.
 
     Parameters
@@ -451,7 +450,7 @@ def vf2pp_all_monomorphisms(FG, SG, node_label=None, default_label=None):
     Yields
     ------
     dict
-        Isomorphic mapping between the nodes in `SG` and `FG`.
+        Isomorphic mapping of the nodes in `FG` to nodes in `SG`.
     """
     yield from _all_morphisms(FG, SG, node_label, default_label, PT="MONO")
 
@@ -547,10 +546,10 @@ def _all_morphisms(FG, SG, node_label, default_label, PT):
 
         if _feasibility(current_node, candidate, graph_info, state_info):
             # Yield mapping if extended to all SG
-            if len(mapping) == SG.number_of_nodes() - 1:
-                cp_mapping = mapping.copy()
-                cp_mapping[current_node] = candidate
-                yield cp_mapping
+            if len(rev_map) == SG.number_of_nodes() - 1:
+                cp_rev_map = rev_map.copy()
+                cp_rev_map[candidate] = current_node
+                yield cp_rev_map
                 continue
 
             # Feasibility rules pass, so extend the mapping and update Tinout

--- a/networkx/algorithms/isomorphism/vf2pp.py
+++ b/networkx/algorithms/isomorphism/vf2pp.py
@@ -112,7 +112,7 @@ because not all induced edges need to be mapped to.
 >>> nx.vf2pp_is_monomorphic(FG, SG, node_label=None)
 True
 >>> map = nx.vf2pp_monomorphism(FG, SG, node_label=None)
->>> map == {1: 0, 2: 1, 0: 3, 3: 2}
+>>> map == {1: 2, 2: 3, 0: 1, 3: 0}
 True
 
 With node labels:


### PR DESCRIPTION
Fixes #8810 

The vf2pp functions (change recently in #8506) return the mapping from the subgraph to the graph instead of the graph to the subgraph. That breaks backward compatibility!  Also, an advantage of mapping from the graph to the subgraph is that the keys of the dict are the nodes in the full graph that make an induced subgraph. And "fixing" vf2pp also brings it in line with the other algorithms in the isomorphism suite.

So:  I have reversed the mapping that gets returned (put it back the way it was -- I never intended it to change).
I also added a test to ensure that the various isomorphism algorithms report the same direction for the mapping, and reversed the mapping for tests recently put into vf2pp with the wrong ordering. 
And I adjusted the docs to reflect this change.

The diff for the 2nd commit is all in `test_vf2pp.py` and it just switches names `SH` and `FH` except in calls to the vf2pp functions. The separate commit is to simplify review. But it is still quite long...

I feel very lucky to have this reported before it was released. Thanks @wenwen-666