### PR TITLE
fix: raise ValueError for invalid method in all_shortest_paths helpers

### DIFF
--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -503,7 +503,13 @@ def all_shortest_paths(G, source, target, weight=None, method="dijkstra"):
     single_source_shortest_path
     all_pairs_shortest_path
     """
-    method = "unweighted" if weight is None else method
+    if weight is None:
+        method = "unweighted"
+    if method == "unweighted":
+        if weight is not None:
+            raise ValueError(f"method not supported: {method}")
+    elif method not in ("dijkstra", "bellman-ford"):
+        raise ValueError(f"method not supported: {method}")
     if method == "unweighted":
         pred = nx.predecessor(G, source)
     elif method == "dijkstra":
@@ -576,7 +582,13 @@ def single_source_all_shortest_paths(G, source, weight=None, method="dijkstra"):
     all_pairs_shortest_path
     all_pairs_all_shortest_paths
     """
-    method = "unweighted" if weight is None else method
+    if weight is None:
+        method = "unweighted"
+    if method == "unweighted":
+        if weight is not None:
+            raise ValueError(f"method not supported: {method}")
+    elif method not in ("dijkstra", "bellman-ford"):
+        raise ValueError(f"method not supported: {method}")
     if method == "unweighted":
         pred = nx.predecessor(G, source)
     elif method == "dijkstra":

--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -67,7 +67,7 @@ def shortest_path(G, source=None, target=None, weight=None, method="dijkstra"):
 
     method : string, optional (default = 'dijkstra')
         The algorithm to use to compute the path.
-        Supported options: 'dijkstra', 'bellman-ford'.
+        Supported options: ``dijkstra``, ``bellman-ford``.
         Other inputs produce a ValueError.
         If `weight` is None, unweighted graph methods are used, and this
         suggestion is ignored.
@@ -208,7 +208,7 @@ def shortest_path_length(G, source=None, target=None, weight=None, method="dijks
 
     method : string, optional (default = 'dijkstra')
         The algorithm to use to compute the path length.
-        Supported options: 'dijkstra', 'bellman-ford'.
+        Supported options: ``dijkstra``, ``bellman-ford``.
         Other inputs produce a ValueError.
         If `weight` is None, unweighted graph methods are used, and this
         suggestion is ignored.
@@ -464,7 +464,7 @@ def all_shortest_paths(G, source, target, weight=None, method="dijkstra"):
 
     method : string, optional (default = 'dijkstra')
        The algorithm to use to compute the path lengths.
-       Supported options: 'dijkstra', 'bellman-ford'.
+       Supported options: ``dijkstra``, ``bellman-ford``.
        Other inputs produce a ValueError.
        If `weight` is None, unweighted graph methods are used, and this
        suggestion is ignored.
@@ -545,7 +545,7 @@ def single_source_all_shortest_paths(G, source, weight=None, method="dijkstra"):
 
     method : string, optional (default = 'dijkstra')
        The algorithm to use to compute the path lengths.
-       Supported options: 'dijkstra', 'bellman-ford'.
+       Supported options: ``dijkstra``, ``bellman-ford``.
        Other inputs produce a ValueError.
        If `weight` is None, unweighted graph methods are used, and this
        suggestion is ignored.
@@ -621,7 +621,7 @@ def all_pairs_all_shortest_paths(G, weight=None, method="dijkstra"):
 
     method : string, optional (default = 'dijkstra')
        The algorithm to use to compute the path lengths.
-       Supported options: 'dijkstra', 'bellman-ford'.
+       Supported options: ``dijkstra``, ``bellman-ford``.
        Other inputs produce a ValueError.
        If `weight` is None, unweighted graph methods are used, and this
        suggestion is ignored.

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -391,6 +391,32 @@ class TestGenericPath:
                 )
             )
 
+    def test_all_shortest_paths_unweighted_method_with_weight(self):
+        G = nx.Graph()
+        G.add_edge("A", "B", weight=100)
+        G.add_edge("A", "C", weight=1)
+        G.add_edge("C", "D", weight=1)
+        G.add_edge("D", "B", weight=1)
+        with pytest.raises(ValueError):
+            list(
+                nx.all_shortest_paths(
+                    G, "A", "B", weight="weight", method="unweighted"
+                )
+            )
+
+    def test_single_source_all_shortest_paths_unweighted_method_with_weight(self):
+        G = nx.Graph()
+        G.add_edge("A", "B", weight=100)
+        G.add_edge("A", "C", weight=1)
+        G.add_edge("C", "D", weight=1)
+        G.add_edge("D", "B", weight=1)
+        with pytest.raises(ValueError):
+            dict(
+                nx.single_source_all_shortest_paths(
+                    G, "A", weight="weight", method="unweighted"
+                )
+            )
+
     def test_all_shortest_paths_zero_weight_edge(self):
         g = nx.Graph()
         nx.add_path(g, [0, 1, 3])


### PR DESCRIPTION
Rebased onto current `main` from the upstream `networkx/networkx`.
