### PR TITLE
DOC: clarify method='unweighted' behavior in all_shortest_paths helpers

### DIFF
--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -464,10 +464,12 @@ def all_shortest_paths(G, source, target, weight=None, method="dijkstra"):
 
     method : string, optional (default = 'dijkstra')
        The algorithm to use to compute the path lengths.
-       Supported options: 'dijkstra', 'bellman-ford'.
-       Other inputs produce a ValueError.
-       If `weight` is None, unweighted graph methods are used, and this
-       suggestion is ignored.
+       Supported options: 'dijkstra', 'bellman-ford', 'unweighted'.
+       Other inputs produce a ValueError. If `method='unweighted'` is
+       passed explicitly, the search treats every edge as having equal
+       weight, and the `weight` argument, if given, is ignored.
+       If `weight` is None, unweighted graph methods are used
+       regardless of what `method` is set to.
 
     Returns
     -------
@@ -477,7 +479,8 @@ def all_shortest_paths(G, source, target, weight=None, method="dijkstra"):
     Raises
     ------
     ValueError
-        If `method` is not among the supported options.
+        If `method` is not among the supported options: 'dijkstra',
+        'bellman-ford', 'unweighted'.
 
     NetworkXNoPath
         If `target` cannot be reached from `source`.
@@ -539,10 +542,12 @@ def single_source_all_shortest_paths(G, source, weight=None, method="dijkstra"):
 
     method : string, optional (default = 'dijkstra')
        The algorithm to use to compute the path lengths.
-       Supported options: 'dijkstra', 'bellman-ford'.
-       Other inputs produce a ValueError.
-       If `weight` is None, unweighted graph methods are used, and this
-       suggestion is ignored.
+       Supported options: 'dijkstra', 'bellman-ford', 'unweighted'.
+       Other inputs produce a ValueError. If `method='unweighted'` is
+       passed explicitly, the search treats every edge as having equal
+       weight, and the `weight` argument, if given, is ignored.
+       If `weight` is None, unweighted graph methods are used
+       regardless of what `method` is set to.
 
     Returns
     -------
@@ -552,7 +557,8 @@ def single_source_all_shortest_paths(G, source, weight=None, method="dijkstra"):
     Raises
     ------
     ValueError
-        If `method` is not among the supported options.
+        If `method` is not among the supported options: 'dijkstra',
+        'bellman-ford', 'unweighted'.
 
     Examples
     --------
@@ -609,10 +615,12 @@ def all_pairs_all_shortest_paths(G, weight=None, method="dijkstra"):
 
     method : string, optional (default = 'dijkstra')
        The algorithm to use to compute the path lengths.
-       Supported options: 'dijkstra', 'bellman-ford'.
-       Other inputs produce a ValueError.
-       If `weight` is None, unweighted graph methods are used, and this
-       suggestion is ignored.
+       Supported options: 'dijkstra', 'bellman-ford', 'unweighted'.
+       Other inputs produce a ValueError. If `method='unweighted'` is
+       passed explicitly, the search treats every edge as having equal
+       weight, and the `weight` argument, if given, is ignored.
+       If `weight` is None, unweighted graph methods are used
+       regardless of what `method` is set to.
 
     Returns
     -------
@@ -622,7 +630,8 @@ def all_pairs_all_shortest_paths(G, weight=None, method="dijkstra"):
     Raises
     ------
     ValueError
-        If `method` is not among the supported options.
+        If `method` is not among the supported options: 'dijkstra',
+        'bellman-ford', 'unweighted'.
 
     Examples
     --------


### PR DESCRIPTION
Fixes #8811

## What changed

Updated the docstrings for `all_shortest_paths`, 
`single_source_all_shortest_paths`, and `all_pairs_all_shortest_paths` 
to document `method='unweighted'` as a supported value, and to 
clarify that passing it explicitly causes the `weight` argument 
to be ignored.

## Why

As discussed in #8811, the current behavior — where 
`method='unweighted'` overrides `weight` — is being kept for 
backward compatibility rather than changed. This PR only updates 
the documentation to accurately reflect that existing behavior, 
per the discussion with @dschult and @amcandio.

## Scope

Documentation only. No code or test changes — behavior is 
unchanged, only now correctly documented.
