### PR TITLE
Raise NetworkXError on unknown attribute class in GEXF reader

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -832,7 +832,7 @@ class GEXFReader(GEXF):
                 edge_default.update(ed)
                 G.graph["edge_default"] = edge_default
             else:
-                raise  # unknown attribute class
+                raise nx.NetworkXError(f"Unknown attribute class {attr_class}.")
 
         # Hack to handle Gephi0.7beta bug
         # add weight attribute

--- a/networkx/readwrite/tests/test_gexf.py
+++ b/networkx/readwrite/tests/test_gexf.py
@@ -300,6 +300,29 @@ org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/\
         fh = io.BytesIO(s.encode("UTF-8"))
         pytest.raises(nx.NetworkXError, nx.read_gexf, fh)
 
+    @pytest.mark.parametrize(
+        "attributes_tag", ['<attributes class="graph">', "<attributes>"]
+    )
+    def test_unknown_attribute_class_raises(self, attributes_tag):
+        s = f"""<?xml version="1.0" encoding="UTF-8"?>
+<gexf xmlns="http://www.gexf.net/1.2draft" version='1.2'>
+    <graph mode="static" defaultedgetype="directed" name="">
+        {attributes_tag}
+            <attribute id="0" title="url" type="string"/>
+        </attributes>
+        <nodes>
+            <node id="0" label="Hello" />
+            <node id="1" label="Word" />
+        </nodes>
+        <edges>
+            <edge id="0" source="0" target="1"/>
+        </edges>
+    </graph>
+</gexf>
+"""
+        fh = io.BytesIO(s.encode("UTF-8"))
+        pytest.raises(nx.NetworkXError, nx.read_gexf, fh)
+
     def test_relabel(self):
         s = """<?xml version="1.0" encoding="UTF-8"?>
 <gexf xmlns="http://www.gexf.net/1.2draft" version='1.2'>


### PR DESCRIPTION
#### What does this implement/fix?

`GEXFReader` dispatches on the `class` attribute of each `<attributes>` element and ends the chain with a bare `raise` outside of an exception handler (`networkx/readwrite/gexf.py:835`). Reading a file whose `<attributes>` element carries any other class — or no class at all — therefore fails with

```
RuntimeError: No active exception to reraise
```

Reproduction on `main`:

```python
import io, networkx as nx

s = """<?xml version="1.0" encoding="UTF-8"?>
<gexf xmlns="http://www.gexf.net/1.2draft" version="1.2">
  <graph mode="static" defaultedgetype="undirected">
    <attributes class="graph">
      <attribute id="0" title="url" type="string"/>
    </attributes>
    <nodes><node id="0" label="a"/><node id="1" label="b"/></nodes>
    <edges><edge id="0" source="0" target="1"/></edges>
  </graph>
</gexf>"""

nx.read_gexf(io.StringIO(s))
# RuntimeError: No active exception to reraise
```

Dropping `class="graph"` to just `<attributes>` gives the same result.

This replaces the bare `raise` with `NetworkXError`, naming the offending class, which is what the rest of the module does for malformed input (`Unknown GEXF version`, `No <graph> element in GEXF file.`, `Undirected edge found in directed graph.`). The test covers both the unknown-class and the missing-class case; it fails with `RuntimeError` on `main` and passes with the fix. `networkx/readwrite/tests/test_gexf.py` is otherwise unchanged: 33 passed, 1 skipped.

#### Additional information

Per the Automated Contributions Policy — AI assistance was used on this PR. Tool: Claude Opus (Claude Code). Scope: it ran the static-analysis sweep that surfaced the bare `raise`, wrote the one-line fix and the test, and ran the test suite. I read the diff and the reproduction before submitting and can explain the change.
