### PR TITLE
Fix docstring parameters that are not in the signature

### DIFF
--- a/networkx/algorithms/assortativity/mixing.py
+++ b/networkx/algorithms/assortativity/mixing.py
@@ -226,9 +226,6 @@ def mixing_dict(xy, normalized=False):
     xy : list or container of two-tuples
        Pairs of (x,y) items.
 
-    attribute : string
-       Node attribute key
-
     normalized : bool (default=False)
        Return counts if False or probabilities if True.
 

--- a/networkx/drawing/layout.py
+++ b/networkx/drawing/layout.py
@@ -1903,11 +1903,6 @@ def rescale_layout(pos, scale=1):
     scale : number (default: 1)
         The size of the resulting extent in all directions.
 
-    attribute : str, default None
-        If non-None, the position of each node will be stored on the graph as
-        an attribute named `attribute` which can be accessed with
-        `G.nodes[...][attribute]`. The function still returns the dictionary.
-
     Returns
     -------
     pos : numpy array

--- a/networkx/generators/degree_seq.py
+++ b/networkx/generators/degree_seq.py
@@ -655,7 +655,7 @@ def degree_sequence_tree(deg_sequence, create_using=None):
 
     Parameters
     ----------
-    degree_sequence : iterable
+    deg_sequence : iterable
         Iterable of node degrees.
 
     create_using : NetworkX graph constructor, optional (default=nx.Graph)

--- a/networkx/generators/joint_degree_seq.py
+++ b/networkx/generators/joint_degree_seq.py
@@ -475,9 +475,10 @@ def directed_joint_degree_graph(in_degrees, out_degrees, nkk, seed=None):
 
     Parameters
     ----------
-    degree_seq :  list of tuples (of size 3)
-        degree sequence contains tuples of nodes with node id, in degree and
-        out degree.
+    in_degrees :  list of integers
+        in degree sequence contains the in degrees of nodes.
+    out_degrees : list of integers
+        out degree sequence contains the out degrees of nodes.
     nkk  :  dictionary of dictionary of integers
         directed joint degree dictionary, for nodes of out degree k (first
         level of dict) and nodes of in degree l (second level of dict)
@@ -493,7 +494,8 @@ def directed_joint_degree_graph(in_degrees, out_degrees, nkk, seed=None):
     Raises
     ------
     NetworkXError
-        If degree_seq and nkk are not realizable as a simple directed graph.
+        If in_degrees, out_degrees and nkk are not realizable as a simple
+        directed graph.
 
 
     Notes


### PR DESCRIPTION
#### What does this implement/fix?

Four docstrings document a parameter that is not in the function's signature. All four are public API, so copying the documented name from the docs gives a `TypeError`, or in the two removal cases promises behaviour the function cannot have.

**`degree_sequence_tree`** (`networkx/generators/degree_seq.py`) — signature is `degree_sequence_tree(deg_sequence, create_using=None)`, docstring says `degree_sequence`. The second parameter is documented correctly, so the block is not a generic template.

**`directed_joint_degree_graph`** (`networkx/generators/joint_degree_seq.py`) — signature is `(in_degrees, out_degrees, nkk, seed=None)`; the docstring still describes a single `degree_seq` of 3-tuples from an older API. The example inside the same docstring already calls it as `nx.directed_joint_degree_graph(in_degrees, out_degrees, nkk)`, and `is_valid_directed_joint_degree` in the same module documents the two sequences properly — I took its wording verbatim so the two stay consistent. The `Raises` section named `degree_seq` too and is updated to match.

**`mixing_dict`** (`networkx/algorithms/assortativity/mixing.py`) — signature is `(xy, normalized=False)`. There is no `attribute` argument and no graph in scope; `attribute_mixing_dict` directly above does take one, which is where the block came from.

**`rescale_layout`** (`networkx/drawing/layout.py`) — signature is `(pos, scale=1)`. The `attribute` block promises that "the position of each node will be stored on the graph as an attribute", but the function only receives a NumPy array and returns a NumPy array — there is no graph to store anything on, and it does not return a dictionary either, contrary to the last sentence of that block. This describes the `store_pos_as` parameter that the real layout functions take; `attribute : str, default None` appears exactly once in `layout.py`, here, while `store_pos_as` appears throughout. `rescale_layout_dict` next to it has no such block.

I removed the block rather than implementing it — adding `store_pos_as` here would mean changing the signature to take a graph, which is a separate decision for maintainers.

Docs only, no code touched. `test_degree_seq.py`, `test_joint_degree_seq.py`, `test_mixing.py` and `test_layout.py` pass (44 passed, 2 skipped).

#### Additional information

Per the Automated Contributions Policy — AI assistance was used on this PR. Tool: Claude Opus (Claude Code). Scope: it compared numpydoc `Parameters` sections against the actual signatures across the package, checked that no decorator (`_dispatchable`, `py_random_state`) injects the missing names, and wrote the diff. I checked each of the four against the source before submitting and can explain them.
