### PR TITLE
Fix four docstring parameter names that do not match the signature

### DIFF
--- a/networkx/algorithms/approximation/traveling_salesman.py
+++ b/networkx/algorithms/approximation/traveling_salesman.py
@@ -724,7 +724,7 @@ def held_karp_ascent(G, weight="weight"):
 
         Parameters
         ----------
-        k_xy : set
+        k : set
             The set of 1-arborescences which have the minimum rate of increase
             in the direction of ascent
 

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -1403,7 +1403,7 @@ def _inner_bellman_ford(
     ----------
     G : NetworkX graph
 
-    source: list
+    sources : list
         List of source nodes. The shortest path from any of the source
         nodes will be found if multiple sources are provided.
 

--- a/networkx/algorithms/summarization.py
+++ b/networkx/algorithms/summarization.py
@@ -371,9 +371,6 @@ def _snap_split(groups, neighbor_info, group_lookup, group_id):
     neighbor_info: dict
         A data structure indicating the number of edges a node has with the
         groups in the current summarization of each edge type
-    edge_types: dict
-        dictionary of edges in the graph and their corresponding attributes recognized
-        in the summarization
     group_lookup: dict
         dictionary of nodes and their current corresponding group ID
     group_id: object

--- a/networkx/drawing/nx_latex.py
+++ b/networkx/drawing/nx_latex.py
@@ -390,7 +390,7 @@ def to_latex(
         The latex label used for the figure for easy referral from the main text
     sub_captions : list of strings
         The sub_caption string for each subfigure in the figure
-    sub_latex_labels : list of strings
+    sub_labels : list of strings
         The latex label for each subfigure in the figure
     n_rows : int
         The number of rows of subfigures to arrange for multiple graphs


### PR DESCRIPTION
Four `Parameters` entries name something the function does not take.

| Where | Says | Takes |
|---|---|---|
| `drawing/nx_latex.py` `to_latex` | `sub_latex_labels` | `sub_labels` |
| `approximation/traveling_salesman.py` `find_epsilon` | `k_xy` | `k` |
| `shortest_paths/weighted.py` `_inner_bellman_ford` | `source` | `sources` |
| `algorithms/summarization.py` `_snap_split` | `edge_types` | nothing, it is not a parameter |

Two of these need care, which is why I am pointing it out rather than leaving you to check.

`source: list` appears twice in `weighted.py`. In `_bellman_ford` the parameter really is `source` and the docstring is right; only `_inner_bellman_ford` takes `sources`. Same story in `summarization.py`, where the `edge_types` block appears in three docstrings and two of them are correct: `_snap_build_graph` and `_snap_eligible_group` do take it. A find and replace would have broken the correct ones, so both edits are scoped to the single function.

For `_snap_split` I removed the block rather than renaming it, since there is no parameter it could refer to.

Docstrings only, no behaviour change.
