### PR TITLE
DOC: fix swapped See Also descriptions in communicability

### DIFF
--- a/networkx/algorithms/communicability_alg.py
+++ b/networkx/algorithms/communicability_alg.py
@@ -35,8 +35,8 @@ def communicability(G):
     See Also
     --------
     communicability_exp:
-       Communicability between all pairs of nodes in G  using spectral
-       decomposition.
+       Communicability between all pairs of nodes in G using matrix
+       exponentiation.
     communicability_betweenness_centrality:
        Communicability betweenness centrality for each node in G.
 
@@ -117,7 +117,8 @@ def communicability_exp(G):
     See Also
     --------
     communicability:
-       Communicability between pairs of nodes in G.
+       Communicability between all pairs of nodes in G using spectral
+       decomposition.
     communicability_betweenness_centrality:
        Communicability betweenness centrality for each node in G.
 


### PR DESCRIPTION
Fixes #8802.

The two `See Also` entries in `communicability_alg.py` attribute the methods the wrong way round.

`communicability`'s entry describes `communicability_exp` as computing communicability "using spectral decomposition" — but spectral decomposition is what `communicability` itself uses. Its own Notes say *"This algorithm uses a spectral decomposition of the adjacency matrix"*, and the implementation calls `np.linalg.eigh`. `communicability_exp` calls `scipy.linalg.expm`, and its Notes say *"This algorithm uses matrix exponentiation of the adjacency matrix"*.

So a reader following the cross-reference to pick between the two is told the opposite of what each does.

This corrects both entries: `communicability_exp` is now described as using matrix exponentiation, and the reciprocal entry in `communicability_exp` (previously just "Communicability between pairs of nodes in G", with no method named) now says spectral decomposition, so the pair is symmetric and matches each function's Notes.

Docstrings only — no behaviour change. `networkx/algorithms/tests/test_communicability.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)