### PR TITLE
Fix group_betweenness_centrality on directed graphs without symmetric reachability

### DIFF
--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -146,11 +146,15 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
                     if not (
                         sigma_m[x][y] == 0 or sigma_m[x][v] == 0 or sigma_m[v][y] == 0
                     ):
-                        if D[x][v] == D[x][y] + D[y][v]:
+                        # The sigma checks above only establish that y, v are
+                        # reachable from x and y from v. On a directed graph
+                        # reachability is not symmetric, so D[y][v] and D[v][x]
+                        # may be missing and have to be tested separately.
+                        if v in D[y] and D[x][v] == D[x][y] + D[y][v]:
                             dxyv = sigma_m[x][y] * sigma_m[y][v] / sigma_m[x][v]
                         if D[x][y] == D[x][v] + D[v][y]:
                             dxvy = sigma_m[x][v] * sigma_m[v][y] / sigma_m[x][y]
-                        if D[v][y] == D[v][x] + D[x][y]:
+                        if x in D[v] and D[v][y] == D[v][x] + D[x][y]:
                             dvxy = sigma_m[v][x] * sigma[x][y] / sigma[v][y]
                     sigma_m_v[x][y] = sigma_m[x][y] * (1 - dxvy)
                     PB_m_v[x][y] = PB_m[x][y] - PB_m[x][y] * dxvy
@@ -164,23 +168,21 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
         # endpoints
         v, c = len(G), len(group)
         if not endpoints:
+            # Subtract the pairs that were counted only because a group node
+            # was one of their endpoints: the ordered pairs (s, t), s != t,
+            # with t reachable from s and at least one of s, t in the group.
+            # Counting from the source side for group nodes and from the
+            # target side otherwise covers each such pair exactly once, and
+            # keeps source and target reachability apart -- on a directed
+            # graph "t is reachable from s" does not imply the reverse.
+            # For a (strongly) connected graph this comes to the familiar
+            # c * (2 * v - c - 1).
             scale = 0
-            # if the graph is connected then subtract the endpoints from
-            # the count for all the nodes in the graph. else count how many
-            # nodes are connected to the group's nodes and subtract that.
-            if nx.is_directed(G):
-                if nx.is_strongly_connected(G):
-                    scale = c * (2 * v - c - 1)
-            elif nx.is_connected(G):
-                scale = c * (2 * v - c - 1)
-            if scale == 0:
-                for group_node1 in group:
-                    for node in D[group_node1]:
-                        if node != group_node1:
-                            if node in group:
-                                scale += 1
-                            else:
-                                scale += 2
+            for node in G:
+                if node in group:
+                    scale += len(D[node]) - 1
+                else:
+                    scale += sum(1 for gn in group if gn != node and gn in D[node])
             GBC_group -= scale
 
         # normalized

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -76,6 +76,62 @@ class TestGroupBetweennessCentrality:
         b_answer = 0.0
         assert b == b_answer
 
+    def test_group_betweenness_single_node_directed_not_strongly_connected(self):
+        """
+        A single-node group equals that node's betweenness centrality, also on
+        a directed graph that is not strongly connected. See gh-8559.
+        """
+        G = nx.path_graph(4, create_using=nx.DiGraph)
+        expected = nx.betweenness_centrality(G, normalized=False, endpoints=False)
+
+        for v in G:
+            b = nx.group_betweenness_centrality(
+                G, {v}, normalized=False, endpoints=False
+            )
+            assert b == expected[v]
+            assert b >= 0
+
+    def test_group_betweenness_single_node_directed_disconnected(self):
+        """
+        Same identity on a directed graph with an unreachable component.
+        """
+        G = nx.DiGraph([(0, 1), (1, 2), (3, 4)])
+        expected = nx.betweenness_centrality(G, normalized=False, endpoints=False)
+
+        for v in G:
+            b = nx.group_betweenness_centrality(
+                G, {v}, normalized=False, endpoints=False
+            )
+            assert b == expected[v]
+
+    def test_group_betweenness_directed_unreachable_group_pair(self):
+        """
+        A group whose nodes cannot all reach each other must not raise. See
+        gh-8559, where the distance lookup assumed symmetric reachability.
+        """
+        G = nx.path_graph(4, create_using=nx.DiGraph)
+
+        # 0 is not reachable from 2, so D[2] has no entry for 0
+        nx.group_betweenness_centrality(G, {0, 2}, normalized=False, endpoints=False)
+
+    def test_group_betweenness_endpoints_directed(self):
+        """
+        With endpoints, a single-node group counts every reachable ordered pair
+        it takes part in, in either direction.
+        """
+        G = nx.path_graph(4, create_using=nx.DiGraph)
+
+        # node 0 is the source of 0->1, 0->2, 0->3 and the target of none
+        assert (
+            nx.group_betweenness_centrality(G, {0}, normalized=False, endpoints=True)
+            == 3.0
+        )
+        # node 3 is the target of 0->3, 1->3, 2->3 and the source of none
+        assert (
+            nx.group_betweenness_centrality(G, {3}, normalized=False, endpoints=True)
+            == 3.0
+        )
+
     def test_group_betweenness_node_not_in_graph(self):
         """
         Node(s) in C not in graph, raises NodeNotFound exception


### PR DESCRIPTION
Addresses #8559.

## Two assumptions of symmetric reachability

**1. The endpoint correction.** For each group node it counted two pairs per node reachable *from* that node. On a directed graph that both misses the pairs where the group node is the *target* and double-counts the ones where it is the source. On `nx.path_graph(4, create_using=nx.DiGraph)`:

| node | `betweenness_centrality` | `group_betweenness_centrality` (before) |
|---|---|---|
| 0 | 0.0 | **-3.0** |
| 1 | 2.0 | 1.0 |
| 2 | 2.0 | 3.0 |
| 3 | 0.0 | 3.0 |

The fix counts the ordered pairs `(s, t)` where `t` is reachable from `s` and at least one endpoint is in the group, taking group nodes from the source side and everything else from the target side so each pair is counted exactly once.

That expression equals the previous closed form `c * (2v - c - 1)` whenever every pair is mutually reachable, so connected and strongly connected graphs are unaffected — which is why the special cases could go, along with the `is_connected` / `is_strongly_connected` calls they needed.

**2. Unguarded distance lookups.** `D[y][v]` and `D[v][x]` are reached under a guard that only checks `sigma` in the *other* direction, so a multi-node group hit `KeyError` (the traceback in the issue). Both now test membership before indexing.

## What this fixes, and what it does not

I checked against a brute-force group betweenness over ~2000 (graph, group) pairs on random graphs of 4–7 nodes:

| graph | connectivity | \|C\| | cases | wrong before | wrong after |
|---|---|---|---|---|---|
| directed | not strongly conn. | 1 | 200 | 158 (45 negative) | **0** |
| directed | not strongly conn. | 2 | 246 | 102 + 117 crashes | 117 |
| directed | not strongly conn. | 3 | 206 | 44 + 143 crashes | 153 |
| directed | strongly conn. | 3 | 108 | 34 | 34 |
| undirected | connected | 3 | 162 | 19 | 19 |
| all others | | | | 0 | 0 |

So **single-node groups are now exact** — the identity the issue asks for — and no result is negative.

Multi-node groups on directed graphs are improved but still wrong in many cases. That is a **separate, pre-existing defect**, not something this change introduces: the last two rows show `|C| >= 3` already disagrees with brute force on *strongly connected* and plain *connected* graphs, where none of the reachability logic above is involved. For example, on the connected undirected graph `[(0,1),(0,2),(0,3),(0,4),(1,3),(2,3),(2,4),(3,4),(4,5)]` with `C = {0,1,2}`, the true value is `0.0` and `main` returns `0.125`. It looks like the sequential peeling keeps using the original distance matrix `D` after a node has been removed. I'll open a separate issue with these cases.

**One thing to flag:** because the `KeyError` guard removes the crash, some multi-node directed inputs that previously raised now return an incorrect number instead. More cases are correct than before (129/246 vs 27/246 at `|C| = 2`), but if you would rather multi-node directed groups fail loudly until the peeling is fixed, I'm happy to drop the guard from this PR and keep it to the endpoint correction, which fully resolves the reported single-node behaviour on its own.

## Tests

Four cases added: the identity against `betweenness_centrality` on the issue's graph (asserting non-negativity too), the same on a directed graph with an unreachable component, the previously crashing `{0, 2}` group, and the directed `endpoints=True` counts in both directions.

`networkx/algorithms/centrality/` passes (345 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)