### PR TITLE
Fix UnboundLocalError in parse_pajek for edges without a vertices section

### DIFF
--- a/networkx/readwrite/pajek.py
+++ b/networkx/readwrite/pajek.py
@@ -189,6 +189,9 @@ def parse_pajek(lines):
     lines = iter([line.rstrip("\n") for line in lines])
     G = nx.MultiDiGraph()  # are multiedges allowed in Pajek? assume yes
     labels = []  # in the order of the file, needed for matrix
+    # Initialize here so an *edges/*arcs section without a preceding *vertices
+    # section does not raise UnboundLocalError; edges then use the raw ids.
+    nodelabels = {}
     while lines:
         try:
             l = next(lines)

--- a/networkx/readwrite/tests/test_pajek.py
+++ b/networkx/readwrite/tests/test_pajek.py
@@ -33,6 +33,13 @@ class TestPajek:
         assert sorted(G.nodes()) == ["1", "2"]
         assert edges_equal(G.edges(), [("1", "2"), ("1", "2")])
 
+    def test_parse_pajek_edges_without_vertices(self):
+        # An *arcs/*edges section without a preceding *vertices section used to
+        # raise UnboundLocalError on 'nodelabels'; edges should use the raw ids.
+        G = nx.parse_pajek("*Arcs\n1 2\n")
+        assert sorted(G.nodes()) == ["1", "2"]
+        assert edges_equal(G.edges(), [("1", "2")])
+
     def test_parse_pajek(self):
         G = nx.parse_pajek(self.data)
         assert sorted(G.nodes()) == ["A1", "Bb", "C", "D2"]


### PR DESCRIPTION
### Problem

`parse_pajek()` assigns `nodelabels` only inside the `*vertices` branch. A Pajek file that contains an `*arcs`/`*edges` section but no `*vertices` section reaches `nodelabels.get(ui, ui)` with the name unassigned:

```python
import networkx as nx
nx.parse_pajek("*Arcs\n1 2\n")
# UnboundLocalError: cannot access local variable 'nodelabels'
```

### Fix

Initialize `nodelabels = {}` before the parsing loop (next to `labels = []`), so a file without a `*vertices` section parses with the raw node ids used as labels. The re-initialization inside the `*vertices` branch is unchanged.

### Test

Added `test_parse_pajek_edges_without_vertices`. It raises `UnboundLocalError` before the change and passes after (nodes `['1','2']`, edge `('1','2')`). The full `test_pajek.py` suite passes (10 tests).