### PR TITLE
Handle malformed input in parse_adjlist and parse_leda

### DIFF
--- a/networkx/readwrite/adjlist.py
+++ b/networkx/readwrite/adjlist.py
@@ -222,6 +222,10 @@ def parse_adjlist(
         if not len(line):
             continue
         vlist = line.rstrip("\n").split(delimiter)
+        if not vlist:
+            # A whitespace-only line splits to an empty list; skip it rather
+            # than popping from it (IndexError).
+            continue
         u = vlist.pop(0)
         # convert types
         if nodetype is not None:

--- a/networkx/readwrite/leda.py
+++ b/networkx/readwrite/leda.py
@@ -75,20 +75,28 @@ def parse_leda(lines):
             if not (line.startswith(("#", "\n")) or line == "")
         ]
     )
+    def next_line():
+        # A truncated LEDA.GRAPH file must raise NetworkXError, not a bare
+        # StopIteration escaping from next().
+        try:
+            return next(lines)
+        except StopIteration:
+            raise nx.NetworkXError("Truncated LEDA.GRAPH file") from None
+
     for i in range(3):
-        next(lines)
+        next_line()
     # Graph
-    du = int(next(lines))  # -1=directed, -2=undirected
+    du = int(next_line())  # -1=directed, -2=undirected
     if du == -1:
         G = nx.DiGraph()
     else:
         G = nx.Graph()
 
     # Nodes
-    n = int(next(lines))  # number of nodes
+    n = int(next_line())  # number of nodes
     node = {}
     for i in range(1, n + 1):  # LEDA counts from 1 to n
-        symbol = next(lines).rstrip().strip("|{}|  ")
+        symbol = next_line().rstrip().strip("|{}|  ")
         if symbol == "":
             symbol = str(i)  # use int if no label - could be trouble
         node[i] = symbol
@@ -96,7 +104,7 @@ def parse_leda(lines):
     G.add_nodes_from([s for i, s in node.items()])
 
     # Edges
-    m = int(next(lines))  # number of edges
+    m = int(next_line())  # number of edges
     for i in range(m):
         try:
             s, t, reversal, label = next(lines).split()

--- a/networkx/readwrite/tests/test_adjlist.py
+++ b/networkx/readwrite/tests/test_adjlist.py
@@ -157,6 +157,13 @@ class TestAdjlist:
         H = nx.read_multiline_adjlist(fname, encoding="latin-1")
         assert graphs_equal(G, H)
 
+    def test_parse_adjlist_whitespace_line(self):
+        # A whitespace-only line splits to an empty list and must be skipped,
+        # not pop from an empty list (IndexError).
+        G = nx.parse_adjlist([" ", "a b c"])
+        assert nodes_equal(G.nodes(), ["a", "b", "c"])
+        assert edges_equal(G.edges(), [("a", "b"), ("a", "c")])
+
     def test_parse_adjlist(self):
         lines = ["1 2 5", "2 3 4", "3 5", "4", "5"]
         nx.parse_adjlist(lines, nodetype=int)  # smoke test

--- a/networkx/readwrite/tests/test_leda.py
+++ b/networkx/readwrite/tests/test_leda.py
@@ -1,9 +1,18 @@
 import io
 
+import pytest
+
 import networkx as nx
 
 
 class TestLEDA:
+    def test_parse_leda_truncated(self):
+        # A truncated LEDA.GRAPH file must raise NetworkXError, not let a bare
+        # StopIteration escape from next().
+        for data in ([""], [" "], ["LEDA.GRAPH", "string", "int"]):
+            with pytest.raises(nx.NetworkXError):
+                nx.parse_leda(data)
+
     def test_parse_leda(self):
         data = """#header section         \nLEDA.GRAPH \nstring\nint\n-1\n#nodes section\n5 \n|{v1}| \n|{v2}| \n|{v3}| \n|{v4}| \n|{v5}| \n\n#edges section\n7 \n1 2 0 |{4}| \n1 3 0 |{3}| \n2 3 0 |{2}| \n3 4 0 |{3}| \n3 5 0 |{7}| \n4 5 0 |{6}| \n5 1 0 |{foo}|"""
         G = nx.parse_leda(data)


### PR DESCRIPTION
Two more read-path crashes on malformed input.

### parse_adjlist

Each line is split and `vlist.pop(0)` is called without checking the result. A whitespace-only line splits (default whitespace delimiter) to an empty list, so:

```python
import networkx as nx
list(nx.parse_adjlist([' ', 'a b']))   # IndexError: pop from empty list
```

Fixed by skipping a line that splits to an empty list.

### parse_leda

The header, node-count and edge-count are read with bare `next(lines)` calls, so a truncated LEDA.GRAPH file lets `StopIteration` escape:

```python
nx.parse_leda([''])   # StopIteration
```

Fixed by routing those reads through a helper that raises `NetworkXError` on a truncated file (matching the parser's existing error handling for edges).

### Tests

Added `test_parse_adjlist_whitespace_line` and `test_parse_leda_truncated`. They fail with `IndexError`/`StopIteration` before this change and pass after. `test_adjlist.py` and `test_leda.py` pass (37 tests).