### PR TITLE
BUG: raise NetworkXError in partition_quality for graphs with fewer t…

### DIFF
--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -666,6 +666,11 @@ def partition_quality(G, partition):
            *Physics Reports*, Volume 486, Feb 2010, Issue 3--5 pp. 75--174
            <https://arxiv.org/abs/0906.0612>
     """
+    if len(G) < 2 or G.size() == 0:
+        raise nx.NetworkXError(
+            "partition_quality is not defined for graphs with fewer than "
+            "two nodes or no edges"
+        )
 
     node_community = {}
     for i, community in enumerate(partition):

--- a/networkx/algorithms/community/tests/test_quality.py
+++ b/networkx/algorithms/community/tests/test_quality.py
@@ -55,8 +55,8 @@ class TestCoverage:
 class TestPartitionQuality:
     """Unit tests for the :func:`partition_quality` function."""
 
-    def test_empty_graph(self):
-        """Tests that an empty graph raises NetworkXError."""
+    def test_null_graph(self):
+        """Tests that a null graph raises NetworkXError."""
         with pytest.raises(nx.NetworkXError, match="partition_quality is not defined"):
             partition_quality(nx.Graph(), [])
 

--- a/networkx/algorithms/community/tests/test_quality.py
+++ b/networkx/algorithms/community/tests/test_quality.py
@@ -52,6 +52,31 @@ class TestCoverage:
         assert 6 / 7 == pytest.approx(partition_quality(G, partition)[0], abs=1e-7)
 
 
+class TestPartitionQuality:
+    """Unit tests for the :func:`partition_quality` function."""
+
+    def test_empty_graph(self):
+        """Tests that an empty graph raises NetworkXError."""
+        with pytest.raises(nx.NetworkXError, match="partition_quality is not defined"):
+            partition_quality(nx.Graph(), [])
+
+    def test_single_node_graph(self):
+        """Tests that a single-node graph raises NetworkXError."""
+        G = nx.Graph()
+        G.add_node(0)
+
+        with pytest.raises(nx.NetworkXError, match="partition_quality is not defined"):
+            partition_quality(G, [{0}])
+
+    def test_graph_with_no_edges(self):
+        """Tests that a graph with no edges raises NetworkXError."""
+        G = nx.Graph()
+        G.add_nodes_from([0, 1, 2])
+
+        with pytest.raises(nx.NetworkXError, match="partition_quality is not defined"):
+            partition_quality(G, [{0}, {1, 2}])
+
+
 def test_modularity():
     G = nx.barbell_graph(3, 0)
     C = [{0, 1, 4}, {2, 3, 5}]


### PR DESCRIPTION
### Summary

`partition_quality` raises `ZeroDivisionError` for graphs with fewer than two nodes or no edges.

This change raises `NetworkXError` instead, since the coverage and performance metrics are undefined for these inputs.

### Tests

Added regression tests covering:
- empty graph
- single-node graph
- graph with multiple nodes but no edges

All existing community quality tests pass.

Fixes #8830