### PR TITLE
fix: deduplicate all-shortest-paths with zero-weight edges

### DIFF
--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -707,11 +707,11 @@ def _build_paths_from_predecessors(sources, target, pred):
 
     while stack:
         node, preds = stack[-1]
-        if node in sources:
-            yield path[::-1]
-
         for predecessor in preds:
             if predecessor in seen:
+                continue
+            if predecessor in sources:
+                yield (path + [predecessor])[::-1]
                 continue
             seen.add(predecessor)
             path.append(predecessor)
@@ -721,3 +721,6 @@ def _build_paths_from_predecessors(sources, target, pred):
             stack.pop()
             path.pop()
             seen.remove(node)
+
+    if target in sources:
+        yield [target]

--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -412,6 +412,20 @@ class TestGenericPath:
         assert sorted(paths03d) == sorted(p[::-1] for p in paths30b)
         assert sorted(paths03b) == sorted(p[::-1] for p in paths30b)
 
+    def test_single_source_all_shortest_paths_zero_weight_cycle(self):
+        # A zero-weight edge back toward the source records the source itself
+        # as a predecessor, which used to produce duplicate paths.
+        # https://github.com/networkx/networkx/issues/8833
+        g = nx.Graph()
+        g.add_edge(0, 1, weight=0)
+        g.add_edge(1, 2, weight=100)
+        ans = dict(nx.single_source_all_shortest_paths(g, 0, weight="weight"))
+        assert ans[0] == [[0]]
+        assert ans[2] == [[0, 1, 2]]
+        ans = dict(nx.all_pairs_all_shortest_paths(g, weight="weight"))
+        assert ans[0][0] == [[0]]
+        assert ans[0][2] == [[0, 1, 2]]
+
 
 class TestAverageShortestPathLength:
     def test_cycle_graph(self):


### PR DESCRIPTION
Fixes #8833

## Problem

With a zero-weight edge back toward the source, `_dijkstra_multisource` records the source itself as a predecessor of its neighbor. `_build_paths_from_predecessors` then yields the same path twice: it fires on every loop pass where a source node sits on top of the stack, including when returning from a deeper predecessor branch.

```python
G = nx.Graph()
G.add_edge(0, 1, weight=0)
G.add_edge(1, 2, weight=100)

list(nx.single_source_all_shortest_paths(G, 0, weight="weight"))
# [(0, [[0], [0]]), (1, [[0, 1]]), (2, [[0, 1, 2]])]   -- duplicate [0]
```

The same duplicate appears in `all_pairs_all_shortest_paths` (e.g. `{1: [[1, 2], [1, 2]]}`).

## Change

Yield each path once, at the point the source predecessor is discovered, instead of re-yielding whenever a source frame is on top of the stack. A path reaching a source terminates there, so the source is never pushed as a deeper frame.

## Testing

- Added regression test `test_single_source_all_shortest_paths_zero_weight_cycle` covering both `single_source_all_shortest_paths` and `all_pairs_all_shortest_paths`.
- `python -m pytest networkx/algorithms/shortest_paths/tests/` — 644 passed, 2 skipped.

## AI disclosure

This contribution was prepared with AI assistance (the change, rationale, and tests were reviewed and validated locally by the contributor before submission).