### PR TITLE
docs: correct communicability See Also algorithm descriptions

### DIFF
--- a/networkx/algorithms/communicability_alg.py
+++ b/networkx/algorithms/communicability_alg.py
@@ -35,8 +35,8 @@ def communicability(G):
     See Also
     --------
     communicability_exp:
-       Communicability between all pairs of nodes in G  using spectral
-       decomposition.
+       Communicability between all pairs of nodes in G using matrix
+       exponentiation.
     communicability_betweenness_centrality:
        Communicability betweenness centrality for each node in G.
 
@@ -117,7 +117,8 @@ def communicability_exp(G):
     See Also
     --------
     communicability:
-       Communicability between pairs of nodes in G.
+       Communicability between pairs of nodes in G using spectral
+       decomposition.
     communicability_betweenness_centrality:
        Communicability betweenness centrality for each node in G.
 


### PR DESCRIPTION
Fixes #8802

## Problem

The `See Also` cross-references between `communicability` and `communicability_exp` had their algorithm descriptions swapped:

- `communicability` (which uses spectral decomposition) pointed at `communicability_exp` and described it as using spectral decomposition.
- `communicability_exp` (which uses matrix exponentiation) pointed at `communicability` without mentioning its method.

## Change

Swap the descriptions so each `See Also` entry names the algorithm the other function actually uses. The `Notes` sections were already correct.

## Testing

- `python -m pytest networkx/algorithms/tests/test_communicability.py` — passed (1 pre-existing skip).
- Inspected the rendered docstrings for both functions.

## AI disclosure

This contribution was prepared with AI assistance (the change, rationale, and tests were reviewed and validated locally by the contributor before submission).