### PR TITLE
BUG: Fix node connectivity and node cuts for digraphs

### DIFF
--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -280,6 +280,9 @@ def node_connectivity(G, s=None, t=None, flow_func=None):
     :meth:`local_node_connectivity`. This implementation is based
     on algorithm 11 in [1]_.
 
+    The local node connectivity of an ordered pair of nodes of a digraph
+    is not symmetric, so both orders of each pair are considered [2]_.
+
     See also
     --------
     :meth:`local_node_connectivity`
@@ -293,6 +296,11 @@ def node_connectivity(G, s=None, t=None, flow_func=None):
     ----------
     .. [1] Abdol-Hossein Esfahanian. Connectivity Algorithms.
         http://www.cse.msu.edu/~cse835/Papers/Graph_connectivity_revised.pdf
+
+    .. [2] Shimon Even and R. Endre Tarjan. Network Flow and Testing Graph
+        Connectivity. SIAM Journal on Computing, Volume 4, Issue 4,
+        pp. 507-518, 1975.
+        https://doi.org/10.1137/0204043
 
     """
     if (s is not None and t is None) or (s is None and t is not None):
@@ -317,26 +325,51 @@ def node_connectivity(G, s=None, t=None, flow_func=None):
         def neighbors(v):
             return itertools.chain.from_iterable([G.predecessors(v), G.successors(v)])
 
+        # Isolating a node only requires removing all its predecessors or all
+        # its successors, so the bound is the smaller of the two.
+        def degree(v):
+            return min(len(G.pred[v].keys() - {v}), len(G.succ[v].keys() - {v}))
+
+        # In a digraph the local node connectivity of an ordered pair is not
+        # symmetric, and v has to lie on the source side of a minimum node cut
+        # for its value to be the right one, so both orders are needed. Page
+        # 513 of [2] states that for a digraph both N(v, w) and N(w, v) have to
+        # be computed.
+        def ordered_pairs(v, w):
+            return ((v, w), (w, v))
+
     else:
         if not nx.is_connected(G):
             return 0
         iter_func = itertools.combinations
         neighbors = G.neighbors
 
+        def degree(v):
+            return len(G[v].keys() - {v})
+
+        def ordered_pairs(v, w):
+            return ((v, w),)
+
     # Reuse the auxiliary digraph and the residual network
     H = build_auxiliary_node_connectivity(G)
     R = build_residual_network(H, "capacity")
     kwargs = {"flow_func": flow_func, "auxiliary": H, "residual": R}
 
-    # Pick a node with minimum degree
-    # Node connectivity is bounded by degree.
-    v, K = min(G.degree(), key=itemgetter(1))
+    # Pick a node with minimum degree. Node connectivity is bounded by the
+    # number of distinct neighbors. `G.degree` cannot be used here because
+    # parallel edges do not add connectivity and self-loops are irrelevant
+    # for it.
+    v, K = min(((n, degree(n)) for n in G), key=itemgetter(1))
+    # Neighbors of v, excluding v itself if it has a self-loop. For digraphs
+    # this deduplicates the nodes that are both predecessors and successors.
+    v_nbrs = set(neighbors(v)) - {v}
     # compute local node connectivity with all its non-neighbors nodes
-    for w in set(G) - set(neighbors(v)) - {v}:
-        kwargs["cutoff"] = K
-        K = min(K, local_node_connectivity(G, v, w, **kwargs))
+    for w in set(G) - v_nbrs - {v}:
+        for s, t in ordered_pairs(v, w):
+            kwargs["cutoff"] = K
+            K = min(K, local_node_connectivity(G, s, t, **kwargs))
     # Also for non adjacent pairs of neighbors of v
-    for x, y in iter_func(neighbors(v), 2):
+    for x, y in iter_func(v_nbrs, 2):
         if y in G[x]:
             continue
         kwargs["cutoff"] = K

--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -208,8 +208,10 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
         source and target in G.
 
         Returns an empty set if source and target are either in different
-        components or are directly connected by an edge, as no node removal
-        can destroy the path.
+        components or are joined by an edge from source to target, as no node
+        removal can destroy that path. In a digraph an arc from target to
+        source is not a source-target path, and does not stop source from
+        being separated from target [2]_.
 
     Examples
     --------
@@ -285,6 +287,11 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
     .. [1] Abdol-Hossein Esfahanian. Connectivity Algorithms.
         http://www.cse.msu.edu/~cse835/Papers/Graph_connectivity_revised.pdf
 
+    .. [2] Shimon Even and R. Endre Tarjan. Network Flow and Testing Graph
+        Connectivity. SIAM Journal on Computing, Volume 4, Issue 4,
+        pp. 507-518, 1975.
+        https://doi.org/10.1137/0204043
+
     """
     if auxiliary is None:
         H = build_auxiliary_node_connectivity(G)
@@ -294,7 +301,12 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
     mapping = H.graph.get("mapping", None)
     if mapping is None:
         raise nx.NetworkXError("Invalid auxiliary digraph.")
-    if G.has_edge(s, t) or G.has_edge(t, s):
+    # No set of nodes other than s and t can destroy a direct s-t edge. In a
+    # digraph an arc from t to s is irrelevant: it is not an s-t path, so s can
+    # still be separated from t. The footnote on page 513 of [2] skips the pair
+    # only in the direction of the arc, for this reason. `has_edge` is
+    # symmetric for undirected graphs.
+    if G.has_edge(s, t):
         return set()
     kwargs = {"flow_func": flow_func, "residual": residual, "auxiliary": H}
 
@@ -381,6 +393,9 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
     and undirected graphs. This implementation is based on algorithm 11
     in [1]_.
 
+    A minimum node cut of a digraph separates an ordered pair of nodes,
+    and the two orders need not agree, so both are considered [2]_.
+
     See also
     --------
     :meth:`minimum_st_node_cut`
@@ -398,6 +413,11 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
     ----------
     .. [1] Abdol-Hossein Esfahanian. Connectivity Algorithms.
         http://www.cse.msu.edu/~cse835/Papers/Graph_connectivity_revised.pdf
+
+    .. [2] Shimon Even and R. Endre Tarjan. Network Flow and Testing Graph
+        Connectivity. SIAM Journal on Computing, Volume 4, Issue 4,
+        pp. 507-518, 1975.
+        https://doi.org/10.1137/0204043
 
     """
     if (s is not None and t is None) or (s is None and t is not None):
@@ -421,28 +441,53 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
         def neighbors(v):
             return itertools.chain.from_iterable([G.predecessors(v), G.successors(v)])
 
+        # Isolating a node only requires removing all its predecessors or all
+        # its successors, so the smaller of the two is the better cutset.
+        def isolating_cut(v):
+            return min(G.pred[v].keys() - {v}, G.succ[v].keys() - {v}, key=len)
+
+        # A minimum node cut of a digraph separates an ordered pair, and the
+        # two orders of a pair need not agree, so v has to lie on the source
+        # side of a minimum node cut for the cut between the pair to be the
+        # right one. Both orders are needed. Page 513 of [2] states that for a
+        # digraph both N(v, w) and N(w, v) have to be computed.
+        def ordered_pairs(v, w):
+            return ((v, w), (w, v))
+
     else:
         if not nx.is_connected(G):
             raise nx.NetworkXError("Input graph is not connected")
         iter_func = itertools.combinations
         neighbors = G.neighbors
 
+        def isolating_cut(v):
+            return G[v].keys() - {v}
+
+        def ordered_pairs(v, w):
+            return ((v, w),)
+
     # Reuse the auxiliary digraph and the residual network.
     H = build_auxiliary_node_connectivity(G)
     R = build_residual_network(H, "capacity")
     kwargs = {"flow_func": flow_func, "auxiliary": H, "residual": R}
 
-    # Choose a node with minimum degree.
-    v = min(G, key=G.degree)
-    # Initial node cutset is all neighbors of the node with minimum degree.
-    min_cut = set(G[v])
+    # Choose a node with minimum degree, and take the nodes that isolate it as
+    # the initial cutset. `G.degree` cannot be used here because parallel edges
+    # do not add connectivity and self-loops are irrelevant for it.
+    v, min_cut = min(((n, isolating_cut(n)) for n in G), key=lambda nc: len(nc[1]))
+    # Neighbors of v, excluding v itself if it has a self-loop. For digraphs
+    # this deduplicates the nodes that are both predecessors and successors.
+    v_nbrs = set(neighbors(v)) - {v}
     # Compute st node cuts between v and all its non-neighbors nodes in G.
-    for w in set(G) - set(neighbors(v)) - {v}:
-        this_cut = minimum_st_node_cut(G, v, w, **kwargs)
-        if len(min_cut) >= len(this_cut):
-            min_cut = this_cut
+    for w in set(G) - v_nbrs - {v}:
+        for s, t in ordered_pairs(v, w):
+            this_cut = minimum_st_node_cut(G, s, t, **kwargs)
+            if len(min_cut) >= len(this_cut):
+                min_cut = this_cut
     # Also for non adjacent pairs of neighbors of v.
-    for x, y in iter_func(neighbors(v), 2):
+    for x, y in iter_func(v_nbrs, 2):
+        # `minimum_st_node_cut` returns an empty set when x and y cannot be
+        # separated, which must not be taken for a smaller cut.
         if y in G[x]:
             continue
         this_cut = minimum_st_node_cut(G, x, y, **kwargs)

--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -209,7 +209,7 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
 
         Returns an empty set if source and target are either in different
         components or are joined by an edge from source to target, as no node
-        removal can destroy that path. In a digraph an arc from target to
+        removal can destroy that path. In a digraph an edge from target to
         source is not a source-target path, and does not stop source from
         being separated from target [2]_.
 
@@ -302,9 +302,9 @@ def minimum_st_node_cut(G, s, t, flow_func=None, auxiliary=None, residual=None):
     if mapping is None:
         raise nx.NetworkXError("Invalid auxiliary digraph.")
     # No set of nodes other than s and t can destroy a direct s-t edge. In a
-    # digraph an arc from t to s is irrelevant: it is not an s-t path, so s can
+    # digraph an edge from t to s is irrelevant: it is not an s-t path, so s can
     # still be separated from t. The footnote on page 513 of [2] skips the pair
-    # only in the direction of the arc, for this reason. `has_edge` is
+    # only in the direction of the edge, for this reason. `has_edge` is
     # symmetric for undirected graphs.
     if G.has_edge(s, t):
         return set()

--- a/networkx/algorithms/connectivity/tests/test_connectivity.py
+++ b/networkx/algorithms/connectivity/tests/test_connectivity.py
@@ -260,6 +260,45 @@ def test_not_connected():
         assert nx.edge_connectivity(G) == 0, errmsg
 
 
+def test_directed_node_connectivity_not_strongly_connected():
+    # A weakly connected digraph that is not strongly connected has node
+    # connectivity 0. Node connectivity for digraphs is bounded by the smaller
+    # of the in-degree and the out-degree. Node 3 has the unique minimum total
+    # degree, so it is always the starting node whatever the insertion order,
+    # and its in-degree is 0.
+    G = nx.DiGraph([(0, 1), (1, 2), (2, 0), (3, 0)])  # a triangle and a source
+    assert nx.is_weakly_connected(G)
+    assert not nx.is_strongly_connected(G)
+    for flow_func in flow_funcs:
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
+        assert 0 == nx.node_connectivity(G, flow_func=flow_func), errmsg
+
+
+def test_node_connectivity_self_loops():
+    # Self-loops do not affect node connectivity. A complete graph is the only
+    # shape that exposes an inflated bound, because no pair of nodes is left to
+    # compute a local node connectivity that would lower it again.
+    G = nx.complete_graph(5)
+    G.add_edges_from((u, u) for u in G)
+    D = G.to_directed()
+    for flow_func in flow_funcs:
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
+        assert nx.node_connectivity(G, flow_func=flow_func) == 4, errmsg
+        assert nx.node_connectivity(D, flow_func=flow_func) == 4, errmsg
+
+
+def test_node_connectivity_multigraphs():
+    # Parallel edges do not add node connectivity, and as with self-loops only
+    # a complete graph exposes an inflated bound.
+    G = nx.complete_graph(5, nx.MultiGraph)
+    G.add_edges_from(list(G.edges()))  # duplicate every edge
+    D = G.to_directed()
+    for flow_func in flow_funcs:
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
+        assert nx.node_connectivity(G, flow_func=flow_func) == 4, errmsg
+        assert nx.node_connectivity(D, flow_func=flow_func) == 4, errmsg
+
+
 def test_directed_edge_connectivity():
     G = nx.cycle_graph(10, create_using=nx.DiGraph())  # only one direction
     D = nx.cycle_graph(10).to_directed()  # 2 reciprocal edges
@@ -419,3 +458,49 @@ class TestAllPairsNodeConnectivity:
         assert sorted((k, sorted(v)) for k, v in A.items()) == sorted(
             (k, sorted(v)) for k, v in C.items()
         )
+
+
+def test_directed_node_connectivity_both_orders():
+    # Node connectivity of a digraph is a minimum over ordered pairs, and the
+    # two orders of a pair need not agree, so the starting node has to be
+    # tried as source and as target. Here node 1 cannot reach node 0, so the
+    # graph is not strongly connected and its node connectivity is 0, but only
+    # the pair (1, 0) shows it: the local node connectivity of (0, 1) is 1.
+    G = nx.DiGraph([(0, 3), (1, 2), (2, 1), (3, 0), (3, 1), (3, 2)])
+    assert nx.is_weakly_connected(G)
+    assert not nx.is_strongly_connected(G)
+    assert local_node_connectivity(G, 0, 1) == 1
+    assert local_node_connectivity(G, 1, 0) == 0
+    for flow_func in flow_funcs:
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
+        assert nx.node_connectivity(G, flow_func=flow_func) == 0, errmsg
+
+
+def test_directed_node_connectivity_both_orders_strongly_connected():
+    # The same, on a strongly connected digraph: removing node 4 leaves it
+    # disconnected, so the node connectivity is 1 and not the 2 that only
+    # looking at one order of each pair reports.
+    G = nx.DiGraph(
+        [
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (1, 0),
+            (1, 2),
+            (2, 0),
+            (2, 5),
+            (3, 4),
+            (3, 5),
+            (4, 0),
+            (4, 1),
+            (4, 2),
+            (4, 3),
+            (4, 5),
+            (5, 3),
+            (5, 4),
+        ]
+    )
+    assert nx.is_strongly_connected(G)
+    for flow_func in flow_funcs:
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
+        assert nx.node_connectivity(G, flow_func=flow_func) == 1, errmsg

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -309,9 +309,9 @@ def test_interface_only_target():
         pytest.raises(nx.NetworkXError, interface_func, G, t=3)
 
 
-def test_directed_minimum_st_node_cut_reverse_arc():
-    # In a digraph an arc from t to s is not an s-t path, so s can still be
-    # separated from t. Only a direct arc from s to t makes the pair
+def test_directed_minimum_st_node_cut_reverse_edge():
+    # In a digraph an edge from t to s is not an s-t path, so s can still be
+    # separated from t. Only a direct edge from s to t makes the pair
     # inseparable, and then the empty set is returned.
     G = nx.DiGraph([(0, 1), (1, 2), (2, 0)])  # the directed triangle
     for flow_func in flow_funcs:

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -307,3 +307,88 @@ def test_interface_only_target():
     G = nx.complete_graph(5)
     for interface_func in [nx.minimum_node_cut, nx.minimum_edge_cut]:
         pytest.raises(nx.NetworkXError, interface_func, G, t=3)
+
+
+def test_directed_minimum_st_node_cut_reverse_arc():
+    # In a digraph an arc from t to s is not an s-t path, so s can still be
+    # separated from t. Only a direct arc from s to t makes the pair
+    # inseparable, and then the empty set is returned.
+    G = nx.DiGraph([(0, 1), (1, 2), (2, 0)])  # the directed triangle
+    for flow_func in flow_funcs:
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
+        assert minimum_st_node_cut(G, 0, 2, flow_func=flow_func) == {1}, errmsg
+        assert minimum_st_node_cut(G, 0, 1, flow_func=flow_func) == set(), errmsg
+
+
+def test_directed_minimum_node_cut():
+    # The node connectivity of the directed triangle is 1, so its minimum node
+    # cut holds a single node. The initial cutset has to isolate the starting
+    # node through its predecessors or its successors, whichever is smaller,
+    # and not through its successors alone.
+    G = nx.DiGraph([(0, 1), (1, 2), (2, 0)])
+    for flow_func in flow_funcs:
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
+        cut = nx.minimum_node_cut(G, flow_func=flow_func)
+        assert len(cut) == nx.node_connectivity(G) == 1, errmsg
+        H = G.copy()
+        H.remove_nodes_from(cut)
+        assert not nx.is_strongly_connected(H), errmsg
+
+
+def test_directed_minimum_node_cut_not_strongly_connected():
+    # A weakly connected digraph that is not strongly connected is already
+    # disconnected, so no node has to be removed and the cut is empty.
+    G = nx.DiGraph([(0, 1), (1, 2), (2, 0), (3, 0)])  # a triangle and a source
+    assert nx.is_weakly_connected(G)
+    assert not nx.is_strongly_connected(G)
+    for flow_func in flow_funcs:
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
+        assert nx.minimum_node_cut(G, flow_func=flow_func) == set(), errmsg
+
+
+def test_directed_minimum_node_cut_both_orders():
+    # A minimum node cut of a digraph separates an ordered pair, and the two
+    # orders need not agree, so the starting node has to be tried as source
+    # and as target. Removing node 4 leaves this digraph not strongly
+    # connected, so the minimum node cut has one node and not two.
+    G = nx.DiGraph(
+        [
+            (0, 1),
+            (0, 2),
+            (0, 3),
+            (1, 0),
+            (1, 2),
+            (2, 0),
+            (2, 5),
+            (3, 4),
+            (3, 5),
+            (4, 0),
+            (4, 1),
+            (4, 2),
+            (4, 3),
+            (4, 5),
+            (5, 3),
+            (5, 4),
+        ]
+    )
+    assert nx.is_strongly_connected(G)
+    for flow_func in flow_funcs:
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
+        cut = nx.minimum_node_cut(G, flow_func=flow_func)
+        assert len(cut) == 1, errmsg
+        H = G.copy()
+        H.remove_nodes_from(cut)
+        assert not nx.is_strongly_connected(H), errmsg
+
+
+def test_minimum_node_cut_self_loops():
+    # Self-loops do not affect node connectivity, so they must not enlarge the
+    # minimum node cut either. The initial cutset is built from the neighbors
+    # of the starting node, and a self-loop puts that node in its own cutset.
+    G = nx.complete_graph(5)
+    G.add_edges_from((u, u) for u in G)
+    D = G.to_directed()
+    for flow_func in flow_funcs:
+        errmsg = f"Assertion failed in function: {flow_func.__name__}"
+        assert len(nx.minimum_node_cut(G, flow_func=flow_func)) == 4, errmsg
+        assert len(nx.minimum_node_cut(D, flow_func=flow_func)) == 4, errmsg


### PR DESCRIPTION
`node_connectivity`, `minimum_node_cut` and `minimum_st_node_cut` return wrong results on directed graphs. `node_connectivity` is also wrong on graphs with self-loops or parallel edges, and `minimum_node_cut` on graphs with self-loops. `minimum_node_cut` can return a set that is not a cut at all.

As an illustration of the bugs:

```python
>>> import networkx as nx

>>> # a directed triangle has node connectivity 1
>>> nx.minimum_node_cut(nx.DiGraph([(0, 1), (1, 2), (2, 0)]))
set()

>>> # weakly but not strongly connected, so the node connectivity is 0
>>> nx.node_connectivity(nx.DiGraph([(0, 3), (1, 2), (2, 1), (3, 0), (3, 1), (3, 2)]))
1

>>> # K5 has node connectivity 4, self-loops should not change that
>>> G = nx.complete_graph(5)
>>> G.add_edges_from((u, u) for u in G)
>>> nx.node_connectivity(G)
6
```

All three functions implement algorithm 11 of Esfahanian's *Connectivity Algorithms* (cited in the docstrings), which is from Esfahanian and Hakimi (Networks 14:355-366, 1984). That algorithm is stated for **undirected graphs only**; section 4 of the chapter and section III of the 1984 paper never mention digraphs. When I implemented this for NetworkX in 2012 it seems that I just derived the implementation for digraphs, and introduced 5 bugs in doing so:

1. **Starting node chosen by total degree.** Node connectivity of a digraph is bounded by the smaller of the in-degree and the out-degree, since isolating a node only requires removing all its predecessors *or* all its successors.

2. **Initial cutset from successors only.** `minimum_node_cut` used `set(G[v])`, which does not isolate a node that also has predecessors and is empty for a node without successors.

3. **Duplicated neighbors.** Predecessors and successors were chained without deduplication, so a node that is both was yielded twice and paired with itself.

4. **`minimum_st_node_cut` checked on both arc directions.** It returned the empty set when `G.has_edge(s, t) or G.has_edge(t, s)`. An arc from `t` to `s` is not an `s`-`t` path and does not stop `s` from being separated from `t`. `minimum_node_cut` then accepted that empty set as a smaller cut.

5. **Starting node only ever used as the source.** Node connectivity of a digraph is a minimum over *ordered* pairs and the two orders need not agree, so when the starting node lay on the target side of every minimum cut the smallest value was never computed.

Bugs 1 and 3 also affect self-loops and parallel edges: they inflate the initial bound, and on a complete graph no pair of nodes is left to lower it again, so the inflated value is returned.

In order to fix bug 5 I checked the literature and found that Even and Tarjan, *Network Flow and Testing Graph Connectivity* (SIAM J. Comput. 4(4):507-518, 1975), p. 513 say:

> In case G is a directed graph, similar definitions and approach lead to the
> same result, except that for each v1, v2, ..., vk, we compute **both
> N(vi, v) and N(v, vi)** (which are now not necessarily the same) for each
> applicable v.

and its footnote 7, which is exactly the rule in bug 4:

> If there is an edge from vi to v, N(vi, v) is not computed, and if there is an
> edge from v to vi, N(v, vi) is not computed.

Even and Tarjan paper is now cited in the docstrings of all three functions.

These fixes have an impact on public functions:

* `minimum_st_node_cut` changes behavior on digraphs. Where the pair is joined only by an arc from target to source, it now returns a real cut instead of `set()`. Undirected graphs are unaffected.

* `minimum_node_cut` may also return a *different* minimum cut than before on some digraphs. It is still a minimum cut and the concrete cut returned was already dependent on iteration order.

I found all these bugs while working on a pre-filter proposed for node_connectivity by Sinkovits (ICCS 2021) which provides a 2.5x-52x speedup while being also exact. Some tests for digraphs failed and that got me into this rabbit hole. 
