### PR TITLE
Add ISMAGS monomorphism support

### DIFF
--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -1066,15 +1066,13 @@ class ISMAGS:
                                 cand_sets[sgn2] = cand_sets[sgn2] | {not_gn_nbrs}
                         else:
                             # edge color must match when sgn2 connected to sgn
-                            g_edges = self_ge_partition[self_sge_colors[sgn, sgn2]]
                             # check if (gn, gn2) has same number of edges as (sgn, sgn2)
                             sgn_e_cnt = subgraph.number_of_edges(sgn, sgn2)
+                            sge_color = self_sge_colors[sgn, sgn2]
                             gn2_cands = {
                                 n
-                                for e in g_edges
-                                if gn in e
-                                for n in e
-                                if n != gn
+                                for n in graph_adj[gn]
+                                if self._ge_colors[gn, n] == sge_color
                                 if MONO_fits(sgn_e_cnt, graph.number_of_edges(gn, n))
                             }
                             # Do not change the original set. So do not use |= operator
@@ -1094,40 +1092,40 @@ class ISMAGS:
                                     cand_sets[sgn2] = cand_sets[sgn2] | {not_gn_nbrs}
                             else:  # sgn2 in sgn_preds
                                 sgn_in = subgraph.number_of_edges(sgn2, sgn)
-                                g_edges = self_ge_partition[self_sge_colors[sgn2, sgn]]
+                                sge_color = self_sge_colors[sgn2, sgn]
                                 gn2_cands = {
-                                    u
-                                    for u, v in g_edges
-                                    if gn == v
-                                    if MONO_fits(sgn_in, graph.number_of_edges(u, gn))
+                                    n
+                                    for n in graph._pred[gn]
+                                    if self._ge_colors[n, gn] == sge_color
+                                    if MONO_fits(sgn_in, graph.number_of_edges(n, gn))
                                 }
                         else:
                             if sgn2 not in sgn_preds:
                                 sgn_out = subgraph.number_of_edges(sgn, sgn2)
-                                g_edges = self_ge_partition[self_sge_colors[sgn, sgn2]]
+                                sge_color = self_sge_colors[sgn, sgn2]
                                 gn2_cands = {
-                                    v
-                                    for u, v in g_edges
-                                    if gn == u
-                                    if MONO_fits(sgn_out, graph.number_of_edges(gn, v))
+                                    n
+                                    for n in graph_adj[gn]
+                                    if self._ge_colors[gn, n] == sge_color
+                                    if MONO_fits(sgn_out, graph.number_of_edges(gn, n))
                                 }
                             else:
                                 sgn_out = subgraph.number_of_edges(sgn, sgn2)
                                 sgn_in = subgraph.number_of_edges(sgn2, sgn)
                                 # gn2 must have correct color in both directions
-                                g_edges = self_ge_partition[self_sge_colors[sgn, sgn2]]
+                                sge_color = self_sge_colors[sgn, sgn2]
                                 gn2_cands = {
-                                    v
-                                    for u, v in g_edges
-                                    if gn == u
-                                    if MONO_fits(sgn_out, graph.number_of_edges(gn, v))
+                                    n
+                                    for n in graph_adj[gn]
+                                    if self._ge_colors[gn, n] == sge_color
+                                    if MONO_fits(sgn_out, graph.number_of_edges(gn, n))
                                 }
-                                g_edges = self_ge_partition[self_sge_colors[sgn2, sgn]]
+                                sge_color = self_sge_colors[sgn2, sgn]
                                 gn2_cands &= {
-                                    u
-                                    for u, v in g_edges
-                                    if gn == v
-                                    if MONO_fits(sgn_in, graph.number_of_edges(u, gn))
+                                    n
+                                    for n in graph._pred[gn]
+                                    if self._ge_colors[n, gn] == sge_color
+                                    if MONO_fits(sgn_in, graph.number_of_edges(n, gn))
                                 }
                             # Do not change the original set. So do not use |= operator
                             cand_sets[sgn2] = cand_sets[sgn2] | {frozenset(gn2_cands)}

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -250,7 +250,7 @@ def color_degree_by_node_no_multi(G, n_colors, e_colors):
     Similar to color_degree_by_node except that multiedges are not included in
     the color tuples.
 
-    Not used for largest_common_subgraph. Only for all_morphisms when considering
+    Not used for largest_common_subgraph. Only for _all_morphisms when considering
     PT == "MONO", or cases with no multigraphs present. MONO needs to allow lower
     numbers of multiedges in the subgraph, so we can't use that as a color (which
     are essentially treated using equality checks for isomorphisms. We handle
@@ -699,10 +699,10 @@ class ISMAGS:
 
     def find_isomorphisms(self, symmetry=True):
         """left for backward compatibility. Use isomorphisms_iter"""
-        yield from self.all_morphisms(symmetry, PT="SUB")
+        yield from self._all_morphisms(symmetry, PT="SUB")
         return
 
-    def all_morphisms(self, symmetry=True, PT="SUB"):
+    def _all_morphisms(self, symmetry=True, PT="SUB"):
         """Find all subgraph isomorphisms between subgraph and graph
 
         Finds isomorphisms where :attr:`subgraph` <= :attr:`graph`.
@@ -902,19 +902,19 @@ class ISMAGS:
 
     def isomorphisms_iter(self, symmetry=True):
         """
-        Does the same as :meth:`all_morphisms` if :attr:`graph` and
+        Does the same as :meth:`_all_morphisms` if :attr:`graph` and
         :attr:`subgraph` have the same number of nodes.
         """
         if len(self.graph) == len(self.subgraph):
-            yield from self.all_morphisms(symmetry=symmetry, PT="ISO")
+            yield from self._all_morphisms(symmetry=symmetry, PT="ISO")
 
     def subgraph_isomorphisms_iter(self, symmetry=True):
-        """Alternative name for :meth:`all_morphisms`."""
-        return self.all_morphisms(symmetry)
+        """Alternative name for :meth:`_all_morphisms`."""
+        return self._all_morphisms(symmetry)
 
     def monomorphisms_iter(self, symmetry=True):
         """Iterate over monomorphism."""
-        return self.all_morphisms(symmetry, PT="MONO")
+        return self._all_morphisms(symmetry, PT="MONO")
 
     def _get_node_color_candidate_sets(self, MONO_fits):
         """

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -123,6 +123,7 @@ References
 __all__ = ["ISMAGS"]
 
 import itertools
+import operator
 from collections import Counter, defaultdict
 
 import networkx as nx
@@ -243,18 +244,60 @@ def node_to_part_ID_dict(partition):
     return {node: ID for ID, part in enumerate(partition) for node in part}
 
 
+def color_degree_by_node_no_multi(G, n_colors, e_colors):
+    """Returns a dict keyed by node to counts of edge and nbr color combos.
+
+    Similar to color_degree_by_node except that multiedges are not included in
+    the color tuples.
+
+    Not used for largest_common_subgraph. Only for all_morphisms when considering
+    PT == "MONO", or cases with no multigraphs present. MONO needs to allow lower
+    numbers of multiedges in the subgraph, so we can't use that as a color (which
+    are essentially treated using equality checks for isomorphisms. We handle
+    multiedge checks for MONO during mapping update checks rather than candidate
+    identifying part of the loop. Ignoring the multiedges gives the same code we
+    can use when both graph and subgraph are not multigraphs.
+    """
+    # undirected colored degree
+    if not G.is_directed():
+        return {
+            u: (n_colors[u], Counter((e_colors[u, v], n_colors[v]) for v in nbrs))
+            for u, nbrs in G.adjacency()
+        }
+    # directed colored out and in degree
+    return {
+        u: (
+            n_colors[u],
+            Counter((e_colors[u, v], n_colors[v]) for v in nbrs),
+            Counter((e_colors[v, u], n_colors[v]) for v in G._pred[u]),
+        )
+        for u, nbrs in G.adjacency()
+    }
+
+
 def color_degree_by_node(G, n_colors, e_colors):
-    """Returns a dict by node to counts of edge and node color for that node.
+    """Returns a dict keyed by node to counts of edge/nbr color for that node.
 
-    This returns a dict by node to a 2-tuple of node color and degree by
-    (edge color and nbr color). E.g. ``{0: (1, {(0, 2): 5})}`` means that
-    node ``0`` has node type 1 and has 5 edges of type 0 that go to nodes of type 2.
-    Thus, this is a measure of degree (edge count) by color of edge and color
-    of the node on the other side of that edge.
+    The inputs are G -- graph of interest; `n_colors` -- a dict keyed by node
+    to the node color/label associated with that node; `e_colors` -- a dict
+    keyed by edge to the edge color/label associated with that edge.
 
-    For directed graphs the degree counts is a 2-tuple of (in, out) degree counts.
+    The returned dict is keyed by node to a 2-tuple of node color and degree
+    dict. The degree dict holds counts for each edge-key which is a
+    3-tuple: (edge color, number of multiedges, nbr color). For example,
+    ``{0: (1, {(0, 1, 2): 5})}`` means that node ``0`` has node color 1 and
+    has 5 edges of color 0 that have 1 multiedge to nodes of color 2.
+    This dict is a measure of degree (edge count) by color of edge, number of
+    multiedges and color of the node on the other side of that edge.
 
-    Ideally, if edge_match is None, this could get simplified to just the node
+    For directed graphs the degree counts are a 2-tuple of 2 dicts indicating
+    (in, out) degree counts respectively.
+
+    When both graph and subgraph are not multigraphs, the multiedge indicator
+    is not relevant. Use `color_degree_by_node_no_multi` to make the keys of
+    the inner dict 2-tuples with edge color and nbr node color.
+
+    TODO: if edge_match is None, this could get simplified to just the node
     color on the other end of the edge. Similarly if node_match is None then only
     edge color is tracked. And if both are None, we simply count the number of edges.
     """
@@ -655,6 +698,11 @@ class ISMAGS:
         return new_sg_p, new_g_p, Ncolors
 
     def find_isomorphisms(self, symmetry=True):
+        """left for backward compatibility. Use isomorphisms_iter"""
+        yield from self.all_morphisms(symmetry, PT="SUB")
+        return
+
+    def all_morphisms(self, symmetry=True, PT="SUB"):
         """Find all subgraph isomorphisms between subgraph and graph
 
         Finds isomorphisms where :attr:`subgraph` <= :attr:`graph`.
@@ -670,6 +718,8 @@ class ISMAGS:
         dict
             The found isomorphism mappings of {graph_node: subgraph_node}.
         """
+        SG_fits = operator.eq if PT == "ISO" else operator.le
+        MONO_fits = operator.eq if PT != "MONO" else operator.le
         # The networkx VF2 algorithm is slightly funny in when it yields an
         # empty dict and when not.
         if not self.subgraph:
@@ -677,14 +727,19 @@ class ISMAGS:
             return
         elif not self.graph:
             return
-        elif len(self.graph) < len(self.subgraph):
+        elif not SG_fits(len(self.subgraph), len(self.graph)):
             return
-        elif len(self._sgn_partition) > self.N_node_colors:
+        elif not SG_fits(len(self._sgn_partition), self.N_node_colors):
             # some subgraph nodes have a color that doesn't occur in graph
             return
-        elif len(self._sge_partition) > self.N_edge_colors:
+        elif not SG_fits(len(self._sge_partition), self.N_edge_colors):
             # some subgraph edges have a color that doesn't occur in graph
             return
+        if PT == "ISO":
+            if not SG_fits(len(self._gn_partition), self.N_node_colors):
+                return
+            if not SG_fits(len(self._ge_partition), self.N_edge_colors):
+                return
 
         if symmetry:
             cosets = self.analyze_subgraph_symmetry()
@@ -693,9 +748,9 @@ class ISMAGS:
         else:
             constraints = []
 
-        cand_sets = self._get_node_color_candidate_sets()
+        cand_sets = self._get_node_color_candidate_sets(MONO_fits)
 
-        lookahead_candidates = self._get_color_degree_candidates()
+        lookahead_candidates = self._get_color_degree_candidates(SG_fits, MONO_fits)
         for sgn, lookahead_cands in lookahead_candidates.items():
             cand_sets[sgn].add(frozenset(lookahead_cands))
 
@@ -706,24 +761,29 @@ class ISMAGS:
             # computing the intersection of the frozensets for each node.
             start_sgn = min(cand_sets, key=lambda n: min(len(x) for x in cand_sets[n]))
             cand_sets[start_sgn] = (frozenset.intersection(*cand_sets[start_sgn]),)
-            yield from self._map_nodes(start_sgn, cand_sets, constraints)
+            yield from self._map_nodes(start_sgn, cand_sets, constraints, MONO_fits)
         return
 
-    def _get_color_degree_candidates(self):
+    def _get_color_degree_candidates(self, SG_fits, MONO_fits):
         """
         Returns a mapping of {subgraph node: set of graph nodes} for
         which the graph nodes are feasible mapping candidate_sets for the
         subgraph node, as determined by looking ahead one edge.
         """
-        g_deg = color_degree_by_node(self.graph, self._gn_colors, self._ge_colors)
-        sg_deg = color_degree_by_node(self.subgraph, self._sgn_colors, self._sge_colors)
+        MONO = MONO_fits == operator.le
+        if (self.graph.is_multigraph() or self.subgraph.is_multigraph()) and not MONO:
+            color_count = color_degree_by_node
+        else:
+            color_count = color_degree_by_node_no_multi
+        g_deg = color_count(self.graph, self._gn_colors, self._ge_colors)
+        sg_deg = color_count(self.subgraph, self._sgn_colors, self._sge_colors)
 
         return {
             sgn: {
                 gn
                 for gn, (_, *g_counts) in g_deg.items()
                 if all(
-                    sg_cnt <= g_counts[idx][color]
+                    SG_fits(sg_cnt, g_counts[idx][color])
                     for idx, counts in enumerate(needed_counts)
                     for color, sg_cnt in counts.items()
                 )
@@ -762,7 +822,7 @@ class ISMAGS:
         else:
             constraints = []
 
-        candidate_sets = self._get_node_color_candidate_sets()
+        candidate_sets = self._get_node_color_candidate_sets(MONO_fits=operator.eq)
 
         if any(candidate_sets.values()):
             relevant_parts = self._sgn_partition[: self.N_node_colors]
@@ -818,9 +878,8 @@ class ISMAGS:
         -------
         bool
         """
-        return len(self.subgraph) == len(self.graph) and self.subgraph_is_isomorphic(
-            symmetry
-        )
+        isom = next(self.isomorphisms_iter(symmetry=symmetry), None)
+        return isom is not None
 
     def subgraph_is_isomorphic(self, symmetry=False):
         """
@@ -837,19 +896,27 @@ class ISMAGS:
         isom = next(self.subgraph_isomorphisms_iter(symmetry=symmetry), None)
         return isom is not None
 
+    def is_monomorphic(self, symmetry=False):
+        mom = next(self.monomorphisms_iter(symmetry=symmetry), None)
+        return mom is not None
+
     def isomorphisms_iter(self, symmetry=True):
         """
-        Does the same as :meth:`find_isomorphisms` if :attr:`graph` and
+        Does the same as :meth:`all_morphisms` if :attr:`graph` and
         :attr:`subgraph` have the same number of nodes.
         """
         if len(self.graph) == len(self.subgraph):
-            yield from self.subgraph_isomorphisms_iter(symmetry=symmetry)
+            yield from self.all_morphisms(symmetry=symmetry, PT="ISO")
 
     def subgraph_isomorphisms_iter(self, symmetry=True):
-        """Alternative name for :meth:`find_isomorphisms`."""
-        return self.find_isomorphisms(symmetry)
+        """Alternative name for :meth:`all_morphisms`."""
+        return self.all_morphisms(symmetry)
 
-    def _get_node_color_candidate_sets(self):
+    def monomorphisms_iter(self, symmetry=True):
+        """Iterate over monomorphism."""
+        return self.all_morphisms(symmetry, PT="MONO")
+
+    def _get_node_color_candidate_sets(self, MONO_fits):
         """
         For each node in subgraph store all nodes in graph with same color
         and self-loop count. These sets should not change so we cache them.
@@ -864,7 +931,7 @@ class ISMAGS:
         we want to avoid that. But I wonder if checking hash/equality when `add`ing
         removes the benefit of avoiding computing intersections.
         """
-        g_loops = {n: self.graph.number_of_edges(n, n) for n in self.graph}
+        loops = {n: self.graph.number_of_edges(n, n) for n in self.graph}
 
         candidate_sets = {}
         for sgn in self.subgraph.nodes:
@@ -873,9 +940,8 @@ class ISMAGS:
                 # color has no candidates in gn
                 candidate_sets[sgn] = {frozenset()}
                 continue
-            # TODO make work for monomorphism (<=)
-            loops = self.subgraph.number_of_edges(sgn, sgn)
-            c = (n for n in self._gn_partition[sgn_color] if loops == g_loops[n])
+            L = self.subgraph.number_of_edges(sgn, sgn)
+            c = (n for n in self._gn_partition[sgn_color] if MONO_fits(L, loops[n]))
             candidate_sets[sgn] = {frozenset(c)}  # cands for sgn must be in c
         return candidate_sets
 
@@ -900,7 +966,9 @@ class ISMAGS:
             color_degree = color_degree_by_node(graph, node_colors, edge_colors)
         return partition
 
-    def _map_nodes(self, sgn, candidate_sets, constraints, to_be_mapped=None):
+    def _map_nodes(
+        self, sgn, candidate_sets, constraints, MONO_fits, to_be_mapped=None
+    ):
         """
         Find all subgraph isomorphisms honoring constraints.
         The collection `candidate_sets` is stored as a dict-of-set-of-frozenset.
@@ -947,6 +1015,22 @@ class ISMAGS:
             sgn, candidate_sets, sgn_cand_iter = queue[-1]
 
             for gn in sgn_cand_iter:
+                if MONO_fits == operator.le:
+                    if any(
+                        sgn != sgn2
+                        and sgn2 in mapping
+                        and mapping[sgn2] not in graph_adj[gn]
+                        for sgn2 in subgraph_adj[sgn]
+                    ):
+                        continue
+                    if is_directed:
+                        if any(
+                            sgn != sgn2
+                            and sgn2 in mapping
+                            and mapping[sgn2] not in graph._pred[gn]
+                            for sgn2 in subgraph._pred[sgn]
+                        ):
+                            continue
                 # We're going to try to map sgn to gn.
                 if gn in rev_mapping:
                     continue  # pragma: no cover
@@ -974,75 +1058,79 @@ class ISMAGS:
                 # update the candidate_sets for unmapped sgn based on sgn mapped
                 if not is_directed:
                     sgn_nbrs = subgraph_adj[sgn]
-                    not_gn_nbrs = graph_adj.keys() - graph_adj[gn].keys()
+                    not_gn_nbrs = frozenset(graph_adj.keys() - graph_adj[gn].keys())
                     for sgn2 in left_to_map:
                         if sgn2 not in sgn_nbrs:
-                            gn2_cands = not_gn_nbrs
+                            # Do not change the original set. So do not use |= operator
+                            if MONO_fits == operator.eq:
+                                cand_sets[sgn2] = cand_sets[sgn2] | {not_gn_nbrs}
                         else:
                             # edge color must match when sgn2 connected to sgn
                             g_edges = self_ge_partition[self_sge_colors[sgn, sgn2]]
                             # check if (gn, gn2) has same number of edges as (sgn, sgn2)
-                            sgn_multi_cnt = subgraph.number_of_edges(sgn, sgn2)
+                            sgn_e_cnt = subgraph.number_of_edges(sgn, sgn2)
                             gn2_cands = {
                                 n
                                 for e in g_edges
                                 if gn in e
                                 for n in e
                                 if n != gn
-                                if graph.number_of_edges(gn, n) == sgn_multi_cnt
+                                if MONO_fits(sgn_e_cnt, graph.number_of_edges(gn, n))
                             }
-                        # Do not change the original set. So do not use |= operator
-                        cand_sets[sgn2] = cand_sets[sgn2] | {frozenset(gn2_cands)}
+                            # Do not change the original set. So do not use |= operator
+                            cand_sets[sgn2] = cand_sets[sgn2] | {frozenset(gn2_cands)}
                 else:  # directed
-                    sgn_nbrs = subgraph_adj[sgn].keys()
-                    sgn_preds = subgraph._pred[sgn].keys()
-                    not_gn_nbrs = (
+                    sgn_nbrs = subgraph_adj[sgn]
+                    sgn_preds = subgraph._pred[sgn]
+                    not_gn_nbrs = frozenset(
                         graph_adj.keys() - graph_adj[gn].keys() - graph._pred[gn].keys()
                     )
                     for sgn2 in left_to_map:
                         # edge color must match when sgn2 connected to sgn
                         if sgn2 not in sgn_nbrs:
                             if sgn2 not in sgn_preds:
-                                gn2_cands = not_gn_nbrs
+                                if MONO_fits == operator.eq:
+                                    # Do not change the original set. So do not use |=
+                                    cand_sets[sgn2] = cand_sets[sgn2] | {not_gn_nbrs}
                             else:  # sgn2 in sgn_preds
-                                sgn_multi_in = subgraph.number_of_edges(sgn2, sgn)
+                                sgn_in = subgraph.number_of_edges(sgn2, sgn)
                                 g_edges = self_ge_partition[self_sge_colors[sgn2, sgn]]
                                 gn2_cands = {
                                     u
                                     for u, v in g_edges
                                     if gn == v
-                                    if graph.number_of_edges(u, gn) == sgn_multi_in
+                                    if MONO_fits(sgn_in, graph.number_of_edges(u, gn))
                                 }
                         else:
                             if sgn2 not in sgn_preds:
-                                sgn_multi_out = subgraph.number_of_edges(sgn, sgn2)
+                                sgn_out = subgraph.number_of_edges(sgn, sgn2)
                                 g_edges = self_ge_partition[self_sge_colors[sgn, sgn2]]
                                 gn2_cands = {
                                     v
                                     for u, v in g_edges
                                     if gn == u
-                                    if graph.number_of_edges(gn, v) == sgn_multi_out
+                                    if MONO_fits(sgn_out, graph.number_of_edges(gn, v))
                                 }
                             else:
-                                sgn_multi_out = subgraph.number_of_edges(sgn, sgn2)
-                                sgn_multi_in = subgraph.number_of_edges(sgn2, sgn)
+                                sgn_out = subgraph.number_of_edges(sgn, sgn2)
+                                sgn_in = subgraph.number_of_edges(sgn2, sgn)
                                 # gn2 must have correct color in both directions
                                 g_edges = self_ge_partition[self_sge_colors[sgn, sgn2]]
                                 gn2_cands = {
                                     v
                                     for u, v in g_edges
                                     if gn == u
-                                    if graph.number_of_edges(gn, v) == sgn_multi_out
+                                    if MONO_fits(sgn_out, graph.number_of_edges(gn, v))
                                 }
                                 g_edges = self_ge_partition[self_sge_colors[sgn2, sgn]]
                                 gn2_cands &= {
                                     u
                                     for u, v in g_edges
                                     if gn == v
-                                    if graph.number_of_edges(u, gn) == sgn_multi_in
+                                    if MONO_fits(sgn_in, graph.number_of_edges(u, gn))
                                 }
-                        # Do not change the original set. So do not use |= operator
-                        cand_sets[sgn2] = cand_sets[sgn2] | {frozenset(gn2_cands)}
+                            # Do not change the original set. So do not use |= operator
+                            cand_sets[sgn2] = cand_sets[sgn2] | {frozenset(gn2_cands)}
 
                 for sgn2 in left_to_map:
                     # symmetry must match. constraints mean gn2>gn iff sgn2>sgn
@@ -1066,7 +1154,7 @@ class ISMAGS:
                     continue
                 cand_sets[new_sgn] = {new_sgn_candidates}
                 queue.append((new_sgn, cand_sets, iter(new_sgn_candidates)))
-                break
+                break  # leave "for gn in sgn_cand_iter" loop. Process next in queue
             else:  # all gn candidates tried for sgn.
                 queue.pop()
                 if sgn in mapping:
@@ -1077,6 +1165,7 @@ class ISMAGS:
         """
         Find all largest common subgraphs honoring constraints.
         """
+        MONO_fits = operator.eq
         # to_be_mapped is a set of frozensets of subgraph nodes
         if to_be_mapped is None:
             to_be_mapped = {frozenset(self.subgraph.nodes)}
@@ -1100,7 +1189,7 @@ class ISMAGS:
                 # Find the isomorphism between subgraph[to_be_mapped] <= graph
                 next_sgn = min(nodes, key=lambda n: min(len(x) for x in candidates[n]))
                 isomorphs = self._map_nodes(
-                    next_sgn, candidates, constraints, to_be_mapped=nodes
+                    next_sgn, candidates, constraints, MONO_fits, to_be_mapped=nodes
                 )
 
                 # This is effectively `yield from isomorphs`, except that we look

--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -251,8 +251,8 @@ def color_degree_by_node_no_multi(G, n_colors, e_colors):
     the color tuples.
 
     Not used for largest_common_subgraph. Only for _all_morphisms when considering
-    PT == "MONO", or cases with no multigraphs present. MONO needs to allow lower
-    numbers of multiedges in the subgraph, so we can't use that as a color (which
+    problem_type == "MONO", or cases with no multigraphs present. MONO needs to allow
+    lower numbers of multiedges in the subgraph, so we can't use that as a color (which
     are essentially treated using equality checks for isomorphisms. We handle
     multiedge checks for MONO during mapping update checks rather than candidate
     identifying part of the loop. Ignoring the multiedges gives the same code we
@@ -699,10 +699,10 @@ class ISMAGS:
 
     def find_isomorphisms(self, symmetry=True):
         """left for backward compatibility. Use isomorphisms_iter"""
-        yield from self._all_morphisms(symmetry, PT="SUB")
+        yield from self._all_morphisms(symmetry, problem_type="SUB")
         return
 
-    def _all_morphisms(self, symmetry=True, PT="SUB"):
+    def _all_morphisms(self, symmetry, problem_type):
         """Find all subgraph isomorphisms between subgraph and graph
 
         Finds isomorphisms where :attr:`subgraph` <= :attr:`graph`.
@@ -712,14 +712,20 @@ class ISMAGS:
         symmetry: bool
             Whether symmetry should be taken into account. If False, found
             isomorphisms may be symmetrically equivalent.
+        problem_type : string
+            The problem type to be used:
+            - "ISO" for graph isomorphism,
+            - "MONO" for monomorphism.
+            - "SUB" or any other string produces subgraph isomorphism
+            Not checked for correctness.
 
         Yields
         ------
         dict
             The found isomorphism mappings of {graph_node: subgraph_node}.
         """
-        SG_fits = operator.eq if PT == "ISO" else operator.le
-        MONO_fits = operator.eq if PT != "MONO" else operator.le
+        SG_fits = operator.eq if problem_type == "ISO" else operator.le
+        MONO_fits = operator.eq if problem_type != "MONO" else operator.le
         # The networkx VF2 algorithm is slightly funny in when it yields an
         # empty dict and when not.
         if not self.subgraph:
@@ -735,7 +741,7 @@ class ISMAGS:
         elif not SG_fits(len(self._sge_partition), self.N_edge_colors):
             # some subgraph edges have a color that doesn't occur in graph
             return
-        if PT == "ISO":
+        if problem_type == "ISO":
             if not SG_fits(len(self._gn_partition), self.N_node_colors):
                 return
             if not SG_fits(len(self._ge_partition), self.N_edge_colors):
@@ -906,15 +912,15 @@ class ISMAGS:
         :attr:`subgraph` have the same number of nodes.
         """
         if len(self.graph) == len(self.subgraph):
-            yield from self._all_morphisms(symmetry=symmetry, PT="ISO")
+            yield from self._all_morphisms(symmetry, problem_type="ISO")
 
     def subgraph_isomorphisms_iter(self, symmetry=True):
         """Alternative name for :meth:`_all_morphisms`."""
-        return self._all_morphisms(symmetry)
+        return self._all_morphisms(symmetry, problem_type="SUB")
 
     def monomorphisms_iter(self, symmetry=True):
         """Iterate over monomorphism."""
-        return self._all_morphisms(symmetry, PT="MONO")
+        return self._all_morphisms(symmetry, problem_type="MONO")
 
     def _get_node_color_candidate_sets(self, MONO_fits):
         """

--- a/networkx/algorithms/isomorphism/tests/test_common.py
+++ b/networkx/algorithms/isomorphism/tests/test_common.py
@@ -747,15 +747,24 @@ def test_monomorphism_path_in_cycle(iso_ic, symmetry, Gclass):
 
     mono = "mono" in iso_ic.__name__
     assert mono == iso_ic(FG, SG, symmetry=symmetry)
+
+    # Test self-loop multiedges
+    # Add a multiedge to FG, then too many to SG, then even them out again.
+    # is_mono functions should pass on all except when SG has more multiedges than FG
+    # is_SG functions should fail on all b/c induced SG cant be missing edge (13, 0)
     if FG.is_multigraph():
+        # more edges in FG does not affect is_mono
         FG.add_edge(3, 3)
         assert mono == iso_ic(FG, SG, symmetry=symmetry)
+        # too many multiedge loops in SG rules out morphism
         SG.add_edge(3, 3)
-        assert mono == iso_ic(FG, SG, symmetry=symmetry)
         SG.add_edge(3, 3)
         assert not iso_ic(FG, SG, symmetry=symmetry)
+        # equal number in SG and FG so back True is_mono
         FG.add_edge(3, 3)
         assert mono == iso_ic(FG, SG, symmetry=symmetry)
+
+    # an extra SG multiedge loop rules out morphism
     SG.add_edge(7, 7)
     assert not iso_ic(FG, SG, symmetry=symmetry)
 
@@ -789,6 +798,7 @@ def test_monomorphism_count_for_path_in_cycle(mono_iter, symmetry, Gclass):
     ans = 1 if (FG.is_directed() or FG.is_multigraph()) else 2
     assert sum(1 for _ in mappings) == ans
 
+    # test multigraph to non-multigraph: simple edge equiv to single multiedge
     if FG.is_multigraph():
         USG = nx.DiGraph(SG) if FG.is_directed() else nx.Graph(SG)
         mappings = mono_iter(FG, USG, symmetry=symmetry)
@@ -799,7 +809,8 @@ def test_monomorphism_count_for_path_in_cycle(mono_iter, symmetry, Gclass):
         mappings = mono_iter(UFG, SG, symmetry=symmetry)
         assert sum(1 for _ in mappings) == 0
 
-    SG.add_edge(10, 11)
+    # Add multiedge to SG. Lowers numb mappings (unless not multigraph cuz not added)
+    SG.add_edge(10, 11)  # multiedge to SG
     mappings = mono_iter(FG, SG, symmetry=symmetry)
     assert sum(1 for _ in mappings) == 0 if FG.is_multigraph() else 1
 

--- a/networkx/algorithms/isomorphism/tests/test_common.py
+++ b/networkx/algorithms/isomorphism/tests/test_common.py
@@ -741,9 +741,21 @@ def test_monomorphism_path_in_cycle(iso_ic, symmetry, Gclass):
     SG = FG.copy()
     SG.remove_edge(13, 0)
     assert FG.number_of_edges() == SG.number_of_edges() + 1
+    FG, SG = Gclass(FG), Gclass(SG)
 
     mono = "mono" in iso_ic.__name__
-    assert mono == iso_ic(Gclass(FG), Gclass(SG), symmetry=symmetry)
+    assert mono == iso_ic(FG, SG, symmetry=symmetry)
+    if FG.is_multigraph():
+        FG.add_edge(3, 3)
+        assert mono == iso_ic(FG, SG, symmetry=symmetry)
+        SG.add_edge(3, 3)
+        assert mono == iso_ic(FG, SG, symmetry=symmetry)
+        SG.add_edge(3, 3)
+        assert not iso_ic(FG, SG, symmetry=symmetry)
+        FG.add_edge(3, 3)
+        assert mono == iso_ic(FG, SG, symmetry=symmetry)
+    SG.add_edge(7, 7)
+    assert not iso_ic(FG, SG, symmetry=symmetry)
 
 
 @pytest.mark.parametrize("Gclass", graph_classes)

--- a/networkx/algorithms/isomorphism/tests/test_common.py
+++ b/networkx/algorithms/isomorphism/tests/test_common.py
@@ -59,7 +59,9 @@ mematch = iso.categorical_multiedge_match("foo", "")
 #   ismags.subgraph_isomorphisms_iter()
 #   ismags.largest_common_subgraph()
 #   ismags.analyse_subgraph_symmetry()
-#   ismags.find_isomorphisms()          # same as isomorphisms_iter
+#   ismags.isomorphisms_iter()
+#   ismags.is_monomorphic()
+#   ismags.monomorphisms_iter()
 
 
 def ismags_is_iso(G1, G2, node_label=None, edge_label=None, symmetry=False):
@@ -82,11 +84,13 @@ def ismags_subgraph_iter(G1, G2, node_label=None, edge_label=None, symmetry=Fals
 
 
 def ismags_is_SG_mono(G1, G2, node_label=None, edge_label=None, symmetry=False):
-    pytest.xfail("ismags does not handle monomorphism yet")
+    gm = iso.ISMAGS(G1, G2, node_label, edge_label)
+    return gm.is_monomorphic(symmetry=symmetry)
 
 
 def ismags_mono_iter(G1, G2, node_label=None, edge_label=None, symmetry=False):
-    pytest.xfail("ismags does not handle monomorphism yet")
+    gm = iso.ISMAGS(G1, G2, node_label, edge_label)
+    return gm.monomorphisms_iter(symmetry=symmetry)
 
 
 def vf2_is_iso(G1, G2, node_label=None, edge_label=None, symmetry=False):
@@ -522,9 +526,8 @@ def test_graph_input_order(morphism):
 def test_single_graph(G, Gclass, iso_ic, iso_iter, symmetry):
     G1 = Gclass(G())
     assert iso_ic(G1, G1, symmetry=symmetry)
-    assert list(iso_iter(G1, G1, symmetry=symmetry))
-
     all_mappings = list(iso_iter(G1, G1, symmetry=symmetry))
+    assert all_mappings
 
     sym = G1.graph.get("numb_symmetries", None)
     mappings = G1.graph.get("mappings", None)
@@ -641,7 +644,6 @@ def test_non_isomorphic_same_degree_sequence(iso_ic, symmetry, Gclass):
     G1.add_edge(4, 8)
     G2 = G.copy()
     G2.add_edge(3, 7)
-    # 3rd value is whether isomorphic or not
     assert not iso_ic(Gclass(G1), Gclass(G2), symmetry=symmetry)
 
 
@@ -781,6 +783,25 @@ def test_monomorphism_count_for_path_in_cycle(mono_iter, symmetry, Gclass):
 
     # switch order of FG and SG (bigger cannot be subgraph)
     assert sum(1 for _ in mono_iter(SG, FG, symmetry=symmetry)) == 0
+
+    FG.add_edge(7, 8)
+    mappings = mono_iter(FG, SG, symmetry=symmetry)
+    ans = 1 if (FG.is_directed() or FG.is_multigraph()) else 2
+    assert sum(1 for _ in mappings) == ans
+
+    if FG.is_multigraph():
+        USG = nx.DiGraph(SG) if FG.is_directed() else nx.Graph(SG)
+        mappings = mono_iter(FG, USG, symmetry=symmetry)
+        ans = 1 if FG.is_directed() else 2
+        assert sum(1 for _ in mappings) == ans
+
+        UFG = nx.DiGraph(FG) if FG.is_directed() else nx.Graph(FG)
+        mappings = mono_iter(UFG, SG, symmetry=symmetry)
+        assert sum(1 for _ in mappings) == 0
+
+    SG.add_edge(10, 11)
+    mappings = mono_iter(FG, SG, symmetry=symmetry)
+    assert sum(1 for _ in mappings) == 0 if FG.is_multigraph() else 1
 
 
 @pytest.mark.parametrize("Gclass", graph_classes)

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -605,6 +605,35 @@ class TestLargestCommonSubgraph:
         assert expected == found_mcis1
         assert expected == found_mcis2
 
+    def test_extra_colors(self):
+        graph = nx.Graph([(0, 1)])
+        graph.nodes[1]["attr1"] = 0
+        graph.add_node(2, attr1=1)
+        subgraph = nx.Graph()
+        subgraph.add_node(2, attr1=2)
+        subgraph.add_node(5, attr1=0)
+
+        nodematch = nx.isomorphism.categorical_node_match(["attr1"], [None])
+        ismags = iso.ISMAGS(graph, subgraph, node_match=nodematch)
+        result = list(ismags.largest_common_subgraph(symmetry=True))
+        assert result == [{1: 5}]
+        result = list(ismags.largest_common_subgraph(symmetry=False))
+        assert result == [{1: 5}]
+
+        assert ismags.N_node_colors == 1
+        assert ismags.N_edge_colors == 1
+        assert len(ismags._sgn_partition) == 2
+        assert ismags._sgn_partition == [{5}, {2}]
+        # _gn_partition padded (empty set aligns with subgraph extra color)
+        assert len(ismags._gn_partition) == 4
+        assert ismags._gn_partition == [{1}, set(), {0}, {2}]
+
+        # switch graph order
+        graph, subgraph = subgraph, graph
+        ismags = iso.ISMAGS(graph, subgraph, node_match=nodematch)
+        assert ismags._sgn_partition == [{1}, {0}, {2}]
+        assert ismags._gn_partition == [{5}, set(), set(), {2}]
+
 
 def is_isomorphic(G, SG, edge_match=None, node_match=None):
     return iso.ISMAGS(G, SG, node_match, edge_match).is_isomorphic()

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -282,10 +282,10 @@ class TestSubgraphIsomorphism:
 
         expected = _matches_to_sets([{0: 0}, {1: 0}])
         none_matches = iso.ISMAGS(graph, subgraph, edge_match=None)
-        assert _matches_to_sets(none_matches.find_isomorphisms()) == expected
+        assert _matches_to_sets(none_matches.subgraph_isomorphisms_iter()) == expected
 
         all_matches = iso.ISMAGS(graph, subgraph, edge_match=lambda e1, e2: True)
-        assert _matches_to_sets(all_matches.find_isomorphisms()) == expected
+        assert _matches_to_sets(all_matches.subgraph_isomorphisms_iter()) == expected
 
     def test_subgraph_with_graph_only_node_color(self):
         # gh-8738: a node color present in the graph but not in the subgraph
@@ -298,13 +298,13 @@ class TestSubgraphIsomorphism:
         subgraph.add_node(0, color="a")
 
         expected = [{0: 0}]
-        result = list(iso.ISMAGS(graph, subgraph, node_match=nm).find_isomorphisms())
-        assert result == expected
+        ismags = iso.ISMAGS(graph, subgraph, node_match=nm)
+        assert list(ismags.subgraph_isomorphisms_iter()) == expected
 
         # A color that only the subgraph has should still yield no matches.
         subgraph.nodes[0]["color"] = "z"
-        result = list(iso.ISMAGS(graph, subgraph, node_match=nm).find_isomorphisms())
-        assert result == []
+        ismags = iso.ISMAGS(graph, subgraph, node_match=nm)
+        assert list(ismags.subgraph_isomorphisms_iter()) == []
 
     def test_subgraph_color_with_only_node(self):
         # see gh-8738: node_match default of None should not lead to result == []
@@ -315,17 +315,17 @@ class TestSubgraphIsomorphism:
 
         nodematch = nx.isomorphism.categorical_node_match(["attr1"], [None])
         ismags = iso.ISMAGS(graph, subgraph, node_match=nodematch)
-        result = list(ismags.find_isomorphisms())
+        result = list(ismags.subgraph_isomorphisms_iter())
         assert result == [{1: 5}]
 
         nodematch = nx.isomorphism.categorical_node_match(["attr1"], [0])
         ismags = iso.ISMAGS(graph, subgraph, node_match=nodematch)
-        result = list(ismags.find_isomorphisms())
+        result = list(ismags.subgraph_isomorphisms_iter())
         assert result == [{0: 5}, {1: 5}]
 
         nodematch = nx.isomorphism.categorical_node_match(["attr1"], ["blue"])
         ismags = iso.ISMAGS(graph, subgraph, node_match=nodematch)
-        result = list(ismags.find_isomorphisms())
+        result = list(ismags.subgraph_isomorphisms_iter())
         assert result == [{1: 5}]
 
     def test_exceptions_for_bad_match_functions(self):
@@ -660,13 +660,13 @@ class TestDiGraphISO:
         G1 = nx.DiGraph(edges1)
         G2 = nx.relabel_nodes(G1, mapped)
 
-        result = next(nx.isomorphism.ISMAGS(G1, G2).find_isomorphisms())
+        result = next(nx.isomorphism.ISMAGS(G1, G2).subgraph_isomorphisms_iter())
         assert result == mapped
 
         # Change the direction of an edge
         G1.remove_edge(1, 5)
         G1.add_edge(5, 1)
-        result = list(nx.isomorphism.ISMAGS(G1, G2).find_isomorphisms())
+        result = list(nx.isomorphism.ISMAGS(G1, G2).subgraph_isomorphisms_iter())
         assert result == []
 
     def test_non_isomorphic_same_degree_sequence(self):


### PR DESCRIPTION
This PR adds support for monomorphism checking with ISMAGS.
That means we can iterate over monomorphisms and get only one
morphisms for each group of morphisms that are symmetrically the same.
The symmetries are found in the subgraph and used to restrict reported
monomorphisms.

The monomorphism code is intertwined with the isomorphisms using `if` 
clauses and operator function `SG_fits` and `mono_fits` functions.
That reduces a lot of duplicate code -- but might affect performance.
I did run a profiler and found that creating `gn2_cands` was poorly behaved
so rewrote those loops. I'm sure more can be done for optimization.
But this at least gets the functionality in place. 

```release-note {label=Highlight}
The isomorphism checking suite of tools has been upgraded. The ISMAGS symmetry
aware isomorphism and subgraph isomorphism checking tools now support directed
and multigraph Graphs. And, now in addition to support for (induced) subgraph
isomorphisms, they support (non-induced subgraph) monomorphism.
```