### PR TITLE
Adding regression test for duplicate shortest-paths

### DIFF
--- a/networkx/algorithms/shortest_paths/tests/test_generic.py
+++ b/networkx/algorithms/shortest_paths/tests/test_generic.py
@@ -371,6 +371,13 @@ class TestGenericPath:
             nx.all_shortest_paths(G, 0, 3, weight="weight", method="bellman-ford")
         )
 
+    def test_all_shortest_paths_8833_regression(self):
+        # Regression test for https://github.com/networkx/networkx/issues/8833
+        G = nx.Graph()
+        G.add_edge(0, 1, weight=0)
+        G.add_edge(1, 2, weight=100)
+        assert [[0, 1, 2]] == sorted(nx.all_shortest_paths(G, 0, 2, weight="weight"))
+
     def test_all_shortest_paths_raise(self):
         with pytest.raises(nx.NetworkXNoPath):
             G = nx.path_graph(4)


### PR DESCRIPTION
Issue reported in https://github.com/networkx/networkx/issues/8833 was actually solved by https://github.com/networkx/networkx/pull/8460. So just adding a test to prevent regressions.