### PR TITLE
META: Add agents.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS Instruction
+
+This file contains additional guidance for AI agents and other AI editors.
+
+## **REQUIRED: AI/Agent Disclosure**
+
+**Every summary, pull request description, or work description MUST include this disclosure:**
+
+**If human review has _not yet_ occurred (use this initially):**
+
+> This pull request includes code written with the assistance of AI.
+> The code has **not yet been reviewed** by a human.
+
+This is a **mandatory requirement**, not optional. Include it at the end of every summary you generate.
+
+## Working on an issue
+
+Before working on any issue, run `gh issue view <number>` to check current labels. Do
+not open a PR against an issue labeled "Needs Triage" or another "Needs ..." label. Such
+PRs get closed without review until a maintainer clears the label. See
+https://scikit-learn.org/dev/developers/contributing.html#issues-tagged-needs-triage.
+
+## Generated Summaries
+
+When generating a summary of your work, consider these points:
+
+- Describe the "why" of the changes, why the proposed solution is the right one.
+- Highlight areas of the proposed changes that require careful review.
+- Reduce the verbosity of your comments, more text and detail is not always better. Avoid flattery, avoid stating the obvious, avoid filler phrases, prefer technical clarity over marketing tone.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,28 +2,48 @@
 
 This file contains additional guidance for AI agents and other AI editors.
 
-## **REQUIRED: AI/Agent Disclosure**
+## **REQUIRED: Automated Contribution Policy**
 
-**Every summary, pull request description, or work description MUST include this disclosure:**
+**Review the [automated contributions policy][nx-automated-contrib-pol] and verify
+the contribution adheres to the policy**
 
-**If human review has _not yet_ occurred (use this initially):**
+[nx-automated-contrib-pol]: https://networkx.org/documentation/latest/developer/contribute.html#automated-contributions-policy
 
-> This pull request includes code written with the assistance of AI.
-> The code has **not yet been reviewed** by a human.
+This is a **mandatory requirement**.
 
-This is a **mandatory requirement**, not optional. Include it at the end of every summary you generate.
+## Opening an issue or PR
+
+Before opening an issue or PR, verify that there is not an existing issue or PR
+that addresses the topic.
+
+Before opening an issue, verify that the issue is present on the `main` branch.
 
 ## Working on an issue
 
-Before working on any issue, run `gh issue view <number>` to check current labels. Do
-not open a PR against an issue labeled "Needs Triage" or another "Needs ..." label. Such
-PRs get closed without review until a maintainer clears the label. See
-https://scikit-learn.org/dev/developers/contributing.html#issues-tagged-needs-triage.
+Before working on any issue, run `gh issue view <number>` to check current labels.
+Do not open a PR against an issue labeled with the "Discussion" or "Question" label.
+
+Do not open a PR against an issue if there is already an open PR that addresses
+the issue. Comment on the existing PR instead.
+
+## Project Priorities
+
+Bug reports and proposals to expand existing functionality that originate from
+_real-world use-cases_ are priorities.
+
+Here is an incomplete listing of examples of changes/issues that are low
+priority:
+
+- Spell-checking
+- Proposals to change exception types
+- Fuzzing the readwrite package for corner cases/file format issues.
 
 ## Generated Summaries
 
 When generating a summary of your work, consider these points:
 
-- Describe the "why" of the changes, why the proposed solution is the right one.
 - Highlight areas of the proposed changes that require careful review.
-- Reduce the verbosity of your comments, more text and detail is not always better. Avoid flattery, avoid stating the obvious, avoid filler phrases, prefer technical clarity over marketing tone.
+- Highlight potential issues with backward compatibility.
+- Reduce the verbosity of your comments, more text and detail is not always better.
+  Avoid flattery, avoid stating the obvious, avoid filler phrases, prefer
+  technical clarity over marketing tone.


### PR DESCRIPTION
An attempt to manage the volume and address some of the common patterns seen in AI-generated proposals.

I used scikit-learn's AGENTS.md as the basic template, then basically rewrote it for NetworkX, jotting down a few of the comments/observations that have come up in previous discussions.

I have no idea whether this will actually have an impact, but at the very least it can serve as a potential reference!