### PR TITLE
Simplifying _build_paths_from_predecessors - 10% faster

### DIFF
--- a/networkx/algorithms/shortest_paths/generic.py
+++ b/networkx/algorithms/shortest_paths/generic.py
@@ -701,23 +701,18 @@ def _build_paths_from_predecessors(sources, target, pred):
     if target not in pred:
         raise nx.NetworkXNoPath(f"Target {target} cannot be reached from given sources")
 
-    stack = [[target, iter(pred[target])]]
+    stack = {target: iter(pred[target])}
     path = [target]
-    seen = {target}
-
     while stack:
-        node, preds = stack[-1]
+        node = path[-1]
         if node in sources:
             yield path[::-1]
-
-        for predecessor in preds:
-            if predecessor in seen:
+        for predecessor in stack[node]:
+            if predecessor in stack:
                 continue
-            seen.add(predecessor)
+            stack[predecessor] = iter(pred[predecessor])
             path.append(predecessor)
-            stack.append([predecessor, iter(pred[predecessor])])
             break
-        else:  # no preds left!
-            stack.pop()
+        else:
+            stack.popitem()
             path.pop()
-            seen.remove(node)


### PR DESCRIPTION
Follow up of https://github.com/networkx/networkx/pull/8460. I remembered I wanted to simplify this one using @rossbar 's favorite trick of dict's order preservation. Code is cleaner and 10% faster :) 

```
[75.00%] ··· benchmark_shortest_path.AllShortestPathsGrid.time_all_shortest_paths                                                                                                                                  ok
[75.00%] ··· ==== =============
              N                
             ---- -------------
              8    3.77±0.04ms 
              10    54.2±0.4ms 
              12     809±7ms   
             ==== =============

[75.00%] · For networkx commit 30bfe1b2 <main> (round 2/2):
[75.00%] ·· Building for virtualenv-py3.14...
[75.00%] ·· Benchmarking virtualenv-py3.14
[100.00%] ··· benchmark_shortest_path.AllShortestPathsGrid.time_all_shortest_paths                                                                                                                                  ok
[100.00%] ··· ==== =============
               N                
              ---- -------------
               8    4.24±0.04ms 
               10    62.2±0.6ms 
               12     906±4ms   
              ==== =============

| Change   | Before [30bfe1b2] <main>   | After [3dbc09f4] <all_shortest_paths_refactoring>   |   Ratio | Benchmark (Parameter)                                                    |
|----------|----------------------------|-----------------------------------------------------|---------|--------------------------------------------------------------------------|
| -        | 906±4ms                    | 809±7ms                                             |    0.89 | benchmark_shortest_path.AllShortestPathsGrid.time_all_shortest_paths(12) |
| -        | 4.24±0.04ms                | 3.77±0.04ms                                         |    0.89 | benchmark_shortest_path.AllShortestPathsGrid.time_all_shortest_paths(8)  |
| -        | 62.2±0.6ms                 | 54.2±0.4ms                                          |    0.87 | benchmark_shortest_path.AllShortestPathsGrid.time_all_shortest_paths(10) |

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```