### PR TITLE
approximation/steiner_tree: raise NetworkXError for disconnected graph in mehlhorn method

### DIFF
--- a/networkx/algorithms/approximation/steinertree.py
+++ b/networkx/algorithms/approximation/steinertree.py
@@ -63,6 +63,9 @@ def metric_closure(G, weight="weight"):
 
 
 def _mehlhorn_steiner_tree(G, terminal_nodes, weight):
+    if not nx.is_connected(G):
+        raise nx.NetworkXError("G is not a connected graph.")
+
     distances, paths = nx.multi_source_dijkstra(G, terminal_nodes, weight=weight)
 
     d_1 = {}

--- a/networkx/algorithms/approximation/tests/test_steinertree.py
+++ b/networkx/algorithms/approximation/tests/test_steinertree.py
@@ -304,3 +304,18 @@ def test_steiner_tree_non_terminal_leaves_multigraph_self_loop_edges():
 
     # Only the terminal nodes should be left
     assert list(G) == [4, 5, 6, 7]
+
+
+def test_steiner_tree_disconnected_raises(method):
+    # GH#8839: mehlhorn method raised KeyError for disconnected graphs;
+    # both methods should raise NetworkXError.
+    G = nx.Graph()
+    G.add_edges_from([("A", "B"), ("C", "D")])
+    with pytest.raises(nx.NetworkXError, match="not a connected graph"):
+        steiner_tree(G, ["A", "C"], method=method)
+
+    # Same for MultiGraph
+    MG = nx.MultiGraph()
+    MG.add_edges_from([("A", "B"), ("C", "D")])
+    with pytest.raises(nx.NetworkXError, match="not a connected graph"):
+        steiner_tree(MG, ["A", "C"], method=method)


### PR DESCRIPTION
## Summary

Fixes #8839.

`_mehlhorn_steiner_tree` calls `nx.multi_source_dijkstra` starting from all terminal nodes simultaneously. For a disconnected graph, nodes in components not reachable from the terminal set still appear in `G.nodes()` but not in `paths`, causing a `KeyError` at:

```python
for v in G.nodes():
    s[v] = paths[v][0]  # KeyError on unreachable v
```

### Fix

Added an explicit `nx.is_connected(G)` guard at the start of `_mehlhorn_steiner_tree`, mirroring the connectivity check already present in `_kou_steiner_tree`. Both methods now raise `NetworkXError("G is not a connected graph.")` consistently instead of a bare `KeyError`.

### Tests

Added `test_steiner_tree_disconnected_raises` parametrized over both methods, testing both `Graph` and `MultiGraph` with a disconnected input.

## Reproduction

```python
import networkx as nx
G = nx.MultiGraph()
G.add_edges_from([("A", "B"), ("C", "D")])
nx.approximation.steiner_tree(G, ["A", "C"], method="mehlhorn")
# Before: KeyError: 'C'
# After:  NetworkXError: G is not a connected graph.
```
