### PR TITLE
community/quality: raise NetworkXPointlessConcept in partition_quality for edgeless/tiny graphs

### DIFF
--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -652,6 +652,9 @@ def partition_quality(G, partition):
     ------
     NetworkXError
         If `partition` is not a valid partition of the nodes of `G`.
+    NetworkXPointlessConcept
+        If `G` has no edges (coverage is undefined) or fewer than 2 nodes
+        (performance is undefined for a non-multigraph).
 
     Notes
     -----
@@ -701,11 +704,19 @@ def partition_quality(G, partition):
         else:
             inter_community_non_edges -= 1
 
+    if len(G.edges) == 0:
+        raise nx.NetworkXPointlessConcept(
+            "coverage is undefined for a graph with no edges"
+        )
     coverage = intra_community_edges / len(G.edges)
 
     if G.is_multigraph():
         performance = -1.0
     else:
+        if total_pairs == 0:
+            raise nx.NetworkXPointlessConcept(
+                "performance is undefined for a graph with fewer than 2 nodes"
+            )
         performance = (intra_community_edges + inter_community_non_edges) / total_pairs
 
     return coverage, performance

--- a/networkx/algorithms/community/tests/test_quality.py
+++ b/networkx/algorithms/community/tests/test_quality.py
@@ -52,6 +52,23 @@ class TestCoverage:
         assert 6 / 7 == pytest.approx(partition_quality(G, partition)[0], abs=1e-7)
 
 
+def test_partition_quality_no_edges_raises():
+    # GH#8830: ZeroDivisionError when the graph has no edges
+    G = nx.Graph()
+    G.add_nodes_from([0, 1, 2])
+    with pytest.raises(nx.NetworkXPointlessConcept, match="no edges"):
+        partition_quality(G, [{0}, {1, 2}])
+
+
+def test_partition_quality_single_node_raises():
+    # GH#8830: ZeroDivisionError for performance when n < 2
+    G = nx.Graph()
+    G.add_node(0)
+    G.add_edge(0, 0)  # self-loop so edges is non-empty
+    with pytest.raises(nx.NetworkXPointlessConcept, match="fewer than 2 nodes"):
+        partition_quality(G, [{0}])
+
+
 def test_modularity():
     G = nx.barbell_graph(3, 0)
     C = [{0, 1, 4}, {2, 3, 5}]


### PR DESCRIPTION
## Summary

Fixes #8830.

`partition_quality` raised `ZeroDivisionError` in two places:

1. `coverage = intra_community_edges / len(G.edges)` — crashes when the graph has no edges.
2. `performance = ... / total_pairs` where `total_pairs = n * (n-1) // 2` — crashes when `n < 2` (0 possible pairs).

### Fix

Added two guards that raise `NetworkXPointlessConcept` with descriptive messages, consistent with how other NetworkX functions handle degenerate graph inputs:

```python
if len(G.edges) == 0:
    raise nx.NetworkXPointlessConcept(
        "coverage is undefined for a graph with no edges"
    )
```

```python
if total_pairs == 0:
    raise nx.NetworkXPointlessConcept(
        "performance is undefined for a graph with fewer than 2 nodes"
    )
```

The docstring is updated to document the new exception.

### Tests

Added `test_partition_quality_no_edges_raises` and `test_partition_quality_single_node_raises`.

## Reproduction

```python
import networkx as nx
from networkx.algorithms.community import partition_quality

# Case 1: graph with no edges
G = nx.Graph()
G.add_nodes_from([0, 1, 2])
partition_quality(G, [{0}, {1, 2}])
# Before: ZeroDivisionError: division by zero
# After:  NetworkXPointlessConcept: coverage is undefined for a graph with no edges

# Case 2: graph with fewer than 2 nodes
G = nx.Graph()
G.add_edge(0, 0)  # self-loop, so edges is non-empty
partition_quality(G, [{0}])
# Before: ZeroDivisionError: integer division or modulo by zero
# After:  NetworkXPointlessConcept: performance is undefined for a graph with fewer than 2 nodes
```
