### PR TITLE
Add DynamicTopologicalSorter for incremental topological ordering

### DIFF
--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -29,6 +29,7 @@ __all__ = [
     "dag_longest_path",
     "dag_longest_path_length",
     "dag_to_branching",
+    "DynamicTopologicalSorter",
 ]
 
 
@@ -1460,3 +1461,47 @@ def colliders(G):
     for node in G.nodes:
         for p1, p2 in combinations(G.predecessors(node), 2):
             yield (p1, node, p2)
+
+
+class DynamicTopologicalSorter:
+    """Maintains a topological ordering of a DAG under edge insertions.
+
+    Keeps a persistent position map so only the affected region is
+    updated when an edge is added, instead of recomputing from scratch.
+    """
+
+    def __init__(self, G=None):
+        # Internal digraph storing the edges
+        self._graph = nx.DiGraph()
+        # Maps each node to its current topological position (integer rank)
+        self._pos = {}
+        # Counter used to assign positions to new nodes
+        self._next_pos = 0
+
+        if G is not None:
+            if not G.is_directed():
+                raise nx.NetworkXError(
+                    "DynamicTopologicalSorter requires a directed graph."
+                )
+            for node in G.nodes:
+                self.add_node(node)
+            for u, v in G.edges:
+                self.add_edge(u, v)
+
+    def add_node(self, n):
+        """Add node `n` and assign it the next available position."""
+        if n not in self._pos:
+            self._pos[n] = self._next_pos
+            self._next_pos += 1
+            self._graph.add_node(n)
+
+    def topological_order(self):
+        """Return nodes sorted by their current topological position."""
+        return sorted(self._pos, key=self._pos.__getitem__)
+
+    def add_edge(self, u, v):
+        """Add edge u -> v and update the topological ordering.
+
+        Raises NetworkXUnfeasible if the edge would create a cycle.
+        """
+        raise NotImplementedError

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1524,6 +1524,25 @@ class DynamicTopologicalSorter:
         self._reorder(u, v)
         self._graph.add_edge(u, v)
 
+    def remove_edge(self, u, v):
+        """Remove edge u -> v from the sorter.
+
+        Raises NetworkXError if the edge does not exist.
+        """
+        if not self._graph.has_edge(u, v):
+            raise nx.NetworkXError(f"Edge ({u}, {v}) not in graph.")
+        self._graph.remove_edge(u, v)
+
+    def remove_node(self, n):
+        """Remove node n and all its edges from the sorter.
+
+        Raises NetworkXError if the node does not exist.
+        """
+        if n not in self._pos:
+            raise nx.NetworkXError(f"Node {n} not in graph.")
+        self._graph.remove_node(n)
+        del self._pos[n]
+
     def _dfs_forward(self, start, lower, upper, source):
         # collect nodes reachable from start within position range [lower, upper]
         # raises NetworkXUnfeasible if source is reached (cycle)

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1504,4 +1504,19 @@ class DynamicTopologicalSorter:
 
         Raises NetworkXUnfeasible if the edge would create a cycle.
         """
+        # ensure both nodes exist
+        self.add_node(u)
+        self.add_node(v)
+
+        # Case 1: order already valid — nothing to do
+        if self._pos[u] < self._pos[v]:
+            self._graph.add_edge(u, v)
+            return
+
+        # Case 2: order violated — need to reorder the affected region
+        self._reorder(u, v)
+        self._graph.add_edge(u, v)
+
+    def _reorder(self, u, v):
+        # Pearce-Kelly reorder — to be implemented
         raise NotImplementedError

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1504,9 +1504,16 @@ class DynamicTopologicalSorter:
 
         Raises NetworkXUnfeasible if the edge would create a cycle.
         """
+        if u == v:
+            raise nx.NetworkXUnfeasible("Adding this edge would create a cycle.")
+
         # ensure both nodes exist
         self.add_node(u)
         self.add_node(v)
+
+        # skip if edge already exists
+        if self._graph.has_edge(u, v):
+            return
 
         # Case 1: order already valid — nothing to do
         if self._pos[u] < self._pos[v]:

--- a/networkx/algorithms/dag.py
+++ b/networkx/algorithms/dag.py
@@ -1517,6 +1517,52 @@ class DynamicTopologicalSorter:
         self._reorder(u, v)
         self._graph.add_edge(u, v)
 
+    def _dfs_forward(self, start, lower, upper, source):
+        # collect nodes reachable from start within position range [lower, upper]
+        # raises NetworkXUnfeasible if source is reached (cycle)
+        visited = set()
+        stack = [start]
+        while stack:
+            node = stack.pop()
+            if node in visited:
+                continue
+            visited.add(node)
+            for successor in self._graph.successors(node):
+                if successor == source:
+                    raise nx.NetworkXUnfeasible(
+                        "Adding this edge would create a cycle."
+                    )
+                if lower <= self._pos[successor] <= upper:
+                    stack.append(successor)
+        return visited
+
+    def _dfs_backward(self, start, lower, upper):
+        # collect nodes that can reach start within position range [lower, upper]
+        visited = set()
+        stack = [start]
+        while stack:
+            node = stack.pop()
+            if node in visited:
+                continue
+            visited.add(node)
+            for predecessor in self._graph.predecessors(node):
+                if lower <= self._pos[predecessor] <= upper:
+                    stack.append(predecessor)
+        return visited
+
     def _reorder(self, u, v):
-        # Pearce-Kelly reorder — to be implemented
-        raise NotImplementedError
+        lower = self._pos[v]
+        upper = self._pos[u]
+
+        df = self._dfs_forward(v, lower, upper, u)
+        db = self._dfs_backward(u, lower, upper)
+
+        # collect and sort the positions occupied by these two groups
+        free_positions = sorted(self._pos[n] for n in df | db)
+
+        # assign db nodes to the lower slots, df nodes to the upper slots
+        db_sorted = sorted(db, key=lambda n: self._pos[n])
+        df_sorted = sorted(df, key=lambda n: self._pos[n])
+
+        for node, pos in zip(db_sorted + df_sorted, free_positions):
+            self._pos[node] = pos

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -843,6 +843,103 @@ def test_ancestors_descendants_undirected():
     nx.ancestors(G, 2) == nx.descendants(G, 2) == {0, 1, 3, 4}
 
 
+class TestDynamicTopologicalSorter:
+    def test_add_node(self):
+        s = nx.DynamicTopologicalSorter()
+        s.add_node("a")
+        s.add_node("b")
+        assert s.topological_order() == ["a", "b"]
+
+    def test_add_node_duplicate(self):
+        s = nx.DynamicTopologicalSorter()
+        s.add_node("a")
+        s.add_node("a")
+        assert s.topological_order() == ["a"]
+
+    def test_add_edge_fast_path(self):
+        s = nx.DynamicTopologicalSorter()
+        s.add_node("a")
+        s.add_node("b")
+        s.add_node("c")
+        s.add_edge("a", "b")
+        s.add_edge("b", "c")
+        assert s.topological_order() == ["a", "b", "c"]
+
+    def test_add_edge_auto_adds_nodes(self):
+        s = nx.DynamicTopologicalSorter()
+        s.add_edge("x", "y")
+        order = s.topological_order()
+        assert order.index("x") < order.index("y")
+
+    def test_add_edge_reorder(self):
+        s = nx.DynamicTopologicalSorter()
+        for n in ["a", "b", "c", "d", "e"]:
+            s.add_node(n)
+        s.add_edge("a", "b")
+        s.add_edge("b", "c")
+        s.add_edge("c", "d")
+        # e is at position 4, b is at position 1 — violated
+        s.add_edge("e", "b")
+        order = s.topological_order()
+        assert order.index("e") < order.index("b")
+        assert order.index("b") < order.index("c")
+        assert order.index("c") < order.index("d")
+
+    def test_add_edge_duplicate_no_op(self):
+        s = nx.DynamicTopologicalSorter()
+        s.add_edge("a", "b")
+        s.add_edge("a", "b")
+        assert s.topological_order().index("a") < s.topological_order().index("b")
+
+    def test_cycle_detection(self):
+        s = nx.DynamicTopologicalSorter()
+        s.add_edge("a", "b")
+        s.add_edge("b", "c")
+        with pytest.raises(nx.NetworkXUnfeasible):
+            s.add_edge("c", "a")
+
+    def test_self_loop(self):
+        s = nx.DynamicTopologicalSorter()
+        with pytest.raises(nx.NetworkXUnfeasible):
+            s.add_edge("a", "a")
+
+    def test_remove_edge(self):
+        s = nx.DynamicTopologicalSorter()
+        s.add_edge("a", "b")
+        s.remove_edge("a", "b")
+        order = s.topological_order()
+        assert "a" in order and "b" in order
+
+    def test_remove_edge_missing(self):
+        s = nx.DynamicTopologicalSorter()
+        s.add_node("a")
+        with pytest.raises(nx.NetworkXError):
+            s.remove_edge("a", "b")
+
+    def test_remove_node(self):
+        s = nx.DynamicTopologicalSorter()
+        s.add_edge("a", "b")
+        s.add_edge("b", "c")
+        s.remove_node("b")
+        assert s.topological_order() == ["a", "c"]
+
+    def test_remove_node_missing(self):
+        s = nx.DynamicTopologicalSorter()
+        with pytest.raises(nx.NetworkXError):
+            s.remove_node("z")
+
+    def test_constructor_with_graph(self):
+        G = nx.DiGraph([("a", "b"), ("b", "c")])
+        s = nx.DynamicTopologicalSorter(G)
+        order = s.topological_order()
+        assert order.index("a") < order.index("b")
+        assert order.index("b") < order.index("c")
+
+    def test_constructor_undirected_raises(self):
+        G = nx.Graph([("a", "b")])
+        with pytest.raises(nx.NetworkXError):
+            nx.DynamicTopologicalSorter(G)
+
 def test_v_structures_raise():
     G = nx.Graph()
     with pytest.raises(nx.NetworkXNotImplemented, match="for undirected type"):

--- a/networkx/algorithms/tests/test_dag.py
+++ b/networkx/algorithms/tests/test_dag.py
@@ -940,6 +940,7 @@ class TestDynamicTopologicalSorter:
         with pytest.raises(nx.NetworkXError):
             nx.DynamicTopologicalSorter(G)
 
+
 def test_v_structures_raise():
     G = nx.Graph()
     with pytest.raises(nx.NetworkXNotImplemented, match="for undirected type"):


### PR DESCRIPTION
**Add DynamicTopologicalSorter for incremental topological ordering**

The existing topological_sort() recomputes the full ordering on every call at O(V+E), even if only one edge changed. This PR adds a new class DynamicTopologicalSorter that maintains a persistent position map and updates only the affected region when an edge is added.

***What this adds:***
- add_node and add_edge to build the graph incrementally, with the ordering updated in place on each insertion
- remove_node and remove_edge to support the full lifecycle, since removing a constraint never breaks the existing order
- Cycle detection built directly into add_edge — raises NetworkXUnfeasible immediately if the edge would create a cycle
- Self-loops are rejected at the point of insertion
- Duplicate edges are silently ignored

***Tests:***
- 14 new tests added under TestDynamicTopologicalSorter covering all
  the above behaviours
- Full existing test suite (91 tests) runs clean with no regressions