### PR TITLE
algorithms: fix swapped method descriptions in communicability docstrings (GH-8802)

### DIFF
--- a/networkx/algorithms/communicability_alg.py
+++ b/networkx/algorithms/communicability_alg.py
@@ -35,8 +35,8 @@ def communicability(G):
     See Also
     --------
     communicability_exp:
-       Communicability between all pairs of nodes in G  using spectral
-       decomposition.
+       Communicability between all pairs of nodes in G using matrix
+       exponentiation.
     communicability_betweenness_centrality:
        Communicability betweenness centrality for each node in G.
 
@@ -117,7 +117,8 @@ def communicability_exp(G):
     See Also
     --------
     communicability:
-       Communicability between pairs of nodes in G.
+       Communicability between pairs of nodes in G using spectral
+       decomposition.
     communicability_betweenness_centrality:
        Communicability betweenness centrality for each node in G.
 


### PR DESCRIPTION
## Summary

Fixes #8802.

The `See Also` section of `communicability()` incorrectly described `communicability_exp()` as using "spectral decomposition", when in fact:

- `communicability()` uses **spectral decomposition** (`numpy.linalg.eigh`) — correct in its own `Notes` section, wrong in `communicability_exp`'s `See Also` entry
- `communicability_exp()` uses **matrix exponentiation** (`scipy.linalg.expm`) — correct in its own `Notes` section

This PR swaps the method description in the `See Also` cross-reference and adds the missing method description to `communicability_exp`'s `See Also` entry for symmetry.

### Before

```
# communicability See Also:
communicability_exp:
   Communicability between all pairs of nodes in G  using spectral decomposition.  # WRONG

# communicability_exp See Also:
communicability:
   Communicability between pairs of nodes in G.  # no method mentioned
```

### After

```
# communicability See Also:
communicability_exp:
   Communicability between all pairs of nodes in G using matrix exponentiation.  # CORRECT

# communicability_exp See Also:
communicability:
   Communicability between pairs of nodes in G using spectral decomposition.  # added for symmetry
```
