### PR TITLE
Bugfix: don't report negative self-loops unreachable from the source (goldberg_radzik / bellman_ford)

### DIFF
--- a/networkx/algorithms/shortest_paths/tests/test_weighted.py
+++ b/networkx/algorithms/shortest_paths/tests/test_weighted.py
@@ -623,6 +623,65 @@ class TestBellmanFordAndGoldbergRadzik(WeightedTestBase):
         )
         pytest.raises(nx.NetworkXUnbounded, nx.goldberg_radzik, G, 1)
 
+    def test_unreachable_negative_selfloop(self):
+        # gh-7362: a negative self-loop (a negative cycle) in a component that
+        # does not contain the source must not be reported, matching the
+        # documented contract of both routines. Previously the global
+        # self-loop pre-check raised regardless of reachability.
+        G = nx.DiGraph()
+        G.add_nodes_from(range(7))
+        edges = [
+            (0, 1, 2),
+            (1, 2, 3),
+            (2, 3, 2),
+            (3, 0, 1),
+            (4, 5, 1),
+            (5, 5, -1),  # negative self-loop in the {4, 5, 6} component
+            (5, 6, 1),
+            (6, 4, 1),
+        ]
+        for u, v, w in edges:
+            G.add_edge(u, v, weight=w)
+        # Source 1 cannot reach node 5, so no cycle should be detected and the
+        # returned distances only cover nodes reachable from the source.
+        assert nx.goldberg_radzik(G, 1)[1] == {1: 0, 2: 3, 3: 5, 0: 6}
+        assert nx.bellman_ford_predecessor_and_distance(G, 1)[1] == {
+            1: 0,
+            2: 3,
+            3: 5,
+            0: 6,
+        }
+
+        # Undirected: a negative self-loop in another connected component is
+        # likewise not reported.
+        H = nx.Graph([(0, 1, {"weight": 1}), (5, 5, {"weight": -2})])
+        assert nx.goldberg_radzik(H, 0)[1] == {0: 0, 1: 1}
+        assert nx.bellman_ford_predecessor_and_distance(H, 0)[1] == {0: 0, 1: 1}
+
+        # MultiDiGraph variant.
+        M = nx.MultiDiGraph([(0, 1, {"weight": 1}), (9, 9, {"weight": -5})])
+        assert nx.goldberg_radzik(M, 0)[1] == {0: 0, 1: 1}
+        assert nx.bellman_ford_predecessor_and_distance(M, 0)[1] == {0: 0, 1: 1}
+
+    def test_reachable_negative_selfloop(self):
+        # A negative self-loop reachable from the source is a negative cycle and
+        # must still raise -- both when it sits on the source and when it is
+        # reached through a path.
+        at_source = nx.DiGraph([(1, 1, {"weight": -1})])
+        pytest.raises(nx.NetworkXUnbounded, nx.goldberg_radzik, at_source, 1)
+        pytest.raises(
+            nx.NetworkXUnbounded, nx.bellman_ford_predecessor_and_distance, at_source, 1
+        )
+
+        reached = nx.DiGraph()
+        reached.add_edge(0, 1, weight=1)
+        reached.add_edge(1, 2, weight=1)
+        reached.add_edge(2, 2, weight=-1)
+        pytest.raises(nx.NetworkXUnbounded, nx.goldberg_radzik, reached, 0)
+        pytest.raises(
+            nx.NetworkXUnbounded, nx.bellman_ford_predecessor_and_distance, reached, 0
+        )
+
     def test_find_negative_cycle_longer_cycle(self):
         G = nx.cycle_graph(5, create_using=nx.DiGraph())
         nx.add_cycle(G, [3, 5, 6, 7, 8, 9])

--- a/networkx/algorithms/shortest_paths/weighted.py
+++ b/networkx/algorithms/shortest_paths/weighted.py
@@ -1162,6 +1162,48 @@ def all_pairs_dijkstra_path(G, cutoff=None, weight="weight"):
         yield (n, path(G, n, cutoff=cutoff, weight=weight))
 
 
+def _has_negative_selfloop_reachable_from(G, source, weight):
+    """Return whether ``G`` has a negative self-loop reachable from ``source``.
+
+    A negative-weight self-loop is a negative cycle located on a single node.
+    Both :func:`bellman_ford_predecessor_and_distance` and
+    :func:`goldberg_radzik` only report negative cycles in the component
+    containing ``source`` (as documented in their ``Notes`` sections), so such
+    a self-loop is relevant only when its node is reachable from ``source``.
+
+    Parameters
+    ----------
+    G : NetworkX graph
+    source : node label
+        Must be a node of ``G``.
+    weight : function
+        Weight function as returned by :func:`_weight_function`.
+
+    Returns
+    -------
+    bool
+    """
+    if G.is_multigraph():
+        neg_selfloop_nodes = {
+            u
+            for u, v, k, d in nx.selfloop_edges(G, keys=True, data=True)
+            if weight(u, v, {k: d}) < 0
+        }
+    else:
+        neg_selfloop_nodes = {
+            u for u, v, d in nx.selfloop_edges(G, data=True) if weight(u, v, d) < 0
+        }
+    if not neg_selfloop_nodes:
+        return False
+    if source in neg_selfloop_nodes:
+        return True
+    # ``nx.descendants`` performs a traversal over the same successor adjacency
+    # (``G._adj``) used by the shortest-path search below, so it yields exactly
+    # the nodes the search can reach (successors for directed graphs, the
+    # connected component for undirected graphs).
+    return not neg_selfloop_nodes.isdisjoint(nx.descendants(G, source))
+
+
 @nx._dispatchable(edge_attrs="weight")
 def bellman_ford_predecessor_and_distance(
     G, source, target=None, weight="weight", heuristic=False
@@ -1268,15 +1310,8 @@ def bellman_ford_predecessor_and_distance(
     if source not in G:
         raise nx.NodeNotFound(f"Node {source} is not found in the graph")
     weight = _weight_function(G, weight)
-    if G.is_multigraph():
-        if any(
-            weight(u, v, {k: d}) < 0
-            for u, v, k, d in nx.selfloop_edges(G, keys=True, data=True)
-        ):
-            raise nx.NetworkXUnbounded("Negative cycle detected.")
-    else:
-        if any(weight(u, v, d) < 0 for u, v, d in nx.selfloop_edges(G, data=True)):
-            raise nx.NetworkXUnbounded("Negative cycle detected.")
+    if _has_negative_selfloop_reachable_from(G, source, weight):
+        raise nx.NetworkXUnbounded("Negative cycle detected.")
 
     dist = {source: 0}
     pred = {source: []}
@@ -2041,15 +2076,8 @@ def goldberg_radzik(G, source, weight="weight"):
     if source not in G:
         raise nx.NodeNotFound(f"Node {source} is not found in the graph")
     weight = _weight_function(G, weight)
-    if G.is_multigraph():
-        if any(
-            weight(u, v, {k: d}) < 0
-            for u, v, k, d in nx.selfloop_edges(G, keys=True, data=True)
-        ):
-            raise nx.NetworkXUnbounded("Negative cycle detected.")
-    else:
-        if any(weight(u, v, d) < 0 for u, v, d in nx.selfloop_edges(G, data=True)):
-            raise nx.NetworkXUnbounded("Negative cycle detected.")
+    if _has_negative_selfloop_reachable_from(G, source, weight):
+        raise nx.NetworkXUnbounded("Negative cycle detected.")
 
     if len(G) == 1:
         return {source: None}, {source: 0}


### PR DESCRIPTION
Closes #7362.

### Problem
`goldberg_radzik` and `bellman_ford_predecessor_and_distance` document (Notes section) that "if a component not containing the source contains a negative (di)cycle, it will not be detected." But both begin with a *global* scan that raises `NetworkXUnbounded` for any negative-weight self-loop anywhere in the graph — a self-loop is a negative cycle on a single node, so this reports cycles in components the source can't reach.

```python
import networkx as nx
G = nx.DiGraph()
G.add_nodes_from(range(7))
for u, v, w in [(0,1,2),(1,2,3),(2,3,2),(3,0,1),(4,5,1),(5,5,-1),(5,6,1),(6,4,1)]:
    G.add_edge(u, v, weight=w)
nx.goldberg_radzik(G, 1)   # source 1 cannot reach node 5
# -> raises NetworkXUnbounded, but node 5's -1 self-loop is unreachable
```

The main relaxation loops only explore nodes reachable from the source, so they would never encounter that self-loop; only the up-front global check does.

### Fix
Restrict the self-loop check to nodes reachable from the source, via a small shared helper `_has_negative_selfloop_reachable_from`. `nx.descendants` walks the same `G._adj` adjacency the search uses, so it matches the search's reach for both directed (successors) and undirected (connected component) graphs.

Behavior after the fix:
- unreachable negative self-loops no longer raise; the search returns shortest paths for the reachable subgraph, as documented;
- reachable negative self-loops — including one on the source itself — still raise `NetworkXUnbounded` (unchanged).

The same buggy pre-check exists verbatim in both functions and they share the identical documented contract, so both are fixed for consistency.

### Tests
Added `test_unreachable_negative_selfloop` (directed / undirected / multigraph unreachable cases) and `test_reachable_negative_selfloop` (self-loop on the source and reached via a path). The first fails on `main` (raises) and passes with this change; the existing suite is unaffected.

---
Disclosure: I used an AI tool to help investigate and draft this change. I have personally reviewed, understood, and tested it.