### PR TITLE
TST: parameterizing with iterables is deprecated in pytest

### DIFF
--- a/networkx/algorithms/bipartite/tests/test_link_analysis.py
+++ b/networkx/algorithms/bipartite/tests/test_link_analysis.py
@@ -1,5 +1,3 @@
-import itertools
-
 import pytest
 
 import networkx as nx
@@ -165,9 +163,8 @@ class TestBipartiteLinkAnalysis:
         with pytest.raises(nx.NetworkXAlgorithmError):
             bipartite.birank(G, all_nodes)
 
-    @pytest.mark.parametrize(
-        "damping_factor,value", list(itertools.product(["alpha", "beta"], [-0.1, 1.1]))
-    )
+    @pytest.mark.parametrize("damping_factor", ["alpha", "beta"])
+    @pytest.mark.parametrize("value", [-0.1, 1.1])
     def test_birank_invalid_alpha_beta(self, damping_factor, value):
         kwargs = {damping_factor: value}
         with pytest.raises(nx.NetworkXAlgorithmError):
@@ -182,22 +179,18 @@ class TestBipartiteLinkAnalysis:
             )
 
     @pytest.mark.parametrize(
-        "personalization,alpha,beta",
-        list(
-            itertools.product(
-                [
-                    # Concentrated case
-                    lambda x: 1000 if x == 0 else 0,
-                    # Uniform case
-                    lambda x: 5,
-                    # Zero case
-                    lambda x: 0,
-                ],
-                [i / 2 for i in range(3)],
-                [i / 2 for i in range(3)],
-            )
-        ),
+        "personalization",
+        [
+            # Concentrated case
+            lambda x: 1000 if x == 0 else 0,
+            # Uniform case
+            lambda x: 5,
+            # Zero case
+            lambda x: 0,
+        ],
     )
+    @pytest.mark.parametrize("alpha", [i / 2 for i in range(3)])
+    @pytest.mark.parametrize("beta", [i / 2 for i in range(3)])
     def test_gnmk_convergence_birank(self, personalization, alpha, beta):
         top_personalization_dict = {
             node: personalization(node) for node in self.gnmk_random_graph_top_nodes

--- a/networkx/algorithms/bipartite/tests/test_link_analysis.py
+++ b/networkx/algorithms/bipartite/tests/test_link_analysis.py
@@ -166,7 +166,7 @@ class TestBipartiteLinkAnalysis:
             bipartite.birank(G, all_nodes)
 
     @pytest.mark.parametrize(
-        "damping_factor,value", itertools.product(["alpha", "beta"], [-0.1, 1.1])
+        "damping_factor,value", list(itertools.product(["alpha", "beta"], [-0.1, 1.1]))
     )
     def test_birank_invalid_alpha_beta(self, damping_factor, value):
         kwargs = {damping_factor: value}
@@ -183,17 +183,19 @@ class TestBipartiteLinkAnalysis:
 
     @pytest.mark.parametrize(
         "personalization,alpha,beta",
-        itertools.product(
-            [
-                # Concentrated case
-                lambda x: 1000 if x == 0 else 0,
-                # Uniform case
-                lambda x: 5,
-                # Zero case
-                lambda x: 0,
-            ],
-            [i / 2 for i in range(3)],
-            [i / 2 for i in range(3)],
+        list(
+            itertools.product(
+                [
+                    # Concentrated case
+                    lambda x: 1000 if x == 0 else 0,
+                    # Uniform case
+                    lambda x: 5,
+                    # Zero case
+                    lambda x: 0,
+                ],
+                [i / 2 for i in range(3)],
+                [i / 2 for i in range(3)],
+            )
         ),
     )
     def test_gnmk_convergence_birank(self, personalization, alpha, beta):

--- a/networkx/algorithms/bipartite/tests/test_matrix.py
+++ b/networkx/algorithms/bipartite/tests/test_matrix.py
@@ -1,5 +1,3 @@
-import itertools
-
 import pytest
 
 import networkx as nx
@@ -83,15 +81,10 @@ class TestBiadjacencyMatrix:
         B = bipartite.from_biadjacency_matrix(M, create_using=nx.MultiGraph())
         assert edges_equal(B.edges(), [(0, 2), (0, 3), (0, 3), (1, 3), (1, 3), (1, 3)])
 
+    @pytest.mark.parametrize("row_order", [None, ("a", "b"), (25, (0, 5, 10))])
+    @pytest.mark.parametrize("column_order", [None, ("c", "d"), (26, (0, 5, 10))])
     @pytest.mark.parametrize(
-        "row_order,column_order,create_using",
-        list(
-            itertools.product(
-                (None, ("a", "b"), (25, (0, 5, 10))),
-                (None, ("c", "d"), (26, (0, 5, 10))),
-                (nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph),
-            )
-        ),
+        "create_using", [nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph]
     )
     def test_from_biadjacency_nodelist(self, row_order, column_order, create_using):
         M = sp.sparse.csc_array([[1, 2], [0, 3]])

--- a/networkx/algorithms/bipartite/tests/test_matrix.py
+++ b/networkx/algorithms/bipartite/tests/test_matrix.py
@@ -85,10 +85,12 @@ class TestBiadjacencyMatrix:
 
     @pytest.mark.parametrize(
         "row_order,column_order,create_using",
-        itertools.product(
-            (None, ("a", "b"), (25, (0, 5, 10))),
-            (None, ("c", "d"), (26, (0, 5, 10))),
-            (nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph),
+        list(
+            itertools.product(
+                (None, ("a", "b"), (25, (0, 5, 10))),
+                (None, ("c", "d"), (26, (0, 5, 10))),
+                (nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph),
+            )
         ),
     )
     def test_from_biadjacency_nodelist(self, row_order, column_order, create_using):

--- a/networkx/algorithms/community/tests/test_leiden.py
+++ b/networkx/algorithms/community/tests/test_leiden.py
@@ -33,7 +33,7 @@ def singletons(G):
 
 
 def _metrics():
-    yield from ["cpm", "modularity"]
+    return ["cpm", "modularity"]
 
 
 def _quality():
@@ -43,8 +43,11 @@ def _quality():
     def qmod(G, P):
         return comm.modularity(G, P, resolution=0.2)
 
-    for gamma in [0.2, 0.5, 0.9]:
-        yield from [("cpm", cpm, gamma), ("modularity", qmod, gamma)]
+    return [
+        (metric, Q_func, gamma)
+        for gamma in [0.2, 0.5, 0.9]
+        for metric, Q_func in [("cpm", cpm), ("modularity", qmod)]
+    ]
 
 
 def test_valid_partition(G):


### PR DESCRIPTION
ran into this while reviewing https://github.com/networkx/networkx/pull/8855

Parameterizing with iterables is deprecated and will be removed in pytest 10 https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators