### PR TITLE
MNT: Use linalg.eigh to compute HITS eigenvalues

### DIFF
--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -214,11 +214,11 @@ def _hits_numpy(G, normalized=True):
     adj_ary = nx.to_numpy_array(G)
     # Hub matrix
     H = adj_ary @ adj_ary.T
-    e, ev = np.linalg.eig(H)
+    e, ev = np.linalg.eigh(H)
     h = ev[:, np.argmax(e)]  # eigenvector corresponding to the maximum eigenvalue
     # Authority matrix
     A = adj_ary.T @ adj_ary
-    e, ev = np.linalg.eig(A)
+    e, ev = np.linalg.eigh(A)
     a = ev[:, np.argmax(e)]  # eigenvector corresponding to the maximum eigenvalue
     if normalized:
         h /= h.sum()


### PR DESCRIPTION
The hub and authority matrix are always symmetric so we can just use https://numpy.org/doc/stable/reference/generated/numpy.linalg.eigh.html (it's faster too)

This also gets rid of these warnings
```
ComplexWarning: Casting complex values to real discards the imaginary part
    authorities = dict(zip(G, map(float, a)))
 ``` 