### PR TITLE
[Perf] Optimize possible_inter_community_edges in partition_quality from O(C^2) to O(C)

### DIFF
--- a/networkx/algorithms/community/quality.py
+++ b/networkx/algorithms/community/quality.py
@@ -4,7 +4,6 @@ communities).
 """
 
 from collections import defaultdict
-from itertools import combinations
 
 import networkx as nx
 from networkx.algorithms.community.community_utils import is_cover, is_partition
@@ -631,7 +630,7 @@ def partition_quality(G, partition):
     intra-community edges plus inter-community non-edges divided by the total
     number of potential edges.
 
-    This algorithm has complexity $O(C^2 + L)$ where C is the number of
+    This algorithm has complexity $O(C + L)$ where C is the number of
     communities and L is the number of links.
 
     Parameters
@@ -674,13 +673,14 @@ def partition_quality(G, partition):
 
     # `performance` is not defined for multigraphs
     if not G.is_multigraph():
-        # Iterate over the communities, quadratic, to calculate `possible_inter_community_edges`
-        possible_inter_community_edges = sum(
-            len(p1) * len(p2) for p1, p2 in combinations(partition, 2)
-        )
-
+        # Calculate `possible_inter_community_edges` in O(C) using the algebraic identity:
+        # 2 * sum_{i < j} |p_i| * |p_j| = (sum |p_i|)^2 - sum |p_i|^2 = n^2 - sum |p_i|^2
+        n = len(G)
+        sum_p_squared = sum(len(p) ** 2 for p in partition)
         if G.is_directed():
-            possible_inter_community_edges *= 2
+            possible_inter_community_edges = n**2 - sum_p_squared
+        else:
+            possible_inter_community_edges = (n**2 - sum_p_squared) // 2
     else:
         possible_inter_community_edges = 0
 

--- a/networkx/algorithms/community/tests/test_quality.py
+++ b/networkx/algorithms/community/tests/test_quality.py
@@ -522,3 +522,30 @@ def test_inter_community_edges_with_digraphs():
     G = nx.cycle_graph(4, create_using=nx.DiGraph())
     partition = [{0, 1}, {2, 3}]
     assert inter_community_edges(G, partition) == 2
+
+
+def test_partition_quality_large_partition_and_directed():
+    # Directed graph
+    G = nx.DiGraph()
+    G.add_edges_from([(0, 1), (1, 2), (2, 3), (3, 0), (0, 2)])
+    partition = [{0, 1}, {2, 3}]
+    coverage, performance = partition_quality(G, partition)
+    # Directed: total_pairs = 4 * 3 = 12.
+    # Intra edges: (0, 1) and (2, 3) = 2.
+    # Total edges = 5 -> coverage = 2/5 = 0.4
+    # Possible inter-community edges = 4^2 - (2^2 + 2^2) = 16 - 8 = 8.
+    # Actual inter-community edges: (1, 2), (3, 0), (0, 2) = 3.
+    # Inter non-edges = 8 - 3 = 5.
+    # Performance = (2 + 5) / 12 = 7 / 12.
+    assert coverage == pytest.approx(2 / 5)
+    assert performance == pytest.approx(7 / 12)
+
+    # 100 single-node communities
+    G_large = nx.path_graph(100)
+    partition_large = [{i} for i in range(100)]
+    cov, perf = partition_quality(G_large, partition_large)
+    assert cov == pytest.approx(0.0)
+    # All 99 edges are inter-community, so inter_community_non_edges = 4950 - 99 = 4851
+    # perf = 4851 / 4950
+    assert perf == pytest.approx(4851 / 4950)
+


### PR DESCRIPTION
## Description
Fixes #8853

In `partition_quality`:
```python
possible_inter_community_edges = sum(
    len(p1) * len(p2) for p1, p2 in combinations(partition, 2)
)
```
Evaluating `combinations(partition, 2)` takes $O(C^2)$ time where $C$ is the number of communities.

Using the algebraic identity:
$$2 \sum_{i < j} |p_i| |p_j| = \left(\sum_i |p_i|\right)^2 - \sum_i |p_i|^2 = n^2 - \sum_i |p_i|^2$$

We can compute `possible_inter_community_edges` in $O(C)$ time as:
- Undirected: `(n**2 - sum(len(p)**2 for p in partition)) // 2`
- Directed: `n**2 - sum(len(p)**2 for p in partition)`

This PR:
1. Replaces the $O(C^2)$ `combinations` scan with the $O(C)$ sum of squares identity.
2. Updates complexity in the docstring from $O(C^2 + L)$ to $O(C + L)$.
3. Adds tests in `test_quality.py` for directed graphs and large partition structures.