### PR TITLE
ENH: Speed up node_connectivity and minimum_node_cut with a pre-filter

### DIFF
--- a/networkx/algorithms/connectivity/connectivity.py
+++ b/networkx/algorithms/connectivity/connectivity.py
@@ -6,6 +6,9 @@ import itertools
 from operator import itemgetter
 
 import networkx as nx
+from networkx.algorithms.approximation.connectivity import (
+    local_node_connectivity as approx_local_node_connectivity,
+)
 
 # Define the default maximum flow function to use in all flow based
 # connectivity algorithms.
@@ -283,6 +286,15 @@ def node_connectivity(G, s=None, t=None, flow_func=None):
     The local node connectivity of an ordered pair of nodes of a digraph
     is not symmetric, so both orders of each pair are considered [2]_.
 
+    Before each of those maximum flow problems a much cheaper call is
+    made to the shortest path based approximation of local node
+    connectivity (see
+    :meth:`networkx.algorithms.approximation.local_node_connectivity`),
+    following [3]_. That approximation is a strict lower bound on the
+    exact value, so whenever it already reaches the best value of $K$
+    found so far the maximum flow computation cannot lower $K$ and is
+    skipped. This does not change the result, which is still exact.
+
     See also
     --------
     :meth:`local_node_connectivity`
@@ -301,6 +313,12 @@ def node_connectivity(G, s=None, t=None, flow_func=None):
         Connectivity. SIAM Journal on Computing, Volume 4, Issue 4,
         pp. 507-518, 1975.
         https://doi.org/10.1137/0204043
+
+    .. [3] Robert S. Sinkovits. Fast and Accurate Determination of Graph Node
+        Connectivity Leveraging Approximate Methods. Computational Science -
+        ICCS 2021, Lecture Notes in Computer Science, Volume 12742,
+        Springer, 2021.
+        https://doi.org/10.1007/978-3-030-77961-0_41
 
     """
     if (s is not None and t is None) or (s is None and t is not None):
@@ -366,11 +384,15 @@ def node_connectivity(G, s=None, t=None, flow_func=None):
     # compute local node connectivity with all its non-neighbors nodes
     for w in set(G) - v_nbrs - {v}:
         for s, t in ordered_pairs(v, w):
+            # The approximation is a strict lower bound, so a value that
+            # already reaches K means the exact computation cannot lower it.
+            if approx_local_node_connectivity(G, s, t, cutoff=K) >= K:
+                continue
             kwargs["cutoff"] = K
             K = min(K, local_node_connectivity(G, s, t, **kwargs))
     # Also for non adjacent pairs of neighbors of v
     for x, y in iter_func(v_nbrs, 2):
-        if y in G[x]:
+        if y in G[x] or approx_local_node_connectivity(G, x, y, cutoff=K) >= K:
             continue
         kwargs["cutoff"] = K
         K = min(K, local_node_connectivity(G, x, y, **kwargs))

--- a/networkx/algorithms/connectivity/cuts.py
+++ b/networkx/algorithms/connectivity/cuts.py
@@ -5,6 +5,9 @@ Flow based cut algorithms
 import itertools
 
 import networkx as nx
+from networkx.algorithms.approximation.connectivity import (
+    local_node_connectivity as approx_local_node_connectivity,
+)
 
 # Define the default maximum flow function to use in all flow based
 # cut algorithms.
@@ -396,6 +399,16 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
     A minimum node cut of a digraph separates an ordered pair of nodes,
     and the two orders need not agree, so both are considered [2]_.
 
+    Each pair is first passed to a much cheaper call to the shortest
+    path based approximation of local node connectivity (see
+    :meth:`networkx.algorithms.approximation.local_node_connectivity`),
+    following [3]_. The size of a minimum st node cut is the local node
+    connectivity of the pair, and the approximation is a strict lower
+    bound on it, so whenever it already reaches the size of the smallest
+    cut found so far that pair cannot yield a smaller one and is skipped.
+    The result is still a cut of minimum cardinality, but which of the
+    minimum cuts is returned may differ from the unfiltered search.
+
     See also
     --------
     :meth:`minimum_st_node_cut`
@@ -418,6 +431,12 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
         Connectivity. SIAM Journal on Computing, Volume 4, Issue 4,
         pp. 507-518, 1975.
         https://doi.org/10.1137/0204043
+
+    .. [3] Robert S. Sinkovits. Fast and Accurate Determination of Graph Node
+        Connectivity Leveraging Approximate Methods. Computational Science -
+        ICCS 2021, Lecture Notes in Computer Science, Volume 12742,
+        Springer, 2021.
+        https://doi.org/10.1007/978-3-030-77961-0_41
 
     """
     if (s is not None and t is None) or (s is None and t is not None):
@@ -481,6 +500,13 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
     # Compute st node cuts between v and all its non-neighbors nodes in G.
     for w in set(G) - v_nbrs - {v}:
         for s, t in ordered_pairs(v, w):
+            # The size of a minimum st node cut is the local node connectivity
+            # of the pair, and the approximation is a strict lower bound on it,
+            # so a value that reaches K means this pair cannot give a smaller
+            # cut.
+            K = len(min_cut)
+            if approx_local_node_connectivity(G, s, t, cutoff=K) >= K:
+                continue
             this_cut = minimum_st_node_cut(G, s, t, **kwargs)
             if len(min_cut) >= len(this_cut):
                 min_cut = this_cut
@@ -488,7 +514,8 @@ def minimum_node_cut(G, s=None, t=None, flow_func=None):
     for x, y in iter_func(v_nbrs, 2):
         # `minimum_st_node_cut` returns an empty set when x and y cannot be
         # separated, which must not be taken for a smaller cut.
-        if y in G[x]:
+        K = len(min_cut)
+        if y in G[x] or approx_local_node_connectivity(G, x, y, cutoff=K) >= K:
             continue
         this_cut = minimum_st_node_cut(G, x, y, **kwargs)
         if len(min_cut) >= len(this_cut):


### PR DESCRIPTION
Implement the approximation pre-filter for `node_connectivity` and `minimum_node_cut` proposed by Sinkovits in *Fast and Accurate Determination of Graph Node Connectivity Leveraging Approximate Methods*, ICCS 2021, <https://doi.org/10.1007/978-3-030-77961-0_41>. This brilliant idea speeds up both functions by 6x to over 100x on the graphs benchmarked below, and the gain grows with the size of the graph: it is largest when the node connectivity equals the minimum degree, where the filter skips every maximum flow computation.

The gist of the filter is that `node_connectivity` and `minimum_node_cut` solve one maximum flow problem for each of a smartly selected set of candidate pairs of nodes, but most of those pairs cannot improve the answer found so far. The shortest path approximation of local node connectivity (already implemented in NetworkX) can prove this much faster because it is a strict lower bound approximation, so whenever it alone reaches the running value of `K`, the exact computation for that pair can only confirm it and can be skipped; the result of the whole computation is still exact.

One caveat for `minimum_node_cut`: it returns *one* of possibly many minimum cuts, and the unfiltered search replaces the incumbent on ties, so skipping a pair whose approximation *equals* the current size can change which minimum cut comes back. The size never changes, and the docstring now says so.

The paper has a second proposal to speed things up, but it's not implemented here. That proposal is a search for a good starting node `v_s`: it samples `n_trial` minimum-degree nodes, scores each by how often the approximation falls below `δ` over `n_target` random non-neighbours, and starts from the best; the defaults are 10 and 100, and section 6 of the paper says the right values are probably graph-dependent. Its reported benefit is measured against *random* starting nodes, which is not what NetworkX does: `min(..., key=itemgetter(1))` returns the first minimum-degree node in insertion order, and on the graphs I measured that is already a good choice. Against that actual default an implementation of the search won about 3.5% on the one family where it helped and lost elsewhere, for roughly 45 lines and two fitted constants. So I decided not to implement it here.

No new test is needed: `node_connectivity` returns the same value as before, and the existing suite already covers both relevant cases, with `test_white_harary_1` (κ=1, δ=3) forcing the exact fallback and `test_petersen` and `test_octahedral` (κ=δ) exercising the skip.

## Question regarding imports

Both files import the approximation at module level:

```python
from networkx.algorithms.approximation.connectivity import (
    local_node_connectivity as approx_local_node_connectivity,
)
```

`networkx/algorithms/__init__.py` imports `approximation` before `connectivity` and nothing under `approximation/` imports `connectivity`, so there is no cycle, but these are as far as I can see the first modules outside `approximation/` to import from it. Happy to move it inside the functions if you would rather not add that dependency at import time.

## Benchmark

`benchmark_sinkovits_prefilter.py`, attached here, times `node_connectivity` on `main` against this PR. `minimum_node_cut` is not timed separately: it uses the same filter in the same loop and gains at least as much. The `main` timing comes from the *same code path* as the PR one, by replacing the approximation with a stub that never lets a pair be skipped, so the two timings differ only in the pre-filter and both start their search from the same node. The `flows` columns count the maximum flow calls actually made, and explain every row: where `K == δ` the filter skips all of them.

Two of the families are not random graphs. `two blobs` is two dense blobs joined by `k` nodes, so that `K = k` is well below `δ`, which is the case where the exact computation cannot be avoided and the one real graphs look like; random graphs nearly always have `K == δ`. The `directed` rows are digraphs, where the filter is applied once per direction.

Run with `PYTHONHASHSEED=0` on 16 cores, one process at a time. The whole table takes about a quarter of an hour to reproduce; `--quick` is a subset that runs in under a minute.

| graph                              | \|V\| | \|E\|  | delta | K  | flows main | flows PR | t main  | t PR  | speedup |
|------------------------------------|-------|--------|-------|----|------------|----------|---------|-------|---------|
| barabasi_albert(1000, m=4)         | 1,000 | 3,984  | 4     | 4  | 1,001      | 0        | 0.78s   | 0.06s | 14x     |
| barabasi_albert(1000, m=8)         | 1,000 | 7,936  | 8     | 8  | 1,018      | 0        | 1.71s   | 0.13s | 13x     |
| barabasi_albert(4000, m=4)         | 4,000 | 15,984 | 4     | 4  | 4,000      | 0        | 23.53s  | 0.39s | 61x     |
| barabasi_albert(4000, m=8)         | 4,000 | 31,936 | 8     | 8  | 4,017      | 0        | 62.65s  | 0.81s | 77x     |
| barabasi_albert(8000, m=4)         | 8,000 | 31,984 | 4     | 4  | 8,000      | 0        | 146.15s | 1.11s | 131x    |
| gnp(1000, 0.01)                    | 1,000 | 4,965  | 3     | 3  | 999        | 0        | 0.90s   | 0.11s | 8x      |
| gnp(1000, 0.03)                    | 1,000 | 15,004 | 13    | 13 | 1,062      | 0        | 5.68s   | 0.29s | 19x     |
| gnp(2000, 0.01)                    | 2,000 | 20,019 | 6     | 6  | 2,008      | 0        | 14.60s  | 0.35s | 42x     |
| gnp(2000, 0.03)                    | 2,000 | 59,761 | 35    | 35 | 2,538      | 0        | 130.04s | 2.98s | 44x     |
| watts_strogatz(1000, k=5)          | 1,000 | 2,000  | 2     | 2  | 997        | 0        | 0.78s   | 0.08s | 10x     |
| watts_strogatz(1000, k=9)          | 1,000 | 4,000  | 5     | 5  | 999        | 0        | 1.57s   | 0.18s | 9x      |
| watts_strogatz(4000, k=5)          | 4,000 | 8,000  | 2     | 2  | 3,997      | 0        | 8.12s   | 0.47s | 17x     |
| watts_strogatz(4000, k=9)          | 4,000 | 16,000 | 5     | 5  | 3,996      | 0        | 29.59s  | 1.41s | 21x     |
| watts_strogatz(8000, k=7)          | 8,000 | 24,000 | 3     | 3  | 7,996      | 2        | 105.97s | 2.51s | 42x     |
| two blobs(250, 0.1, k=3)           | 503   | 6,153  | 8     | 3  | 520        | 1        | 1.67s   | 0.16s | 10x     |
| two blobs(500, 0.05, k=3)          | 1,003 | 12,649 | 8     | 3  | 1,020      | 2        | 14.19s  | 1.41s | 10x     |
| two blobs(1000, 0.03, k=3)         | 2,003 | 30,031 | 8     | 3  | 2,021      | 2        | 83.57s  | 5.07s | 16x     |
| directed gnp(500, 0.03)            | 500   | 7,500  | 4     | 4  | 1,483      | 0        | 1.13s   | 0.07s | 16x     |
| directed gnp(2000, 0.006)          | 2,000 | 23,877 | 2     | 2  | 4,067      | 0        | 8.70s   | 0.22s | 40x     |
| directed gnp(2000, 0.01)           | 2,000 | 40,225 | 8     | 8  | 4,370      | 0        | 33.40s  | 0.95s | 35x     |
| directed two blobs(150, 0.15, k=3) | 303   | 6,761  | 8     | 3  | 644        | 2        | 1.49s   | 0.25s | 6x      |
| directed two blobs(250, 0.1, k=4)  | 504   | 12,536 | 10    | 4  | 1,069      | 2        | 5.83s   | 0.87s | 7x      |
| directed two blobs(400, 0.08, k=3) | 803   | 25,734 | 8     | 3  | 1,644      | 3        | 14.21s  | 2.25s | 6x      |

The filter is what makes it safe to use the approximation at all here, and `watts_strogatz(8000, k=7)` is the row that shows it: it is the only row with `K == δ` whose `flows PR` is not 0. The approximation alone returns 2 there where the answer is 3, so replacing the exact computation with it would silently give a wrong result; the filter catches that pair, spends 2 maximum flow calls out of 7996, and returns 3.

AI disclaimer: The benchmark script is generated by Claude and I reviewed and made sure that is measuring what it's expected. It does a quite ugly monkey patching but I convinced myself that it works as intended and it's much more compact than alternatives I could think of, so I kept what Claude did on the benchmark script with some edits. Also reproduced the results by running  `node_connectivity` both in this PR and main and got the same results.

[benchmark_sinkovits_prefilter.py](https://github.com/user-attachments/files/31334272/benchmark_sinkovits_prefilter.py)
 