### PR TITLE
BUG: Fix approximate node connectivity for digraphs

### DIFF
--- a/networkx/algorithms/approximation/connectivity.py
+++ b/networkx/algorithms/approximation/connectivity.py
@@ -160,6 +160,9 @@ def node_connectivity(G, s=None, t=None):
     to two different node independent paths. Thus it only guarantees an
     strict lower bound on node connectivity.
 
+    The local node connectivity of an ordered pair of nodes of a digraph
+    is not symmetric, so both orders of each pair are considered [2]_.
+
     See also
     --------
     all_pairs_node_connectivity
@@ -170,6 +173,11 @@ def node_connectivity(G, s=None, t=None):
     .. [1] White, Douglas R., and Mark Newman. 2001 A Fast Algorithm for
         Node-Independent Paths. Santa Fe Institute Working Paper #01-07-035
         http://eclectic.ss.uci.edu/~drwhite/working.pdf
+
+    .. [2] Shimon Even and R. Endre Tarjan. Network Flow and Testing Graph
+        Connectivity. SIAM Journal on Computing, Volume 4, Issue 4,
+        pp. 507-518, 1975.
+        https://doi.org/10.1137/0204043
 
     """
     if (s is not None and t is None) or (s is None and t is not None):
@@ -191,26 +199,51 @@ def node_connectivity(G, s=None, t=None):
         def neighbors(v):
             return itertools.chain(G.predecessors(v), G.successors(v))
 
+        # Isolating a node only requires removing all its predecessors or all
+        # its successors, so the bound is the smaller of the two.
+        def degree(v):
+            return min(len(G.pred[v].keys() - {v}), len(G.succ[v].keys() - {v}))
+
+        # In a digraph the local node connectivity of an ordered pair is not
+        # symmetric, and v has to lie on the source side of a minimum node cut
+        # for its value to be the right one, so both orders are needed. Page
+        # 513 of [2] states that for a digraph both N(v, w) and N(w, v) have to
+        # be computed.
+        def ordered_pairs(v, w):
+            return ((v, w), (w, v))
+
     else:
         connected_func = nx.is_connected
         iter_func = itertools.combinations
         neighbors = G.neighbors
 
+        def degree(v):
+            return len(G[v].keys() - {v})
+
+        def ordered_pairs(v, w):
+            return ((v, w),)
+
     if not connected_func(G):
         return 0
 
-    # Choose a node with minimum degree
-    v, minimum_degree = min(G.degree(), key=itemgetter(1))
-    # Node connectivity is bounded by minimum degree
-    K = minimum_degree
+    # Choose a node with minimum degree. Node connectivity is bounded by the
+    # number of distinct neighbors. `G.degree` cannot be used here because
+    # parallel edges do not add connectivity and self-loops are irrelevant
+    # for it.
+    v, K = min(((n, degree(n)) for n in G), key=itemgetter(1))
+    # Neighbors of v, excluding v itself if it has a self-loop. For digraphs
+    # this deduplicates the nodes that are both predecessors and successors.
+    v_nbrs = set(neighbors(v)) - {v}
     # compute local node connectivity with all non-neighbors nodes
     # and store the minimum
-    for w in set(G) - set(neighbors(v)) - {v}:
-        K = min(K, local_node_connectivity(G, v, w, cutoff=K))
+    for w in set(G) - v_nbrs - {v}:
+        for s, t in ordered_pairs(v, w):
+            K = min(K, local_node_connectivity(G, s, t, cutoff=K))
     # Same for non adjacent pairs of neighbors of v
-    for x, y in iter_func(neighbors(v), 2):
-        if y not in G[x] and x != y:
-            K = min(K, local_node_connectivity(G, x, y, cutoff=K))
+    for x, y in iter_func(v_nbrs, 2):
+        if y in G[x]:
+            continue
+        K = min(K, local_node_connectivity(G, x, y, cutoff=K))
     return K
 
 

--- a/networkx/algorithms/approximation/tests/test_connectivity.py
+++ b/networkx/algorithms/approximation/tests/test_connectivity.py
@@ -130,6 +130,61 @@ def test_directed_node_connectivity():
     assert 2 == approx.node_connectivity(D, 1, 4)
 
 
+def test_directed_node_connectivity_not_strongly_connected():
+    # A weakly connected digraph that is not strongly connected has node
+    # connectivity 0. Node connectivity for digraphs is bounded by the smaller
+    # of the in-degree and the out-degree. Node 3 has the unique minimum total
+    # degree, so it is always the starting node whatever the insertion order,
+    # and its in-degree is 0.
+    G = nx.DiGraph([(0, 1), (1, 2), (2, 0), (3, 0)])  # a triangle and a source
+    assert nx.is_weakly_connected(G)
+    assert not nx.is_strongly_connected(G)
+    assert 0 == approx.node_connectivity(G)
+
+
+def test_directed_node_connectivity_both_orders():
+    # Node connectivity of a digraph is a minimum over ordered pairs, and the
+    # two orders of a pair need not agree, so the starting node has to be
+    # tried as source and as target. Here node 1 cannot reach node 0, so the
+    # graph is not strongly connected and its node connectivity is 0, but only
+    # the pair (1, 0) shows it: the local node connectivity of (0, 1) is 1.
+    G = nx.DiGraph([(0, 3), (1, 2), (2, 1), (3, 0), (3, 1), (3, 2)])
+    assert nx.is_weakly_connected(G)
+    assert not nx.is_strongly_connected(G)
+    assert 1 == approx.local_node_connectivity(G, 0, 1)
+    assert 0 == approx.local_node_connectivity(G, 1, 0)
+    assert 0 == approx.node_connectivity(G)
+
+
+def test_node_connectivity_self_loops():
+    # Self-loops do not affect node connectivity. A complete graph is the only
+    # shape that exposes an inflated bound, because no pair of nodes is left to
+    # compute a local node connectivity that would lower it again.
+    G = nx.complete_graph(5)
+    G.add_edges_from((u, u) for u in G)
+    D = G.to_directed()
+    assert 4 == approx.node_connectivity(G)
+    assert 4 == approx.node_connectivity(D)
+
+
+def test_node_connectivity_multigraphs():
+    # Parallel edges do not add node connectivity, and as with self-loops only
+    # a complete graph exposes an inflated bound.
+    G = nx.complete_graph(5, nx.MultiGraph)
+    G.add_edges_from(list(G.edges()))  # duplicate every edge
+    D = G.to_directed()
+    assert 4 == approx.node_connectivity(G)
+    assert 4 == approx.node_connectivity(D)
+
+
+def test_node_connectivity_is_a_lower_bound():
+    # The approximation must never exceed the exact value, for digraphs too.
+    for seed in range(30):
+        for directed in (False, True):
+            G = nx.gnp_random_graph(12, 0.25, seed=seed, directed=directed)
+            assert approx.node_connectivity(G) <= nx.node_connectivity(G)
+
+
 class TestAllPairsNodeConnectivityApprox:
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
`approximation.node_connectivity` implements the same approach as the exact `node_connectivity`, algorithm 11 of Esfahanian's Connectivity Algorithms, which is stated for undirected graphs only. Its adaptation to digraphs was wrong in the same ways that #8837 has just fixed for the exact function, so it returns values that are too large. That contradicts the guarantee its own docstring makes, that it is a strict lower bound on node connectivity:

```python
>>> D = nx.DiGraph([(0, 2), (2, 1)])
>>> nx.node_connectivity(D)
0
>>> nx.approximation.node_connectivity(D)
1
```

The fix follows #8837 as closely as the two functions allow, so that they can be read side by side, and three of the five defects listed there have a counterpart here. Defect 1: the starting node was chosen by total degree, but node connectivity of a digraph is bounded by the smaller of the in-degree and the out-degree, since isolating a node only requires removing all its predecessors or all its successors. Defect 3: the pairs of neighbours were built by chaining predecessors and successors, so a node that is both was yielded twice. Defect 5, the one that breaks the lower bound: the starting node was always the source of the pair, never the target, so the local node connectivity was computed from it to each of its non-neighbours but never from each of them back to it. Node connectivity of a digraph is a minimum over ordered pairs and the two orders need not agree, so when the starting node lay on the target side of every minimum cut the smallest value was never computed. Defects 2 and 4 of #8837 are specific to node cuts and have no counterpart here.

Self-loops and parallel edges also inflated the initial bound, in undirected graphs too, and as in #8837 only a complete graph exposes it, because there no pair of nodes is left to compute a local node connectivity that would lower the bound again.

The weak connectivity test at the top of the function is left as it is. Now that both orders of each pair are computed, a digraph that is weakly but not strongly connected reaches 0 through the loop, exactly as the exact function does since #8837.

Four of the five tests added are the digraph, self-loop and multigraph tests of #8837 adapted to the approximate function, so the two test suites test the same examples. The fifth asserts the documented guarantee directly, that the approximation never exceeds the exact value, over random graphs and digraphs.