### PR TITLE
TST: Cleanup & modernize the minimum cuts test suite

### DIFF
--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -39,7 +39,8 @@ def test_articulation_points(flow_func):
     assert cut.pop() in set(nx.articulation_points(G))
 
 
-def test_brandes_erlebach_book():
+@pytest.mark.parametrize("flow_func", flow_funcs)
+def test_brandes_erlebach_book(flow_func):
     # Figure 1 chapter 7: Connectivity
     # http://www.informatik.uni-augsburg.de/thi/personen/kammer/Graph_Connectivity.pdf
     G = nx.Graph()
@@ -66,25 +67,22 @@ def test_brandes_erlebach_book():
             (10, 11),
         ]
     )
-    for flow_func in flow_funcs:
-        kwargs = {"flow_func": flow_func}
-        errmsg = f"Assertion failed in function: {flow_func.__name__}"
-        # edge cutsets
-        assert 3 == len(nx.minimum_edge_cut(G, 1, 11, **kwargs)), errmsg
-        edge_cut = nx.minimum_edge_cut(G, **kwargs)
-        # Node 5 has only two edges
-        assert 2 == len(edge_cut), errmsg
-        H = G.copy()
-        H.remove_edges_from(edge_cut)
-        assert not nx.is_connected(H), errmsg
-        # node cuts
-        assert {6, 7} == minimum_st_node_cut(G, 1, 11, **kwargs), errmsg
-        assert {6, 7} == nx.minimum_node_cut(G, 1, 11, **kwargs), errmsg
-        node_cut = nx.minimum_node_cut(G, **kwargs)
-        assert 2 == len(node_cut), errmsg
-        H = G.copy()
-        H.remove_nodes_from(node_cut)
-        assert not nx.is_connected(H), errmsg
+    # edge cutsets
+    assert 3 == len(nx.minimum_edge_cut(G, 1, 11, flow_func=flow_func))
+    edge_cut = nx.minimum_edge_cut(G, flow_func=flow_func)
+    # Node 5 has only two edges
+    assert 2 == len(edge_cut)
+    H = G.copy()
+    H.remove_edges_from(edge_cut)
+    assert not nx.is_connected(H)
+    # node cuts
+    assert {6, 7} == minimum_st_node_cut(G, 1, 11, flow_func=flow_func)
+    assert {6, 7} == nx.minimum_node_cut(G, 1, 11, flow_func=flow_func)
+    node_cut = nx.minimum_node_cut(G, flow_func=flow_func)
+    assert 2 == len(node_cut)
+    H = G.copy()
+    H.remove_nodes_from(node_cut)
+    assert not nx.is_connected(H)
 
 
 def test_white_harary_paper():

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -133,7 +133,8 @@ def test_node_cutset_exception(flow_func):
 
 @pytest.mark.parametrize("flow_func", flow_funcs)
 def test_node_cutset_random_graphs(flow_func):
-    G = nx.fast_gnp_random_graph(50, 0.25, seed=42)
+    G = nx.fast_gnp_random_graph(50, 0.25, seed=42)  # A connected graph
+    assert nx.is_connected(G)
 
     cutset = nx.minimum_node_cut(G, flow_func=flow_func)
     assert nx.node_connectivity(G) == len(cutset)
@@ -143,7 +144,8 @@ def test_node_cutset_random_graphs(flow_func):
 
 @pytest.mark.parametrize("flow_func", flow_funcs)
 def test_edge_cutset_random_graphs(flow_func):
-    G = nx.fast_gnp_random_graph(50, 0.25, seed=42)
+    G = nx.fast_gnp_random_graph(50, 0.25, seed=42)  # A connected graph
+    assert nx.is_connected(G)
 
     cutset = nx.minimum_edge_cut(G, flow_func=flow_func)
     assert nx.edge_connectivity(G) == len(cutset)

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -101,54 +101,24 @@ def test_white_harary_paper(flow_func):
 
 
 @pytest.mark.parametrize("flow_func", flow_funcs)
-def test_petersen_cutset(flow_func):
-    G = nx.petersen_graph()
-
+@pytest.mark.parametrize(
+    ("G", "expected"),
+    [
+        (nx.petersen_graph(), 3),
+        (nx.octahedral_graph(), 4),
+        (nx.icosahedral_graph(), 5),
+    ],
+)
+def test_node_edge_cutsets(flow_func, G, expected):
     # edge cuts
     edge_cut = nx.minimum_edge_cut(G, flow_func=flow_func)
-    assert 3 == len(edge_cut)
+    assert len(edge_cut) == expected
     H = G.copy()
     H.remove_edges_from(edge_cut)
     assert not nx.is_connected(H)
     # node cuts
     node_cut = nx.minimum_node_cut(G, flow_func=flow_func)
-    assert 3 == len(node_cut)
-    H = G.copy()
-    H.remove_nodes_from(node_cut)
-    assert not nx.is_connected(H)
-
-
-@pytest.mark.parametrize("flow_func", flow_funcs)
-def test_octahedral_cutset(flow_func):
-    G = nx.octahedral_graph()
-
-    # edge cuts
-    edge_cut = nx.minimum_edge_cut(G, flow_func=flow_func)
-    assert 4 == len(edge_cut)
-    H = G.copy()
-    H.remove_edges_from(edge_cut)
-    assert not nx.is_connected(H)
-    # node cuts
-    node_cut = nx.minimum_node_cut(G, flow_func=flow_func)
-    assert 4 == len(node_cut)
-    H = G.copy()
-    H.remove_nodes_from(node_cut)
-    assert not nx.is_connected(H)
-
-
-@pytest.mark.parametrize("flow_func", flow_funcs)
-def test_icosahedral_cutset(flow_func):
-    G = nx.icosahedral_graph()
-
-    # edge cuts
-    edge_cut = nx.minimum_edge_cut(G, flow_func=flow_func)
-    assert 5 == len(edge_cut)
-    H = G.copy()
-    H.remove_edges_from(edge_cut)
-    assert not nx.is_connected(H)
-    # node cuts
-    node_cut = nx.minimum_node_cut(G, flow_func=flow_func)
-    assert 5 == len(node_cut)
+    assert len(node_cut) == expected
     H = G.copy()
     H.remove_nodes_from(node_cut)
     assert not nx.is_connected(H)

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -3,7 +3,6 @@ import pytest
 import networkx as nx
 from networkx.algorithms import flow
 from networkx.algorithms.connectivity import minimum_st_edge_cut, minimum_st_node_cut
-from networkx.utils import arbitrary_element
 
 flow_funcs = [
     flow.boykov_kolmogorov,
@@ -16,24 +15,11 @@ flow_funcs = [
 # Tests for node and edge cutsets
 
 
-def _generate_no_biconnected(max_attempts=50):
-    attempts = 0
-    while True:
-        G = nx.fast_gnp_random_graph(100, 0.0575, seed=42)
-        if nx.is_connected(G) and not nx.is_biconnected(G):
-            attempts = 0
-            yield G
-        else:
-            if attempts >= max_attempts:
-                msg = f"Tried {attempts} times: no suitable Graph."
-                raise Exception(msg)
-            else:
-                attempts += 1
-
-
 @pytest.mark.parametrize("flow_func", flow_funcs)
 def test_articulation_points(flow_func):
-    G = next(_generate_no_biconnected())
+    # Graph instance which is connected but *not* biconnected
+    G = nx.fast_gnp_random_graph(100, 0.0575, seed=42)
+    assert nx.is_connected(G) and not nx.is_biconnected(G)
     cut = nx.minimum_node_cut(G, flow_func=flow_func)
     assert len(cut) == 1
     assert cut.pop() in set(nx.articulation_points(G))

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -12,7 +12,7 @@ flow_funcs = [
     flow.shortest_augmenting_path,
 ]
 
-# Tests for node and edge cutsets
+interface_funcs = [nx.minimum_node_cut, nx.minimum_edge_cut]
 
 
 @pytest.mark.parametrize("flow_func", flow_funcs)
@@ -152,7 +152,7 @@ def test_edge_cutset_random_graphs(flow_func):
 
 
 @pytest.mark.parametrize("flow_func", flow_funcs)
-@pytest.mark.parametrize("interface_func", [nx.minimum_node_cut, nx.minimum_edge_cut])
+@pytest.mark.parametrize("interface_func", interface_funcs)
 @pytest.mark.parametrize("graph", [nx.Graph, nx.DiGraph])
 def test_empty_graphs(flow_func, interface_func, graph):
     G = graph()
@@ -168,7 +168,7 @@ def test_unbounded(flow_func):
 
 
 @pytest.mark.parametrize("flow_func", flow_funcs)
-@pytest.mark.parametrize("interface_func", [nx.minimum_node_cut, nx.minimum_edge_cut])
+@pytest.mark.parametrize("interface_func", interface_funcs)
 def test_missing_source_target(flow_func, interface_func):
     G = nx.path_graph(4)
 
@@ -182,7 +182,7 @@ def test_missing_source_target(flow_func, interface_func):
 
 
 @pytest.mark.parametrize("flow_func", flow_funcs)
-@pytest.mark.parametrize("interface_func", [nx.minimum_node_cut, nx.minimum_edge_cut])
+@pytest.mark.parametrize("interface_func", interface_funcs)
 @pytest.mark.parametrize("graph", [nx.Graph, nx.DiGraph])
 def test_not_connected(flow_func, interface_func, graph):
     # Input must be connected (weakly connected if digraph)
@@ -193,7 +193,7 @@ def test_not_connected(flow_func, interface_func, graph):
 
 
 @pytest.mark.parametrize("flow_func", flow_funcs)
-@pytest.mark.parametrize("interface_func", [nx.minimum_node_cut, nx.minimum_edge_cut])
+@pytest.mark.parametrize("interface_func", interface_funcs)
 @pytest.mark.parametrize("graph", [nx.Graph, nx.DiGraph])
 def tests_min_cut_complete(flow_func, interface_func, graph):
     G = nx.complete_graph(5, create_using=graph)
@@ -214,7 +214,7 @@ def test_invalid_auxiliary():
         minimum_st_node_cut(G, 0, 3, auxiliary=G)
 
 
-@pytest.mark.parametrize("interface_func", [nx.minimum_node_cut, nx.minimum_edge_cut])
+@pytest.mark.parametrize("interface_func", interface_funcs)
 def test_interface_only_source(interface_func):
     G = nx.complete_graph(5)
 

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -217,7 +217,7 @@ def test_invalid_auxiliary():
 
 
 @pytest.mark.parametrize("interface_func", interface_funcs)
-def test_interface_only_source(interface_func):
+def test_interface_only_source_or_only_target_specified(interface_func):
     G = nx.complete_graph(5)
 
     with pytest.raises(nx.NetworkXError, match="source and target must be specified"):

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -114,144 +114,126 @@ def test_white_harary_paper(flow_func):
     assert not nx.is_connected(H)
 
 
-def test_petersen_cutset():
+@pytest.mark.parametrize("flow_func", flow_funcs)
+def test_petersen_cutset(flow_func):
     G = nx.petersen_graph()
-    for flow_func in flow_funcs:
-        kwargs = {"flow_func": flow_func}
-        errmsg = f"Assertion failed in function: {flow_func.__name__}"
-        # edge cuts
-        edge_cut = nx.minimum_edge_cut(G, **kwargs)
-        assert 3 == len(edge_cut), errmsg
-        H = G.copy()
-        H.remove_edges_from(edge_cut)
-        assert not nx.is_connected(H), errmsg
-        # node cuts
-        node_cut = nx.minimum_node_cut(G, **kwargs)
-        assert 3 == len(node_cut), errmsg
-        H = G.copy()
-        H.remove_nodes_from(node_cut)
-        assert not nx.is_connected(H), errmsg
+
+    # edge cuts
+    edge_cut = nx.minimum_edge_cut(G, flow_func=flow_func)
+    assert 3 == len(edge_cut)
+    H = G.copy()
+    H.remove_edges_from(edge_cut)
+    assert not nx.is_connected(H)
+    # node cuts
+    node_cut = nx.minimum_node_cut(G, flow_func=flow_func)
+    assert 3 == len(node_cut)
+    H = G.copy()
+    H.remove_nodes_from(node_cut)
+    assert not nx.is_connected(H)
 
 
-def test_octahedral_cutset():
+@pytest.mark.parametrize("flow_func", flow_funcs)
+def test_octahedral_cutset(flow_func):
     G = nx.octahedral_graph()
-    for flow_func in flow_funcs:
-        kwargs = {"flow_func": flow_func}
-        errmsg = f"Assertion failed in function: {flow_func.__name__}"
-        # edge cuts
-        edge_cut = nx.minimum_edge_cut(G, **kwargs)
-        assert 4 == len(edge_cut), errmsg
-        H = G.copy()
-        H.remove_edges_from(edge_cut)
-        assert not nx.is_connected(H), errmsg
-        # node cuts
-        node_cut = nx.minimum_node_cut(G, **kwargs)
-        assert 4 == len(node_cut), errmsg
-        H = G.copy()
-        H.remove_nodes_from(node_cut)
-        assert not nx.is_connected(H), errmsg
+
+    # edge cuts
+    edge_cut = nx.minimum_edge_cut(G, flow_func=flow_func)
+    assert 4 == len(edge_cut)
+    H = G.copy()
+    H.remove_edges_from(edge_cut)
+    assert not nx.is_connected(H)
+    # node cuts
+    node_cut = nx.minimum_node_cut(G, flow_func=flow_func)
+    assert 4 == len(node_cut)
+    H = G.copy()
+    H.remove_nodes_from(node_cut)
+    assert not nx.is_connected(H)
 
 
-def test_icosahedral_cutset():
+@pytest.mark.parametrize("flow_func", flow_funcs)
+def test_icosahedral_cutset(flow_func):
     G = nx.icosahedral_graph()
-    for flow_func in flow_funcs:
-        kwargs = {"flow_func": flow_func}
-        errmsg = f"Assertion failed in function: {flow_func.__name__}"
-        # edge cuts
-        edge_cut = nx.minimum_edge_cut(G, **kwargs)
-        assert 5 == len(edge_cut), errmsg
-        H = G.copy()
-        H.remove_edges_from(edge_cut)
-        assert not nx.is_connected(H), errmsg
-        # node cuts
-        node_cut = nx.minimum_node_cut(G, **kwargs)
-        assert 5 == len(node_cut), errmsg
-        H = G.copy()
-        H.remove_nodes_from(node_cut)
-        assert not nx.is_connected(H), errmsg
+
+    # edge cuts
+    edge_cut = nx.minimum_edge_cut(G, flow_func=flow_func)
+    assert 5 == len(edge_cut)
+    H = G.copy()
+    H.remove_edges_from(edge_cut)
+    assert not nx.is_connected(H)
+    # node cuts
+    node_cut = nx.minimum_node_cut(G, flow_func=flow_func)
+    assert 5 == len(node_cut)
+    H = G.copy()
+    H.remove_nodes_from(node_cut)
+    assert not nx.is_connected(H)
 
 
-def test_node_cutset_exception():
-    G = nx.Graph()
-    G.add_edges_from([(1, 2), (3, 4)])
-    for flow_func in flow_funcs:
-        pytest.raises(nx.NetworkXError, nx.minimum_node_cut, G, flow_func=flow_func)
+@pytest.mark.parametrize("flow_func", flow_funcs)
+def test_node_cutset_exception(flow_func):
+    G = nx.Graph([(1, 2), (3, 4)])
+    with pytest.raises(nx.NetworkXError, match="is not connected"):
+        nx.minimum_node_cut(G, flow_func=flow_func)
 
 
-def test_node_cutset_random_graphs():
-    for flow_func in flow_funcs:
-        errmsg = f"Assertion failed in function: {flow_func.__name__}"
-        for i in range(3):
-            G = nx.fast_gnp_random_graph(50, 0.25, seed=42)
-            if not nx.is_connected(G):
-                ccs = iter(nx.connected_components(G))
-                start = arbitrary_element(next(ccs))
-                G.add_edges_from((start, arbitrary_element(c)) for c in ccs)
-            cutset = nx.minimum_node_cut(G, flow_func=flow_func)
-            assert nx.node_connectivity(G) == len(cutset), errmsg
-            G.remove_nodes_from(cutset)
-            assert not nx.is_connected(G), errmsg
+@pytest.mark.parametrize("flow_func", flow_funcs)
+def test_node_cutset_random_graphs(flow_func):
+    G = nx.fast_gnp_random_graph(50, 0.25, seed=42)
+
+    cutset = nx.minimum_node_cut(G, flow_func=flow_func)
+    assert nx.node_connectivity(G) == len(cutset)
+    G.remove_nodes_from(cutset)
+    assert not nx.is_connected(G)
 
 
-def test_edge_cutset_random_graphs():
-    for flow_func in flow_funcs:
-        errmsg = f"Assertion failed in function: {flow_func.__name__}"
-        for i in range(3):
-            G = nx.fast_gnp_random_graph(50, 0.25, seed=42)
-            if not nx.is_connected(G):
-                ccs = iter(nx.connected_components(G))
-                start = arbitrary_element(next(ccs))
-                G.add_edges_from((start, arbitrary_element(c)) for c in ccs)
-            cutset = nx.minimum_edge_cut(G, flow_func=flow_func)
-            assert nx.edge_connectivity(G) == len(cutset), errmsg
-            G.remove_edges_from(cutset)
-            assert not nx.is_connected(G), errmsg
+@pytest.mark.parametrize("flow_func", flow_funcs)
+def test_edge_cutset_random_graphs(flow_func):
+    G = nx.fast_gnp_random_graph(50, 0.25, seed=42)
+
+    cutset = nx.minimum_edge_cut(G, flow_func=flow_func)
+    assert nx.edge_connectivity(G) == len(cutset)
+    G.remove_edges_from(cutset)
+    assert not nx.is_connected(G)
 
 
-def test_empty_graphs():
-    G = nx.Graph()
-    D = nx.DiGraph()
-    for interface_func in [nx.minimum_node_cut, nx.minimum_edge_cut]:
-        for flow_func in flow_funcs:
-            pytest.raises(
-                nx.NetworkXPointlessConcept, interface_func, G, flow_func=flow_func
-            )
-            pytest.raises(
-                nx.NetworkXPointlessConcept, interface_func, D, flow_func=flow_func
-            )
+@pytest.mark.parametrize("flow_func", flow_funcs)
+@pytest.mark.parametrize("interface_func", [nx.minimum_node_cut, nx.minimum_edge_cut])
+@pytest.mark.parametrize("graph", [nx.Graph, nx.DiGraph])
+def test_empty_graphs(flow_func, interface_func, graph):
+    G = graph()
+
+    with pytest.raises(nx.NetworkXPointlessConcept):
+        interface_func(G, flow_func=flow_func)
 
 
-def test_unbounded():
+@pytest.mark.parametrize("flow_func", flow_funcs)
+def test_unbounded(flow_func):
     G = nx.complete_graph(5)
-    for flow_func in flow_funcs:
-        assert 4 == len(minimum_st_edge_cut(G, 1, 4, flow_func=flow_func))
+    assert 4 == len(minimum_st_edge_cut(G, 1, 4, flow_func=flow_func))
 
 
-def test_missing_source():
+@pytest.mark.parametrize("flow_func", flow_funcs)
+@pytest.mark.parametrize("interface_func", [nx.minimum_node_cut, nx.minimum_edge_cut])
+def test_missing_source_target(flow_func, interface_func):
     G = nx.path_graph(4)
-    for interface_func in [nx.minimum_edge_cut, nx.minimum_node_cut]:
-        for flow_func in flow_funcs:
-            pytest.raises(
-                nx.NetworkXError, interface_func, G, 10, 1, flow_func=flow_func
-            )
+
+    # Source node not in graph
+    with pytest.raises(nx.NetworkXError, match="node 10 not in graph"):
+        interface_func(G, 10, 1, flow_func=flow_func)
+
+    # Target node not in graph
+    with pytest.raises(nx.NetworkXError, match="node 10 not in graph"):
+        interface_func(G, 1, 10, flow_func=flow_func)
 
 
-def test_missing_target():
-    G = nx.path_graph(4)
-    for interface_func in [nx.minimum_edge_cut, nx.minimum_node_cut]:
-        for flow_func in flow_funcs:
-            pytest.raises(
-                nx.NetworkXError, interface_func, G, 1, 10, flow_func=flow_func
-            )
-
-
-def test_not_weakly_connected():
+@pytest.mark.parametrize("flow_func", flow_funcs)
+@pytest.mark.parametrize("interface_func", [nx.minimum_node_cut, nx.minimum_edge_cut])
+def test_not_weakly_connected(flow_func, interface_func):
     G = nx.DiGraph()
     nx.add_path(G, [1, 2, 3])
     nx.add_path(G, [4, 5])
-    for interface_func in [nx.minimum_edge_cut, nx.minimum_node_cut]:
-        for flow_func in flow_funcs:
-            pytest.raises(nx.NetworkXError, interface_func, G, flow_func=flow_func)
+
+    with pytest.raises(nx.NetworkXError, match="graph is not connected"):
+        interface_func(G, flow_func=flow_func)
 
 
 def test_not_connected():

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -309,44 +309,42 @@ def test_interface_only_target():
         pytest.raises(nx.NetworkXError, interface_func, G, t=3)
 
 
-def test_directed_minimum_st_node_cut_reverse_edge():
+@pytest.mark.parametrize("flow_func", flow_funcs)
+def test_directed_minimum_st_node_cut_reverse_edge(flow_func):
     # In a digraph an edge from t to s is not an s-t path, so s can still be
     # separated from t. Only a direct edge from s to t makes the pair
     # inseparable, and then the empty set is returned.
     G = nx.DiGraph([(0, 1), (1, 2), (2, 0)])  # the directed triangle
-    for flow_func in flow_funcs:
-        errmsg = f"Assertion failed in function: {flow_func.__name__}"
-        assert minimum_st_node_cut(G, 0, 2, flow_func=flow_func) == {1}, errmsg
-        assert minimum_st_node_cut(G, 0, 1, flow_func=flow_func) == set(), errmsg
+    assert minimum_st_node_cut(G, 0, 2, flow_func=flow_func) == {1}
+    assert minimum_st_node_cut(G, 0, 1, flow_func=flow_func) == set()
 
 
-def test_directed_minimum_node_cut():
+@pytest.mark.parametrize("flow_func", flow_funcs)
+def test_directed_minimum_node_cut(flow_func):
     # The node connectivity of the directed triangle is 1, so its minimum node
     # cut holds a single node. The initial cutset has to isolate the starting
     # node through its predecessors or its successors, whichever is smaller,
     # and not through its successors alone.
     G = nx.DiGraph([(0, 1), (1, 2), (2, 0)])
-    for flow_func in flow_funcs:
-        errmsg = f"Assertion failed in function: {flow_func.__name__}"
-        cut = nx.minimum_node_cut(G, flow_func=flow_func)
-        assert len(cut) == nx.node_connectivity(G) == 1, errmsg
-        H = G.copy()
-        H.remove_nodes_from(cut)
-        assert not nx.is_strongly_connected(H), errmsg
+    cut = nx.minimum_node_cut(G, flow_func=flow_func)
+    assert len(cut) == nx.node_connectivity(G) == 1
+    H = G.copy()
+    H.remove_nodes_from(cut)
+    assert not nx.is_strongly_connected(H)
 
 
-def test_directed_minimum_node_cut_not_strongly_connected():
+@pytest.mark.parametrize("flow_func", flow_funcs)
+def test_directed_minimum_node_cut_not_strongly_connected(flow_func):
     # A weakly connected digraph that is not strongly connected is already
     # disconnected, so no node has to be removed and the cut is empty.
     G = nx.DiGraph([(0, 1), (1, 2), (2, 0), (3, 0)])  # a triangle and a source
     assert nx.is_weakly_connected(G)
     assert not nx.is_strongly_connected(G)
-    for flow_func in flow_funcs:
-        errmsg = f"Assertion failed in function: {flow_func.__name__}"
-        assert nx.minimum_node_cut(G, flow_func=flow_func) == set(), errmsg
+    assert nx.minimum_node_cut(G, flow_func=flow_func) == set()
 
 
-def test_directed_minimum_node_cut_both_orders():
+@pytest.mark.parametrize("flow_func", flow_funcs)
+def test_directed_minimum_node_cut_both_orders(flow_func):
     # A minimum node cut of a digraph separates an ordered pair, and the two
     # orders need not agree, so the starting node has to be tried as source
     # and as target. Removing node 4 leaves this digraph not strongly
@@ -372,23 +370,20 @@ def test_directed_minimum_node_cut_both_orders():
         ]
     )
     assert nx.is_strongly_connected(G)
-    for flow_func in flow_funcs:
-        errmsg = f"Assertion failed in function: {flow_func.__name__}"
-        cut = nx.minimum_node_cut(G, flow_func=flow_func)
-        assert len(cut) == 1, errmsg
-        H = G.copy()
-        H.remove_nodes_from(cut)
-        assert not nx.is_strongly_connected(H), errmsg
+    cut = nx.minimum_node_cut(G, flow_func=flow_func)
+    assert len(cut) == 1
+    H = G.copy()
+    H.remove_nodes_from(cut)
+    assert not nx.is_strongly_connected(H)
 
 
-def test_minimum_node_cut_self_loops():
+@pytest.mark.parametrize("flow_func", flow_funcs)
+def test_minimum_node_cut_self_loops(flow_func):
     # Self-loops do not affect node connectivity, so they must not enlarge the
     # minimum node cut either. The initial cutset is built from the neighbors
     # of the starting node, and a self-loop puts that node in its own cutset.
     G = nx.complete_graph(5)
     G.add_edges_from((u, u) for u in G)
     D = G.to_directed()
-    for flow_func in flow_funcs:
-        errmsg = f"Assertion failed in function: {flow_func.__name__}"
-        assert len(nx.minimum_node_cut(G, flow_func=flow_func)) == 4, errmsg
-        assert len(nx.minimum_node_cut(D, flow_func=flow_func)) == 4, errmsg
+    assert len(nx.minimum_node_cut(G, flow_func=flow_func)) == 4
+    assert len(nx.minimum_node_cut(D, flow_func=flow_func)) == 4

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -227,37 +227,21 @@ def test_missing_source_target(flow_func, interface_func):
 
 @pytest.mark.parametrize("flow_func", flow_funcs)
 @pytest.mark.parametrize("interface_func", [nx.minimum_node_cut, nx.minimum_edge_cut])
-def test_not_weakly_connected(flow_func, interface_func):
-    G = nx.DiGraph()
-    nx.add_path(G, [1, 2, 3])
-    nx.add_path(G, [4, 5])
+@pytest.mark.parametrize("graph", [nx.Graph, nx.DiGraph])
+def test_not_connected(flow_func, interface_func, graph):
+    # Input must be connected (weakly connected if digraph)
+    G = graph([(1, 2), (2, 3), (4, 5)])
 
     with pytest.raises(nx.NetworkXError, match="graph is not connected"):
         interface_func(G, flow_func=flow_func)
 
 
-def test_not_connected():
-    G = nx.Graph()
-    nx.add_path(G, [1, 2, 3])
-    nx.add_path(G, [4, 5])
-    for interface_func in [nx.minimum_edge_cut, nx.minimum_node_cut]:
-        for flow_func in flow_funcs:
-            pytest.raises(nx.NetworkXError, interface_func, G, flow_func=flow_func)
-
-
-def tests_min_cut_complete():
-    G = nx.complete_graph(5)
-    for interface_func in [nx.minimum_edge_cut, nx.minimum_node_cut]:
-        for flow_func in flow_funcs:
-            assert 4 == len(interface_func(G, flow_func=flow_func))
-
-
-def tests_min_cut_complete_directed():
-    G = nx.complete_graph(5)
-    G = G.to_directed()
-    for interface_func in [nx.minimum_edge_cut, nx.minimum_node_cut]:
-        for flow_func in flow_funcs:
-            assert 4 == len(interface_func(G, flow_func=flow_func))
+@pytest.mark.parametrize("flow_func", flow_funcs)
+@pytest.mark.parametrize("interface_func", [nx.minimum_node_cut, nx.minimum_edge_cut])
+@pytest.mark.parametrize("graph", [nx.Graph, nx.DiGraph])
+def tests_min_cut_complete(flow_func, interface_func, graph):
+    G = nx.complete_graph(5, create_using=graph)
+    assert 4 == len(interface_func(G, flow_func=flow_func))
 
 
 def tests_minimum_st_node_cut():
@@ -270,19 +254,19 @@ def tests_minimum_st_node_cut():
 
 def test_invalid_auxiliary():
     G = nx.complete_graph(5)
-    pytest.raises(nx.NetworkXError, minimum_st_node_cut, G, 0, 3, auxiliary=G)
+    with pytest.raises(nx.NetworkXError, match="Invalid auxiliary digraph"):
+        minimum_st_node_cut(G, 0, 3, auxiliary=G)
 
 
-def test_interface_only_source():
+@pytest.mark.parametrize("interface_func", [nx.minimum_node_cut, nx.minimum_edge_cut])
+def test_interface_only_source(interface_func):
     G = nx.complete_graph(5)
-    for interface_func in [nx.minimum_node_cut, nx.minimum_edge_cut]:
-        pytest.raises(nx.NetworkXError, interface_func, G, s=0)
 
+    with pytest.raises(nx.NetworkXError, match="source and target must be specified"):
+        interface_func(G, s=0)
 
-def test_interface_only_target():
-    G = nx.complete_graph(5)
-    for interface_func in [nx.minimum_node_cut, nx.minimum_edge_cut]:
-        pytest.raises(nx.NetworkXError, interface_func, G, t=3)
+    with pytest.raises(nx.NetworkXError, match="source and target must be specified"):
+        interface_func(G, t=3)
 
 
 @pytest.mark.parametrize("flow_func", flow_funcs)

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -31,15 +31,12 @@ def _generate_no_biconnected(max_attempts=50):
                 attempts += 1
 
 
-def test_articulation_points():
-    Ggen = _generate_no_biconnected()
-    for flow_func in flow_funcs:
-        errmsg = f"Assertion failed in function: {flow_func.__name__}"
-        for i in range(1):  # change 1 to 3 or more for more realizations.
-            G = next(Ggen)
-            cut = nx.minimum_node_cut(G, flow_func=flow_func)
-            assert len(cut) == 1, errmsg
-            assert cut.pop() in set(nx.articulation_points(G)), errmsg
+@pytest.mark.parametrize("flow_func", flow_funcs)
+def test_articulation_points(flow_func):
+    G = next(_generate_no_biconnected())
+    cut = nx.minimum_node_cut(G, flow_func=flow_func)
+    assert len(cut) == 1
+    assert cut.pop() in set(nx.articulation_points(G))
 
 
 def test_brandes_erlebach_book():

--- a/networkx/algorithms/connectivity/tests/test_cuts.py
+++ b/networkx/algorithms/connectivity/tests/test_cuts.py
@@ -85,7 +85,8 @@ def test_brandes_erlebach_book(flow_func):
     assert not nx.is_connected(H)
 
 
-def test_white_harary_paper():
+@pytest.mark.parametrize("flow_func", flow_funcs)
+def test_white_harary_paper(flow_func):
     # Figure 1b white and harary (2001)
     # https://doi.org/10.1111/0081-1750.00098
     # A graph with high adhesion (edge connectivity) and low cohesion
@@ -98,21 +99,19 @@ def test_white_harary_paper():
     G.remove_node(G.order() - 1)
     for i in range(7, 10):
         G.add_edge(0, i)
-    for flow_func in flow_funcs:
-        kwargs = {"flow_func": flow_func}
-        errmsg = f"Assertion failed in function: {flow_func.__name__}"
-        # edge cuts
-        edge_cut = nx.minimum_edge_cut(G, **kwargs)
-        assert 3 == len(edge_cut), errmsg
-        H = G.copy()
-        H.remove_edges_from(edge_cut)
-        assert not nx.is_connected(H), errmsg
-        # node cuts
-        node_cut = nx.minimum_node_cut(G, **kwargs)
-        assert {0} == node_cut, errmsg
-        H = G.copy()
-        H.remove_nodes_from(node_cut)
-        assert not nx.is_connected(H), errmsg
+
+    # edge cuts
+    edge_cut = nx.minimum_edge_cut(G, flow_func=flow_func)
+    assert 3 == len(edge_cut)
+    H = G.copy()
+    H.remove_edges_from(edge_cut)
+    assert not nx.is_connected(H)
+    # node cuts
+    node_cut = nx.minimum_node_cut(G, flow_func=flow_func)
+    assert {0} == node_cut
+    H = G.copy()
+    H.remove_nodes_from(node_cut)
+    assert not nx.is_connected(H)
 
 
 def test_petersen_cutset():


### PR DESCRIPTION
Inspired while reviewing #8837 

There are two primary improvements:
 1. Replacing the existing pattern of looping over flow funcs with a custom assertion errmsg indicating the current flow-func with straight-up pytest parametrization. It accomplishes the same thing: if a test fails, the failure message indicates the value of the test parameter. See e.g. 6c52365 for examples of this style of change
 2. Remove some unused (e.g. `for i in range(1)`) or superfluous (i.e. looping over the same seeded example graph multiple times) internal loops in the tests. This also significantly reduces the test runtime, as some of the seeded example graph tests were among the more expensive.

There are some other minor improvements, like removing a graph generator that keeps producing the same random graph over and over (see 42f4021) and parametrizing over interface function as well as flow_func.

Ultimately the tests themselves are unchanged (except for the few tests were running the same example multiple times). Though the total number of tests has gone from 21 -> 149 from replacing internal loops with parametrization, the cases themselves remain!