### PR TITLE
ENH: Speed up `all_node_cuts` with an approximate pre-filter

### DIFF
--- a/networkx/algorithms/connectivity/kcutsets.py
+++ b/networkx/algorithms/connectivity/kcutsets.py
@@ -6,6 +6,9 @@ from collections import defaultdict
 from operator import itemgetter
 
 import networkx as nx
+from networkx.algorithms.approximation.connectivity import (
+    local_node_connectivity as approx_local_node_connectivity,
+)
 from networkx.algorithms.flow import (
     build_residual_network,
     edmonds_karp,
@@ -74,6 +77,16 @@ def all_node_cuts(G, k=None, flow_func=None):
     node and the target node of the local maximum flow computation to make
     sure that we will not find that minimum cut again.
 
+    Before each of those maximum flow computations a much cheaper call is
+    made to the shortest path based approximation of local node
+    connectivity (see
+    :meth:`networkx.algorithms.approximation.local_node_connectivity`),
+    following [2]_. Only a pair of nodes whose local node connectivity is
+    exactly $k$ can yield a cut of cardinality $k$, and the approximation
+    is a strict lower bound on that connectivity, so a pair for which it
+    already exceeds $k$ is skipped. This does not change the cuts that are
+    returned, nor the order in which they are generated.
+
     See also
     --------
     node_connectivity
@@ -85,6 +98,12 @@ def all_node_cuts(G, k=None, flow_func=None):
     .. [1]  Kanevsky, A. (1993). Finding all minimum-size separating vertex
             sets in a graph. Networks 23(6), 533--541.
             http://onlinelibrary.wiley.com/doi/10.1002/net.3230230604/abstract
+
+    .. [2]  Robert S. Sinkovits. Fast and Accurate Determination of Graph Node
+            Connectivity Leveraging Approximate Methods. Computational Science
+            - ICCS 2021, Lecture Notes in Computer Science, Volume 12742,
+            Springer, 2021.
+            https://doi.org/10.1007/978-3-030-77961-0_41
 
     """
     if not nx.is_connected(G):
@@ -137,6 +156,16 @@ def all_node_cuts(G, k=None, flow_func=None):
         # non adjacent nodes in G
         non_adjacent = set(G) - {x} - set(G[x])
         for v in non_adjacent:
+            # Only a pair whose local node connectivity is exactly k can
+            # contribute a cut of cardinality k. The shortest path based
+            # approximation is a strict lower bound on that connectivity,
+            # so a value above k proves this pair cannot, and the maximum
+            # flow below is a waste. Skipping the pair is not merely safe
+            # but invisible: everything the loop does past this point,
+            # including the bookkeeping edge added to H and R, happens
+            # only when the flow value equals k.
+            if approx_local_node_connectivity(G, x, v, cutoff=k + 1) > k:
+                continue
             # step 4: compute maximum flow in an Even-Tarjan reduction H of G
             # and step 5: build the associated residual network R
             # After adding edges in previous iterations, there may be

--- a/networkx/algorithms/connectivity/tests/test_kcutsets.py
+++ b/networkx/algorithms/connectivity/tests/test_kcutsets.py
@@ -267,6 +267,51 @@ def test_all_node_cuts_simple_case():
         assert cut in expected
 
 
+def _two_blobs(blob_size, separator_size):
+    """Two cliques joined only through a separator of non adjacent nodes.
+
+    The connectivity is `separator_size` and the separator is the only
+    minimum cut, while every pair of nodes inside a blob is far more
+    connected than that. That is the shape that makes the pre-filter fire.
+    """
+    G = nx.Graph()
+    for prefix in "ab":
+        blob = [f"{prefix}{i}" for i in range(blob_size)]
+        G.add_edges_from(itertools.combinations(blob, 2))
+    for i in range(separator_size):
+        for prefix in "ab":
+            G.add_edges_from((f"s{i}", f"{prefix}{j}") for j in range(blob_size))
+    return G
+
+
+@pytest.mark.parametrize(
+    "G",
+    [
+        nx.karate_club_graph(),
+        nx.florentine_families_graph(),
+        _two_blobs(4, 2),
+        _two_blobs(5, 3),
+    ],
+)
+def test_all_node_cuts_is_complete_under_the_prefilter(G):
+    """The approximate pre-filter must not drop a minimum cut.
+
+    A pair of nodes whose approximate local node connectivity exceeds `k`
+    cannot yield a cut of cardinality `k`, so `all_node_cuts` skips its
+    maximum flow computation. These are graphs where that skip does fire,
+    unlike the regular graphs elsewhere in this file, and the enumeration is
+    checked against brute force over every `k`-subset of nodes.
+    """
+    k = nx.node_connectivity(G)
+    expected = {
+        frozenset(candidate)
+        for candidate in itertools.combinations(G, k)
+        if not nx.is_connected(nx.restricted_view(G, candidate, []))
+    }
+    assert expected, "the fixture has no minimum cut to find"
+    assert {frozenset(cut) for cut in nx.all_node_cuts(G)} == expected
+
+
 def test_all_node_cuts_sap():
     """Non-slow test for `all_node_cuts` using the shortest augmenting path flow."""
     G = nx.cycle_graph(5)


### PR DESCRIPTION
Apply the approximation pre-filter of Sinkovits also implemented in gh-8862 one level down, inside `all_node_cuts`. This is independent of that PR; this one touches only `kcutsets.py` and can go in on its own, but they compose: gh-8862 speeds up the `node_connectivity` call `all_node_cuts` makes to find `k`, and this speeds up Kanevsky's own maximum flow computations, which are the rest of the run.

Kanevsky's algorithm solves one maximum flow problem for each pair formed by a node of highest degree and one of its non-neighbours. But only a pair whose local node connectivity is exactly `k` can contribute a cut of cardinality `k`, and the shortest path approximation of local node connectivity proves that much faster because it is a strict lower bound: whenever it already exceeds `k`, that pair cannot yield a minimum cut and its flow computation can be skipped.

Note that the caveat in gh-8862 (that `minimum_node_cut` may return a different one of several minimum cuts) does not apply here. Here **the generated sequence of cuts is identical, in the same order**, for two reasons.

Everything the pair loop does past the flow computation is inside `if flow_value == k`: the antichain enumeration, the cuts it yields, and the bookkeeping edge added to the auxiliary digraph `H` and its residual network `R` so that the same cutset is not found twice. A skipped pair therefore contributes nothing to the output, and nothing to the state that later pairs see.

The approximation runs on `G`, but the value it is short-circuiting does not: `flow_value` is the local node connectivity of the pair in the graph `H` currently represents, which is `G` plus the bookkeeping edges added so far. The two are related in the direction the filter needs: `approx(G, x, v) <= K_G(x, v) <= K_{G+added}(x, v) = flow_value`, the first step because the approximation is a strict lower bound and the second because adding edges can never lower local node connectivity. So `approx > k` implies `flow_value > k`, which is precisely the case the loop does nothing with, and the filter needs no tracking of the added edges.

I added tests because the graphs already in `test_kcutsets.py` are regular or node transitive, where every non-adjacent pair sits at exactly `k` and the filter can never fire. The new test adds four fixtures where it does fire, between 1 and 316 pairs, and checks the enumeration against brute force over every `k`-subset of nodes, which is the property a pre-filter could actually break.

Separately, and not part of the PR, I compared the full generated sequence with the filter live and stubbed out over 44 graphs: named graphs, random gnp / BA / WS, and fixtures with known minimum cutsets, with the same brute force check on every graph of 22 nodes or fewer. No differences.

## Benchmark

`benchmark_all_node_cuts_prefilter.py`, attached, and built like the one in gh-8862: the `main` timing comes from the *same code path*, by replacing the approximation with a stub that never lets a pair be skipped, so the two arms differ only in the pre-filter. It asserts that both arms produce the identical sequence of cuts. The `flows` columns count the maximum flow computations actually made.

Both arms call `all_node_cuts(G)` with `k` unset, the way a user would, so both pay for the initial `node_connectivity` call and both count its flows. That call is untouched here, which is why `flows PR` bottoms out near `|V|` rather than at zero, and it makes these speedups conservative.

`affiliation` is the one-mode projection of a random two-mode network: every group becomes a clique among its members, so the projection is clique-rich and its connectivity is high. That is the shape of a co-authorship, co-commit or developer/package network, and the case where `all_node_cuts` is slowest, because the number of candidate pairs grows with `k`. `two blobs` is the family from gh-8862. `hypercube(7)` is node transitive, so the filter can never fire there; it is therefore what the filter costs when it cannot help.

Run with `PYTHONHASHSEED=0` on 16 cores, one process at a time. `--quick` is a subset that runs in seconds.

| graph                     | \|V\| | \|E\| | K | cuts | flows main | flows PR | t main | t PR   | speedup |
|---------------------------|-------|-------|---|------|------------|----------|--------|--------|---------|
| affiliation(60, 40, 6)    | 60    | 509   | 5 | 4    | 205        | 70       | 0.33s  | 0.06s  | 6x      |
| affiliation(80, 60, 7)    | 79    | 1,024 | 6 | 1    | 277        | 77       | 0.94s  | 0.05s  | 19x     |
| affiliation(120, 90, 8)   | 118   | 2,144 | 7 | 1    | 516        | 116      | 2.76s  | 0.12s  | 24x     |
| affiliation(150, 120, 9)  | 150   | 3,597 | 8 | 1    | 732        | 148      | 9.16s  | 0.20s  | 46x     |
| affiliation(200, 150, 10) | 200   | 5,730 | 9 | 1    | 1,160      | 199      | 29.02s | 0.41s  | 71x     |
| two blobs(80, 0.15, k=3)  | 163   | 982   | 3 | 1    | 587        | 403      | 0.59s  | 0.51s  | 1.2x    |
| two blobs(150, 0.1, k=3)  | 303   | 2,253 | 3 | 1    | 1,146      | 760      | 2.42s  | 2.26s  | 1.1x    |
| two blobs(250, 0.1, k=4)  | 504   | 6,199 | 4 | 1    | 2,383      | 1,522    | 17.58s | 15.00s | 1.2x    |
| barabasi_albert(200, m=4) | 200   | 784   | 3 | 1    | 671        | 200      | 0.27s  | 0.08s  | 3x      |
| watts_strogatz(200, k=6)  | 200   | 600   | 4 | 3    | 960        | 211      | 0.59s  | 0.17s  | 3x      |
| grid_2d(8, 8)             | 64    | 112   | 2 | 4    | 180        | 70       | 0.03s  | 0.01s  | 2x      |
| hypercube(7)              | 128   | 448   | 7 | 128  | 981        | 981      | 0.89s  | 0.96s  | 0.9x    |

The gain tracks `k`, because `k` is what sets the number of candidate pairs: the `affiliation` rows grow from 6x to 71x with size, while `two blobs` stays at 1.2x; there `k` is 3 or 4, so there are only 3 or 4 high degree nodes to pair with, and the flows that remain are most of the work.

`hypercube(7)` is the lower bound: identical flow counts in both arms, because every pair is exactly 7-connected and nothing can be skipped, for an 8% loss. I measured the same 0-7% on other graphs where the filter cannot fire. That seems a fair price, and I would rather pay it than add a heuristic guard that needs tuning of its own.

## Where this matters in practice

`all_node_cuts` is used by `k_components`, whose kernels on clique-rich graphs are exactly the high-`k` regime above. On a corpus of affiliation networks (developer x package and author x file, not public) the decomposition of the one-mode projections went from 300-490s to 56-78s, 3.8x to 6.7x end to end, while the gh-8862 filter alone moved those same graphs only 1.1x to 1.4x.

[benchmark_all_node_cuts_prefilter.py](https://github.com/user-attachments/files/31354296/benchmark_all_node_cuts_prefilter.py)
