### PR TITLE
ENH: Compute current-flow rows from inverse endpoints

### DIFF
--- a/benchmarks/benchmarks/benchmark_current_flow_betweenness.py
+++ b/benchmarks/benchmarks/benchmark_current_flow_betweenness.py
@@ -1,0 +1,35 @@
+"""Benchmarks for current-flow betweenness centrality."""
+
+import networkx as nx
+
+
+class CurrentFlowBetweennessCentralityBenchmarks:
+    timeout = 120
+    params = ["full", "lu", "cg"]
+    param_names = ["solver"]
+
+    def setup(self, solver):
+        self.graph = nx.complete_graph(40)
+        self.sources = [0]
+        self.targets = [39]
+
+    def time_current_flow_betweenness_centrality_subset(self, solver):
+        _ = nx.current_flow_betweenness_centrality_subset(
+            self.graph, self.sources, self.targets, solver=solver
+        )
+
+
+class AdjacentCurrentFlowBetweennessCentralityBenchmarks:
+    timeout = 120
+    params = ["lu", "cg"]
+    param_names = ["solver"]
+
+    def setup(self, solver):
+        self.graph = nx.path_graph(1024)
+        self.sources = [0]
+        self.targets = [1023]
+
+    def time_current_flow_betweenness_centrality_subset(self, solver):
+        _ = nx.current_flow_betweenness_centrality_subset(
+            self.graph, self.sources, self.targets, solver=solver
+        )

--- a/networkx/algorithms/centrality/current_flow_betweenness.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness.py
@@ -224,8 +224,11 @@ def current_flow_betweenness_centrality(
     sparse methods you can achieve $O(nm{\sqrt k})$ where $k$ is the
     Laplacian matrix condition number.
 
-    The space required is $O(nw)$ where $w$ is the width of the sparse
-    Laplacian matrix.  Worse case is $w=n$ for $O(n^2)$.
+    The algorithm uses $O(n + m)$ space, excluding storage used by the linear
+    solver, for $n$ nodes and $m$ edges. Solver storage depends on ``solver``:
+    ``"full"`` stores an $O(n^2)$ dense inverse, while ``"lu"`` and ``"cg"``
+    use sparse factorization or preconditioner storage whose size depends on
+    fill-in and can reach $O(n^2)$ in the worst case.
 
     If the edges have a 'weight' attribute they will be used as
     weights in this algorithm.  Unspecified weights are set to 1.
@@ -325,8 +328,11 @@ def edge_current_flow_betweenness_centrality(
     sparse methods you can achieve $O(nm{\sqrt k})$ where $k$ is the
     Laplacian matrix condition number.
 
-    The space required is $O(nw)$ where $w$ is the width of the sparse
-    Laplacian matrix.  Worse case is $w=n$ for $O(n^2)$.
+    The algorithm uses $O(n + m)$ space, excluding storage used by the linear
+    solver, for $n$ nodes and $m$ edges. Solver storage depends on ``solver``:
+    ``"full"`` stores an $O(n^2)$ dense inverse, while ``"lu"`` and ``"cg"``
+    use sparse factorization or preconditioner storage whose size depends on
+    fill-in and can reach $O(n^2)$ in the worst case.
 
     If the edges have a 'weight' attribute they will be used as
     weights in this algorithm.  Unspecified weights are set to 1.

--- a/networkx/algorithms/centrality/current_flow_betweenness_subset.py
+++ b/networkx/algorithms/centrality/current_flow_betweenness_subset.py
@@ -74,8 +74,11 @@ def current_flow_betweenness_centrality_subset(
     sparse methods you can achieve $O(nm{\sqrt k})$ where $k$ is the
     Laplacian matrix condition number.
 
-    The space required is $O(nw)$ where $w$ is the width of the sparse
-    Laplacian matrix.  Worse case is $w=n$ for $O(n^2)$.
+    The algorithm uses $O(n + m)$ space, excluding storage used by the linear
+    solver, for $n$ nodes and $m$ edges. Solver storage depends on ``solver``:
+    ``"full"`` stores an $O(n^2)$ dense inverse, while ``"lu"`` and ``"cg"``
+    use sparse factorization or preconditioner storage whose size depends on
+    fill-in and can reach $O(n^2)$ in the worst case.
 
     If the edges have a 'weight' attribute they will be used as
     weights in this algorithm.  Unspecified weights are set to 1.
@@ -182,8 +185,11 @@ def edge_current_flow_betweenness_centrality_subset(
     sparse methods you can achieve $O(nm{\sqrt k})$ where $k$ is the
     Laplacian matrix condition number.
 
-    The space required is $O(nw)$ where $w$ is the width of the sparse
-    Laplacian matrix.  Worse case is $w=n$ for $O(n^2)$.
+    The algorithm uses $O(n + m)$ space, excluding storage used by the linear
+    solver, for $n$ nodes and $m$ edges. Solver storage depends on ``solver``:
+    ``"full"`` stores an $O(n^2)$ dense inverse, while ``"lu"`` and ``"cg"``
+    use sparse factorization or preconditioner storage whose size depends on
+    fill-in and can reach $O(n^2)$ in the worst case.
 
     If the edges have a 'weight' attribute they will be used as
     weights in this algorithm.  Unspecified weights are set to 1.

--- a/networkx/algorithms/centrality/flow_matrix.py
+++ b/networkx/algorithms/centrality/flow_matrix.py
@@ -16,17 +16,22 @@ def flow_matrix_row(G, weight=None, dtype=float, solver="lu"):
     n = G.number_of_nodes()
     L = nx.laplacian_matrix(G, nodelist=range(n), weight=weight).asformat("csc")
     L = L.astype(dtype)
-    C = solvername[solver](L, dtype=dtype)  # initialize solver
-    w = C.w  # w is the Laplacian matrix width
+    # The endpoint formulation needs only one reusable right-hand-side row.
+    C = solvername[solver](L, width=1, dtype=dtype)  # initialize solver
+    rhs = C.C[0]
     # row-by-row flow matrix
     for u, v in sorted(sorted((u, v)) for u, v in G.edges()):
-        B = np.zeros(w, dtype=dtype)
-        c = G[u][v].get(weight, 1.0)
-        B[u % w] = c
-        B[v % w] = -c
-        # get only the rows needed in the inverse laplacian
-        # and multiply to get the flow matrix row
-        row = B @ C.get_rows(u, v)
+        c = C.C.dtype.type(G[u][v].get(weight, 1.0))
+        if u == v or c == 0:
+            row = np.zeros(n, dtype=C.C.dtype)
+        elif isinstance(C, FullInverseLaplacian):
+            row = np.subtract(C.IL[u], C.IL[v])
+            row *= c
+        else:
+            rhs[u] = c
+            rhs[v] = -c
+            row = C.solve(rhs)
+            rhs[u] = rhs[v] = 0
         yield row, (u, v)
 
 

--- a/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality.py
+++ b/networkx/algorithms/centrality/tests/test_current_flow_betweenness_centrality.py
@@ -3,9 +3,155 @@ import pytest
 import networkx as nx
 from networkx import approximate_current_flow_betweenness_centrality as approximate_cfbc
 from networkx import edge_current_flow_betweenness_centrality as edge_current_flow
+from networkx.algorithms.centrality.flow_matrix import (
+    CGInverseLaplacian,
+    FullInverseLaplacian,
+    SuperLUInverseLaplacian,
+    flow_matrix_row,
+)
 
 np = pytest.importorskip("numpy")
 pytest.importorskip("scipy")
+
+INVERSE_LAPLACIANS = {
+    "full": FullInverseLaplacian,
+    "lu": SuperLUInverseLaplacian,
+    "cg": CGInverseLaplacian,
+}
+
+
+def test_full_solver_uses_inverse_endpoint_rows(monkeypatch):
+    def fail_if_called(self, rhs):
+        raise AssertionError("full inverse endpoint rows should be used directly")
+
+    monkeypatch.setattr(FullInverseLaplacian, "solve", fail_if_called)
+    graph = nx.power(nx.path_graph(6), 2)
+    rows = list(flow_matrix_row(graph, solver="full"))
+    assert len(rows) == len(graph.edges)
+
+
+@pytest.mark.parametrize("solver", INVERSE_LAPLACIANS)
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_endpoint_row_difference_matches_full_inverse(dtype, solver):
+    graph = nx.power(nx.path_graph(6), 2)
+    for i, (u, v) in enumerate(graph.edges()):
+        graph[u][v]["weight"] = 0.5 + i / 7
+
+    n = len(graph)
+    laplacian = nx.laplacian_matrix(graph, nodelist=range(n), weight="weight").asformat(
+        "csc"
+    )
+    laplacian = laplacian.astype(dtype)
+    inverse = np.zeros((n, n), dtype=dtype)
+    inverse[1:, 1:] = np.linalg.inv(laplacian[1:, 1:].toarray())
+
+    for actual, (u, v) in flow_matrix_row(
+        graph, weight="weight", dtype=dtype, solver=solver
+    ):
+        c = dtype(graph[u][v]["weight"])
+        expected = c * (inverse[u] - inverse[v])
+        assert actual.dtype == expected.dtype == dtype
+        tolerance = (
+            1e-4 if solver == "cg" and dtype == np.float32 else 50 * np.finfo(dtype).eps
+        )
+        np.testing.assert_allclose(actual, expected, rtol=tolerance, atol=tolerance)
+
+
+@pytest.mark.parametrize("solver", ["lu", "cg"])
+def test_endpoint_row_difference_uses_one_linear_solve(monkeypatch, solver):
+    calls = []
+    inverse_type = INVERSE_LAPLACIANS[solver]
+    solve = inverse_type.solve
+
+    def record_call(self, rhs):
+        calls.append(rhs.copy())
+        return solve(self, rhs)
+
+    monkeypatch.setattr(inverse_type, "solve", record_call)
+    graph = nx.complete_graph(5)
+    list(flow_matrix_row(graph, solver=solver))
+    edges = sorted(tuple(sorted(edge)) for edge in graph.edges)
+    assert len(calls) == len(edges)
+    for rhs, (u, v) in zip(calls, edges):
+        expected = np.zeros(len(graph))
+        expected[u] = 1
+        expected[v] = -1
+        np.testing.assert_array_equal(rhs, expected)
+
+
+@pytest.mark.parametrize("solver", INVERSE_LAPLACIANS)
+def test_flow_rows_are_independent(solver):
+    rows = []
+    snapshots = []
+    for row, _ in flow_matrix_row(nx.power(nx.path_graph(6), 2), solver=solver):
+        rows.append(row)
+        snapshots.append(row.copy())
+
+    for i, (row, expected) in enumerate(zip(rows, snapshots)):
+        np.testing.assert_array_equal(row, expected)
+        assert all(not np.shares_memory(row, other) for other in rows[i + 1 :])
+
+
+@pytest.mark.parametrize("solver", INVERSE_LAPLACIANS)
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_self_loop_flow_row_is_zero(solver, dtype):
+    graph = nx.path_graph(4)
+    graph.add_edge(1, 1, weight=7)
+    rows = {
+        edge: row
+        for row, edge in flow_matrix_row(
+            graph, weight="weight", dtype=dtype, solver=solver
+        )
+    }
+    assert rows[1, 1].dtype == dtype
+    np.testing.assert_array_equal(rows[1, 1], np.zeros(len(graph), dtype=dtype))
+
+
+@pytest.mark.parametrize("solver", INVERSE_LAPLACIANS)
+def test_self_loop_does_not_change_current_flow_centrality(solver):
+    graph = nx.path_graph(4)
+    expected_nodes = nx.current_flow_betweenness_centrality(graph, solver=solver)
+    expected_edges = nx.edge_current_flow_betweenness_centrality(graph, solver=solver)
+
+    graph.add_edge(1, 1, weight=7)
+    actual_nodes = nx.current_flow_betweenness_centrality(
+        graph, weight="weight", solver=solver
+    )
+    actual_edges = nx.edge_current_flow_betweenness_centrality(
+        graph, weight="weight", solver=solver
+    )
+
+    assert actual_nodes == pytest.approx(expected_nodes)
+    assert actual_edges[1, 1] == pytest.approx(0)
+    for edge, expected in expected_edges.items():
+        assert actual_edges[edge] == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("solver", ["lu", "cg"])
+def test_zero_weight_edge_does_not_solve_linear_system(monkeypatch, solver):
+    inverse_type = INVERSE_LAPLACIANS[solver]
+    calls = []
+    solve = inverse_type.solve
+
+    def record_call(self, rhs):
+        calls.append(rhs.copy())
+        return solve(self, rhs)
+
+    monkeypatch.setattr(inverse_type, "solve", record_call)
+    graph = nx.path_graph(5)
+    graph.add_edge(0, 4, weight=0.0)
+    rows = {
+        edge: row
+        for row, edge in flow_matrix_row(graph, weight="weight", solver=solver)
+    }
+    edges = sorted(tuple(sorted(edge)) for edge in nx.path_graph(5).edges)
+    assert len(calls) == len(edges)
+    for rhs, (u, v) in zip(calls, edges):
+        expected = np.zeros(len(graph))
+        expected[u] = 1
+        expected[v] = -1
+        np.testing.assert_array_equal(rhs, expected)
+    np.testing.assert_array_equal(rows[0, 4], 0)
 
 
 class TestFlowBetweennessCentrality:


### PR DESCRIPTION
## Summary

This PR changes `flow_matrix_row` to compute each current-flow matrix row directly from the endpoints of an edge.

For an edge `(u, v)` with conductance `c`, let `K` denote the grounded Laplacian inverse used by `InverseLaplacian`. The required flow-matrix row is

```text
c * (e_u - e_v)^T K = c * (K[u] - K[v])
```

The previous implementation called `get_rows(u, v)`, which populated every inverse-Laplacian row with an index between the two endpoints and then multiplied those rows by an incidence vector. All intermediate rows have zero coefficients in that product and therefore do not contribute to the result.

The new implementation computes the same quantity directly:

* `full` subtracts the two stored inverse-Laplacian endpoint rows;
* `lu` and `cg` form the right-hand side `c * (e_u - e_v)` and perform a single solve of the grounded Laplacian system.

Because the grounded Laplacian is symmetric, its inverse is also symmetric. Therefore the solution of the endpoint right-hand side is the same length-`n` vector as `c * (K[u] - K[v])`.

This also removes the width-sized cyclic workspace from the flow-row computation. LU and CG now reuse a single length-`n` right-hand-side buffer.

## Performance motivation

For LU and CG, the previous `get_rows(u, v)` call solved for every inverse-Laplacian row between the two endpoint indices. Only the endpoint rows were subsequently used.

For edges whose endpoints are far apart after the reverse Cuthill-McKee relabeling used by the current-flow routines, this can result in many unnecessary solves. Even for adjacent endpoints, the old implementation requires two solves, while the endpoint formulation requires one.

For the `full` solver, the inverse Laplacian is already stored, but the old implementation still copied a range of rows into the cyclic workspace and performed an additional matrix product. Direct endpoint subtraction removes that intermediate work.

## Behavioral changes

A self-loop has zero incidence vector:

```text
e_u - e_u = 0
```

and therefore its flow-matrix row is identically zero.

In the previous implementation, the positive and negative incidence coefficients of a self-loop were assigned to the same workspace entry. Because the assignments occurred sequentially, the second value overwrote the first instead of canceling it. As a result, a self-loop could affect exact current-flow centrality.

This PR returns a zero flow row for self-loops and adds regression tests verifying that adding a self-loop does not change node current-flow betweenness or the current-flow betweenness of non-self-loop edges. This fixes the behavior reported in #2292.

An edge whose selected conductance is zero also has a zero flow row. Such edges are returned without performing a per-edge linear solve.

## Benchmarks

I added ASV benchmarks for `current_flow_betweenness_centrality_subset` on two graph structures:

* `path_graph(1024)`, where edges remain adjacent under the relevant ordering and the old LU/CG implementation already performs close to the minimum amount of endpoint work;
* `complete_graph(40)`, where endpoint separations cover a wide range and the old implementation computes many unused intermediate inverse rows.

Local ASV results against the base commit:

| Benchmark  |  Base |     PR | Speedup |
| ---------- | -----: | -----: | ------: |
| P1024 / LU | 77.161 ms | 29.167 ms |  2.646x |
| P1024 / CG | 135.118 ms | 62.598 ms  |  2.159x |
| K40 / Full | 10.510 ms | 3.704 ms  |  2.837x |
| K40 / LU | 50.519 ms | 6.453 ms  |  7.829x |
| K40 / CG | 337.781 ms | 25.961 ms  | 13.011x |

Each value is the median of 10 timing samples. The base and PR implementations were measured in the same environment in two interleaved ASV rounds.

(Environment: ASV 0.6.5, Python 3.12.8, NumPy 2.5.2, SciPy 1.18.1, on WSL with an Intel Core i5-13500H and 8 visible logical CPUs.)

The path benchmark exercises the adjacent-edge case for LU and CG: the previous implementation typically performs two inverse solves per edge, while the new implementation performs one. The complete-graph benchmark exercises the larger overhead caused by computing intermediate inverse rows for widely separated endpoints.

## Tests

The added tests verify that:

* all three solvers agree with a dense grounded-inverse reference calculation;
* both `float32` and `float64` paths are covered;
* LU and CG perform exactly one linear solve per nonzero, non-self-loop edge;
* returned flow rows do not alias the reusable workspace;
* self-loop flow rows are zero and self-loops do not change current-flow centrality;
* zero-conductance edges return zero rows without triggering a per-edge linear solve.

Local validation:

* targeted tests: 65 passed;
* full NetworkX test suite: 8869 passed, 61 skipped, 741 xfailed;
* formatting and lint checks pass.

## AI use

I used ChatGPT for technical implementation and review and adopted some of its suggestions for writing this PR.  I manually reviewed and verified the implementation, mathematical reasoning, tests, and benchmark results.