### PR TITLE
DOC: Add AtlasView example in coreviews.py

### DIFF
--- a/networkx/classes/coreviews.py
+++ b/networkx/classes/coreviews.py
@@ -27,6 +27,20 @@ class AtlasView(Mapping):
     The inner level of dict is read-write. But the
     outer level is read-only.
 
+    Indexing a graph with a node, such as `G[n]`, returns an
+    `AtlasView` that maps each neighbor of `n` to the edge-attribute
+    dictionary for the edge between `n` and that neighbor.
+
+    Examples
+    --------
+    >>> import networkx as nx
+    >>> G = nx.DiGraph()
+    >>> G.add_edge(1, 2, weight=3)
+    >>> G[1]
+    AtlasView({2: {'weight': 3}})
+    >>> G[1][2]["weight"]
+    3
+
     See Also
     ========
     AdjacencyView: View into dict-of-dict-of-dict


### PR DESCRIPTION
## Summary
Adds a short `Examples` section to the `AtlasView` docstring showing `G[n]` indexing, the `AtlasView` repr, and inner attribute access.

## Context
Indexing a graph with a node, such as `G[n]`, returns an `AtlasView` that maps each neighbor of `n` to the edge-attribute dictionary. The existing `AtlasView` docstring described this but lacked a runnable example. This adds one in the standard `Examples` section format used elsewhere in NetworkX.

## Verification
- Output verified against the current repr (`AtlasView({2: {'weight': 3}})`).
- `pytest --doctest-modules` passes for the modified file.

## Note
This change was prepared with AI assistance and reviewed manually before submission, in line with NetworkX's automated contributions policy.