### PR TITLE
ENH: Use linear algebra to compute communicability

### DIFF
--- a/networkx/algorithms/communicability_alg.py
+++ b/networkx/algorithms/communicability_alg.py
@@ -72,20 +72,13 @@ def communicability(G):
     A = nx.to_numpy_array(G, nodelist, weight=None)
 
     w, vec = np.linalg.eigh(A)
-    expw = np.exp(w)
-    mapping = dict(zip(nodelist, range(len(nodelist))))
-    c = {}
-    # computing communicabilities
-    for u in G:
-        c[u] = {}
-        for v in G:
-            s = 0
-            p = mapping[u]
-            q = mapping[v]
-            for j in range(len(nodelist)):
-                s += vec[:, j][p] * vec[:, j][q] * expw[j]
-            c[u][v] = float(s)
-    return c
+    communicability = (vec * np.exp(w)) @ vec.T
+
+    # Convert to dict-of-dict keyed by nodes to the communicability value
+    return {
+        u: {v: float(communicability[i][j]) for j, v in enumerate(G)}
+        for i, u in enumerate(G)
+    }
 
 
 @not_implemented_for("directed")

--- a/networkx/algorithms/communicability_alg.py
+++ b/networkx/algorithms/communicability_alg.py
@@ -68,9 +68,7 @@ def communicability(G):
     """
     import numpy as np
 
-    nodelist = list(G)  # ordering of nodes in matrix
-    A = nx.to_numpy_array(G, nodelist, weight=None)
-
+    A = nx.to_numpy_array(G, weight=None)
     w, vec = np.linalg.eigh(A)
     communicability = (vec * np.exp(w)) @ vec.T
 

--- a/networkx/algorithms/communicability_alg.py
+++ b/networkx/algorithms/communicability_alg.py
@@ -69,9 +69,8 @@ def communicability(G):
     import numpy as np
 
     nodelist = list(G)  # ordering of nodes in matrix
-    A = nx.to_numpy_array(G, nodelist)
-    # convert to 0-1 matrix
-    A[A != 0.0] = 1
+    A = nx.to_numpy_array(G, nodelist, weight=None)
+
     w, vec = np.linalg.eigh(A)
     expw = np.exp(w)
     mapping = dict(zip(nodelist, range(len(nodelist))))


### PR DESCRIPTION
This PR scratches a brain-itch raised during review of #8802 .

For the record the primary motivation here is to improve readability rather than performance - IMO the linalg formulation is much easier to understand; YMMV of course! Replacing Python for-loops with `np.linalg` is likely to have performance benefits as well, but I didn't want to fall too far down that rabbit hole. I.e. I'm not trying to squeeze every last ounce of performance by leveraging symmetry etc.

Another consequence of replacing the original implementation with `np.linalg` is that there are going to differences in the results due to precision issues. The test suite caps the "approximately equal" limit at 1e-7 which is fine, but these will be different at the ~1e-13 level (potentially greater, depending on the scale of the adjacency matrix). IMV this is not a problem, but just a heads up in case we want to make any guarantees about numerical consistency.

Finally, there is also the `communicability_exp` function that would benefit from a similar treatment. I left it out of here on purpose because I think it might be worth deprecating instead (to be continued)!