### PR TITLE
DOC: Example - fixing readwrite example docstrings with io

### DIFF
--- a/networkx/algorithms/bipartite/edgelist.py
+++ b/networkx/algorithms/bipartite/edgelist.py
@@ -63,20 +63,22 @@ def write_edgelist(G, path, comments="#", delimiter=" ", data=True, encoding="ut
     Use a BytesIO object to simulate a file handle opened in "wb" mode.
 
     >>> test_edgelist = io.BytesIO()
-    >>> nx.write_edgelist(G, test_edgelist)
+    >>> nx.bipartite.write_edgelist(G, test_edgelist)
     >>> print(test_edgelist.getvalue().decode())
     0 1 {}
-    1 2 {}
+    2 1 {}
     2 3 {}
     <BLANKLINE>
 
     Edge data are included by default
 
     >>> G = nx.Graph()
+    >>> G.add_node(1, bipartite=0)
+    >>> G.add_node(2, bipartite=1)
     >>> G.add_edge(1, 2, weight=7, color="red")
 
     >>> test_edgelist = io.BytesIO()
-    >>> nx.write_edgelist(G, test_edgelist)
+    >>> nx.bipartite.write_edgelist(G, test_edgelist)
     >>> print(test_edgelist.getvalue().decode())
     1 2 {'weight': 7, 'color': 'red'}
     <BLANKLINE>
@@ -85,7 +87,7 @@ def write_edgelist(G, path, comments="#", delimiter=" ", data=True, encoding="ut
     are included.
 
     >>> test_edgelist = io.BytesIO()
-    >>> nx.write_edgelist(G, test_edgelist, data=False)
+    >>> nx.bipartite.write_edgelist(G, test_edgelist, data=False)
     >>> print(test_edgelist.getvalue().decode())
     1 2
     <BLANKLINE>
@@ -93,13 +95,13 @@ def write_edgelist(G, path, comments="#", delimiter=" ", data=True, encoding="ut
     Or to specify which edge attribute data to include:
 
     >>> test_edgelist = io.BytesIO()
-    >>> nx.write_edgelist(G, test_edgelist, data=["color"])
+    >>> nx.bipartite.write_edgelist(G, test_edgelist, data=["color"])
     >>> print(test_edgelist.getvalue().decode())
     1 2 red
     <BLANKLINE>
 
     >>> test_edgelist = io.BytesIO()
-    >>> nx.write_edgelist(G, test_edgelist, data=["color", "weight"])
+    >>> nx.bipartite.write_edgelist(G, test_edgelist, data=["color", "weight"])
     >>> print(test_edgelist.getvalue().decode())
     1 2 red 7
     <BLANKLINE>

--- a/networkx/algorithms/bipartite/edgelist.py
+++ b/networkx/algorithms/bipartite/edgelist.py
@@ -54,20 +54,55 @@ def write_edgelist(G, path, comments="#", delimiter=" ", data=True, encoding="ut
 
     Examples
     --------
+    >>> import io
+
     >>> G = nx.path_graph(4)
     >>> G.add_nodes_from([0, 2], bipartite=0)
     >>> G.add_nodes_from([1, 3], bipartite=1)
-    >>> nx.write_edgelist(G, "test.edgelist")
-    >>> fh = open("test.edgelist_open", "wb")
-    >>> nx.write_edgelist(G, fh)
-    >>> nx.write_edgelist(G, "test.edgelist.gz")
-    >>> nx.write_edgelist(G, "test.edgelist_nodata.gz", data=False)
+
+    Use a BytesIO object to simulate a file handle opened in "wb" mode.
+
+    >>> test_edgelist = io.BytesIO()
+    >>> nx.write_edgelist(G, test_edgelist)
+    >>> print(test_edgelist.getvalue().decode())
+    0 1 {}
+    1 2 {}
+    2 3 {}
+    <BLANKLINE>
+
+    Edge data are included by default
 
     >>> G = nx.Graph()
     >>> G.add_edge(1, 2, weight=7, color="red")
-    >>> nx.write_edgelist(G, "test.edgelist_bigger_nodata", data=False)
-    >>> nx.write_edgelist(G, "test.edgelist_color", data=["color"])
-    >>> nx.write_edgelist(G, "test.edgelist_color_weight", data=["color", "weight"])
+
+    >>> test_edgelist = io.BytesIO()
+    >>> nx.write_edgelist(G, test_edgelist)
+    >>> print(test_edgelist.getvalue().decode())
+    1 2 {'weight': 7, 'color': 'red'}
+    <BLANKLINE>
+
+    The `data` keyword argument is used to toggle whether edge attribute data
+    are included.
+
+    >>> test_edgelist = io.BytesIO()
+    >>> nx.write_edgelist(G, test_edgelist, data=False)
+    >>> print(test_edgelist.getvalue().decode())
+    1 2
+    <BLANKLINE>
+
+    Or to specify which edge attribute data to include:
+
+    >>> test_edgelist = io.BytesIO()
+    >>> nx.write_edgelist(G, test_edgelist, data=["color"])
+    >>> print(test_edgelist.getvalue().decode())
+    1 2 red
+    <BLANKLINE>
+
+    >>> test_edgelist = io.BytesIO()
+    >>> nx.write_edgelist(G, test_edgelist, data=["color", "weight"])
+    >>> print(test_edgelist.getvalue().decode())
+    1 2 red 7
+    <BLANKLINE>
 
     See Also
     --------


### PR DESCRIPTION
An example of "fixing" the `bipartite.write_edgelist` docstring examples using `io.BytesIO`. The main advantages are:
 - no explicit file objects, so no disk I/O nor any dangling file handles from e.g. failing to properly close a file
 - easy introspection of the "file contents" via `getvalue()`.

The main disadvantage is that `io.BytesIO` isn't actually a file object, so the patterns you use to create/access aren't the same as with "real" file object handling (i.e. using `open`). In general this is fine, but for a docstring example it means the patterns shown in the example might be different than those you would use in the real world.