### PR TITLE
DOC: Fix write graphml docstring examples

### DIFF
--- a/networkx/conftest.py
+++ b/networkx/conftest.py
@@ -189,6 +189,13 @@ try:
 except ImportError:
     has_sympy = False
 
+try:
+    import lxml
+
+    has_lxml = True
+except ImportError:
+    has_lxml = False
+
 
 # List of files that pytest should ignore
 
@@ -255,6 +262,7 @@ needs_pandas = ["convert_matrix.py"]
 needs_pygraphviz = ["drawing/nx_agraph.py"]
 needs_pydot = ["drawing/nx_pydot.py"]
 needs_sympy = ["algorithms/polynomials.py"]
+needs_lxml = ["readwrite/graphml.py"]
 
 if not has_numpy:
     collect_ignore += needs_numpy
@@ -270,3 +278,5 @@ if not has_pydot:
     collect_ignore += needs_pydot
 if not has_sympy:
     collect_ignore += needs_sympy
+if not has_lxml:
+    collect_ignore += needs_lxml

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -95,8 +95,28 @@ def write_graphml_xml(
 
     Examples
     --------
+    >>> from pathlib import Path
+    >>> import tempfile
+    >>> tmp_path = Path(tempfile.gettempdir())
+
+    Write graph data to disk in graphml format:
+
     >>> G = nx.path_graph(4)
-    >>> nx.write_graphml(G, "test.graphml")
+    >>> fpath = tmp_path / "test.graphml"
+    >>> nx.write_graphml(G, fpath)
+
+    View the graphml data, ignoring the first two lines of header/metadata:
+
+    >>> with open(fpath) as fh:
+    ...     lines_from_file = fh.readlines()
+    >>> print("".join(lines_from_file[2:]))
+    <node id="1"/>
+    <node id="2"/>
+    <node id="3"/>
+    <edge source="0" target="1"/>
+    <edge source="1" target="2"/>
+    <edge source="2" target="3"/>
+    </graph></graphml>
 
     Notes
     -----

--- a/networkx/readwrite/graphml.py
+++ b/networkx/readwrite/graphml.py
@@ -173,8 +173,28 @@ def write_graphml_lxml(
 
     Examples
     --------
+    >>> from pathlib import Path
+    >>> import tempfile
+    >>> tmp_path = Path(tempfile.gettempdir())
+
+    Write graph data to disk in graphml format:
+
     >>> G = nx.path_graph(4)
-    >>> nx.write_graphml_lxml(G, "fourpath.graphml")
+    >>> fpath = tmp_path / "fourpath.graphml"
+    >>> nx.write_graphml(G, fpath)
+
+    View the graphml data, ignoring the first two lines of header/metadata:
+
+    >>> with open(fpath) as fh:
+    ...     lines_from_file = fh.readlines()
+    >>> print("".join(lines_from_file[2:]))
+    <node id="1"/>
+    <node id="2"/>
+    <node id="3"/>
+    <edge source="0" target="1"/>
+    <edge source="1" target="2"/>
+    <edge source="2" target="3"/>
+    </graph></graphml>
 
     Notes
     -----


### PR DESCRIPTION
Same treatment as #8872 , this time applied to the `write_graphml` docstring examples.

This one included a bit of a curveball - it turns out that there's a difference in whitespace rendering/newlines between the Python builtin `xml` module and the `lxml` module (which is recommended and used by default when available). It's not a problem in general, but the whitespace differences were an issue for the doctests. Fortunately, there's already a pattern for skipping doctests based on the availability of optional dependencies, so I just did that - see 31a6bdf for details!