### PR TITLE
DOC: Fix gexf docstring examples

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -73,14 +73,63 @@ def write_gexf(G, path, encoding="utf-8", prettyprint=True, version="1.2draft"):
 
     Examples
     --------
-    >>> G = nx.path_graph(4)
-    >>> nx.write_gexf(G, "test.gexf")
+    >>> from pathlib import Path
+    >>> import tempfile
+    >>> tmp_path = Path(tempfile.gettempdir())
 
-    # visualization data
+    >>> G = nx.path_graph(4)
+    >>> fpath = tmp_path / "test.gexf"
+    >>> nx.write_gexf(G, fpath)
+
+    View the GEXF graph data, ignoring the header/metadata:
+
+    >>> with open(fpath) as fh:
+    ...     lines_from_file = fh.readlines()
+    >>> print("".join(lines_from_file[5:-1]))
+      <graph defaultedgetype="undirected" mode="static" name="">
+        <nodes>
+          <node id="0" label="0" />
+          <node id="1" label="1" />
+          <node id="2" label="2" />
+          <node id="3" label="3" />
+        </nodes>
+        <edges>
+          <edge source="0" target="1" id="0" />
+          <edge source="1" target="2" id="1" />
+          <edge source="2" target="3" id="2" />
+        </edges>
+      </graph>
+    <BLANKLINE>
+
+    Visualization data in GEXF format is supported and is read from the ``"viz"``
+    node attribute:
+
     >>> G.nodes[0]["viz"] = {"size": 54}
     >>> G.nodes[0]["viz"]["position"] = {"x": 0, "y": 1}
     >>> G.nodes[0]["viz"]["color"] = {"r": 0, "g": 0, "b": 256}
+    >>> nx.write_gexf(G, fpath)
 
+    >>> with open(fpath) as fh:
+    ...     lines_from_file = fh.readlines()
+    >>> print("".join(lines_from_file[5:-1]))  # Ignore header and metadata tags
+      <graph defaultedgetype="undirected" mode="static" name="">
+        <nodes>
+          <node id="0" label="0">
+            <viz:color r="0" g="0" b="256" a="1.0" />
+            <viz:size value="54" />
+            <viz:position x="0" y="1" z="None" />
+          </node>
+          <node id="1" label="1" />
+          <node id="2" label="2" />
+          <node id="3" label="3" />
+        </nodes>
+        <edges>
+          <edge source="0" target="1" id="0" />
+          <edge source="1" target="2" id="1" />
+          <edge source="2" target="3" id="2" />
+        </edges>
+      </graph>
+    <BLANKLINE>
 
     Notes
     -----

--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -154,7 +154,7 @@ def write_gexf(G, path, encoding="utf-8", prettyprint=True, version="1.2draft"):
 
 
 def generate_gexf(G, encoding="utf-8", prettyprint=True, version="1.2draft"):
-    """Generate lines of GEXF format representation of G.
+    r"""Generate lines of GEXF format representation of G.
 
     "GEXF (Graph Exchange XML Format) is a language for describing
     complex networks structures, their associated data and dynamics" [1]_.
@@ -183,11 +183,30 @@ def generate_gexf(G, encoding="utf-8", prettyprint=True, version="1.2draft"):
 
     Examples
     --------
+    >>> import itertools
+
     >>> G = nx.path_graph(4)
-    >>> linefeed = chr(10)  # linefeed=\n
-    >>> s = linefeed.join(nx.generate_gexf(G))
-    >>> for line in nx.generate_gexf(G):  # doctest: +SKIP
-    ...     print(line)
+    >>> gexf_gen = nx.generate_gexf(G)
+
+    The first several lines are the header containing only metadata - skip them
+    in this example for the purposes of viewing only the GEXF-formatted graph data:
+
+    >>> gexf_headerless = itertools.islice(gexf_gen, 4, None)
+    >>> print("\n".join(gexf_headerless))
+      <graph defaultedgetype="undirected" mode="static" name="">
+        <nodes>
+          <node id="0" label="0" />
+          <node id="1" label="1" />
+          <node id="2" label="2" />
+          <node id="3" label="3" />
+        </nodes>
+        <edges>
+          <edge source="0" target="1" id="0" />
+          <edge source="1" target="2" id="1" />
+          <edge source="2" target="3" id="2" />
+        </edges>
+      </graph>
+    </gexf>
 
     Notes
     -----


### PR DESCRIPTION
The main focus is `write_gexf` which is the only example that included file I/O. I also took the liberty of turning the `generate_gexf` example into a doctest that highlights the GEXF data format by removing the doctest: skip. This also required converting the docstring to a raw-string to deal with whitespace issues in the example output. This is not super critical so I'm happy to back it out if it's too much churn!