### PR TITLE
BUG: group betweenness gives incorrect values for undirected connected graph

### DIFF
--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -151,7 +151,7 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
                         if D[x][y] == D[x][v] + D[v][y]:
                             dxvy = sigma_m[x][v] * sigma_m[v][y] / sigma_m[x][y]
                         if D[v][y] == D[v][x] + D[x][y]:
-                            dvxy = sigma_m[v][x] * sigma[x][y] / sigma[v][y]
+                            dvxy = sigma_m[v][x] * sigma_m[x][y] / sigma_m[v][y]
                     sigma_m_v[x][y] = sigma_m[x][y] * (1 - dxvy)
                     PB_m_v[x][y] = PB_m[x][y] - PB_m[x][y] * dxvy
                     if y != v:

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -100,6 +100,15 @@ class TestGroupBetweennessCentrality:
         b_answer = 5.0
         assert b == b_answer
 
+    def test_group_betweenness_no_paths_through_group(self):
+        """
+        GBC sanity check when no paths pass through group (regression test for gh-8827)
+        """
+        # The non-group nodes 3, 4 and 5 have no shortest path between them that also
+        # has an interior node in C, so the group betweenness is 0.
+        G = nx.Graph([(0, 1), (0, 2), (0, 3), (0, 4), (1, 3), (2, 3), (3, 4), (4, 5)])
+        assert 0 == nx.group_betweenness_centrality(G, [0, 1, 2], normalized=False)
+
 
 class TestProminentGroup:
     np = pytest.importorskip("numpy")

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -65,6 +65,22 @@ class TestGroupBetweennessCentrality:
         b_answer = 0.0
         assert b == b_answer
 
+    def test_group_betweenness_many_groups(self):
+        """
+        Group betweenness centrality with single graph over many groups.
+        Also checks that singleton groups equal regular betweenness values.
+        """
+        G = nx.path_graph(5)
+        G.remove_edge(0, 1)
+
+        bc = nx.betweenness_centrality(G, normalized=False)
+        gbc_singletons = [0, 0, 2, 2, 0]
+        assert list(bc.values()) == gbc_singletons
+
+        many_groups = [[node] for node in G]
+        results = nx.group_betweenness_centrality(G, many_groups, normalized=False)
+        assert results == gbc_singletons
+
     def test_group_betweenness_disconnected_graph(self):
         """
         Group betweenness centrality in a disconnected graph


### PR DESCRIPTION
This splits off the simplest bug reported in #8666 and #8559 and fixes it. Related discussion in #8827.
I'm hoping splitting these up makes review simple.

The bug is that `sigma` is used instead of `sigma_m` in two places where the symmetry of the formulas makes it clear that it should have been `sigma_m`.  This corrects an easily checked test where no shortest paths between non-group nodes pass through the group. So `GBC==0`.  It was giving `0.125`.

I also added a test that checks many groups at once and compares singleton groups with the BC values from `betweenness_centrality`  to ensure they are the same.  That test passes before or after this fix, but I found it helpful to see that symmetry so I included it in this PR.

Upcoming PRs: (todo list)
- [x] test and fix the subtraction of paths with an endpoint in the group so it works for directed graphs that aren't strongly connected. #8880
- [x] test and fix the bug of skipping all 3 adjustments when any denominator is zero (should only skip the one with zero denominator). #8881
- [ ] test and fix cases where not strongly connected directed graphs give KeyErrors. #8882
- [ ] Discover the meaning of keyword `endpoints=True` and figure out how to make it meaningful, or remove that option.
- [ ] propagate these test changes to `prominent_group_*`, `group_degree_*` and `group_closeness_*`.