### PR TITLE
BUG: Group betweenness centrality counts paths incorrectly for directed but not strongly connected.

### DIFF
--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -162,30 +162,32 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
             PB_m, PB_m_v = PB_m_v, PB_m
 
         # endpoints
-        v, c = len(G), len(group)
+        N, c = len(G), len(group)
         if not endpoints:
-            scale = 0
             # if the graph is connected then subtract the endpoints from
             # the count for all the nodes in the graph. else count how many
             # nodes are connected to the group's nodes and subtract that.
             if nx.is_directed(G):
                 if nx.is_strongly_connected(G):
-                    scale = c * (2 * v - c - 1)
+                    extra = c * (2 * N - c - 1)
+                else:
+                    # count paths for group to or from anything
+                    reachables = ((u, v) for u in G for v in D[u] if v != u)
+                    extra = sum(1 for u, v in reachables if (u in group or v in group))
             elif nx.is_connected(G):
-                scale = c * (2 * v - c - 1)
-            if scale == 0:
-                for group_node1 in group:
-                    for node in D[group_node1]:
-                        if node != group_node1:
-                            if node in group:
-                                scale += 1
-                            else:
-                                scale += 2
-            GBC_group -= scale
+                extra = c * (2 * N - c - 1)
+            else:
+                # count paths for group to anything
+                # (use 2 if v not in group to shorten reachables)
+                reachables = ((u, v) for u in group for v in D[u] if v != u)
+                extra = sum((1 if v in group else 2) for u, v in reachables)
+
+            GBC_group -= extra
 
         # normalized
         if normalized:
-            scale = 1 / ((v - c) * (v - c - 1))
+            N_out = N - c
+            scale = 1 / (N_out * (N_out - 1))
             GBC_group *= scale
 
         # If undirected than count only the undirected edges

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -151,7 +151,7 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
                         if D[x][y] == D[x][v] + D[v][y]:
                             dxvy = sigma_m[x][v] * sigma_m[v][y] / sigma_m[x][y]
                         if D[v][y] == D[v][x] + D[x][y]:
-                            dvxy = sigma_m[v][x] * sigma[x][y] / sigma[v][y]
+                            dvxy = sigma_m[v][x] * sigma_m[x][y] / sigma_m[v][y]
                     sigma_m_v[x][y] = sigma_m[x][y] * (1 - dxvy)
                     PB_m_v[x][y] = PB_m[x][y] - PB_m[x][y] * dxvy
                     if y != v:

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -92,6 +92,22 @@ class TestGroupBetweennessCentrality:
         b_answer = 0.0
         assert b == b_answer
 
+    def test_group_betweenness_many_groups_directed_graph(self):
+        """
+        Group betweenness centrality with directed graph over many groups.
+        Also checks that singleton groups equal regular betweenness values.
+        """
+        G = nx.path_graph(5, create_using=nx.DiGraph)
+        G.remove_edge(0, 1)
+
+        bc = nx.betweenness_centrality(G, normalized=False)
+        gbc_singletons = [0, 0, 2, 2, 0]
+        assert list(bc.values()) == gbc_singletons
+
+        many_groups = [[node] for node in G]
+        results = nx.group_betweenness_centrality(G, many_groups, normalized=False)
+        assert results == gbc_singletons
+
     def test_group_betweenness_node_not_in_graph(self):
         """
         Node(s) in C not in graph, raises NodeNotFound exception
@@ -115,6 +131,25 @@ class TestGroupBetweennessCentrality:
         b = nx.group_betweenness_centrality(G, C, weight="weight", normalized=False)
         b_answer = 5.0
         assert b == b_answer
+
+    def test_group_betweenness_disconnected_directed_graph(self):
+        """
+        GBC check of disconnected directed graph (from gh-8666 comment)
+        """
+        # unweighted version
+        G = nx.DiGraph([(1, 0), (1, 5), (2, 0), (2, 3), (3, 2), (5, 3)])
+        G.add_node(4)
+        C = [3, 4, 2]
+        assert 1 == nx.group_betweenness_centrality(G, C, normalized=False)
+
+        # weighted version
+        G = nx.DiGraph()
+        G.add_node(4)
+        G.add_weighted_edges_from(
+            [(1, 0, 2), (1, 5, 4), (2, 0, 1), (2, 3, 5), (3, 2, 2), (5, 3, 3)]
+        )
+        ans = nx.group_betweenness_centrality(G, C, weight="weight", normalized=False)
+        assert ans == 1
 
     def test_group_betweenness_no_paths_through_group(self):
         """

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -100,6 +100,15 @@ class TestGroupBetweennessCentrality:
         b_answer = 5.0
         assert b == b_answer
 
+    def test_group_betweenness_no_paths_through_group(self):
+        """
+        GBC sanity check when no paths pass through group (regression test for gh-8827)
+        """
+        # The non-group nodes 3, 4 and 5 have no shortest path between them that also
+        # has an interior node in C, so the group betweenness is 0.
+        G = nx.Graph([(0, 1), (0, 2), (0, 3), (0, 4), (1, 3), (2, 3), (3, 4), (4, 5)])
+        assert 0 == nx.group_betweenness_centrality(G, [0, 1, 2], normalized=False)
+
 
 class TestProminentGroup:
     np = pytest.importorskip("numpy")

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -65,6 +65,22 @@ class TestGroupBetweennessCentrality:
         b_answer = 0.0
         assert b == b_answer
 
+    def test_group_betweenness_many_groups(self):
+        """
+        Group betweenness centrality with single graph over many groups.
+        Also checks that singleton groups equal regular betweenness values.
+        """
+        G = nx.path_graph(5)
+        G.remove_edge(0, 1)
+
+        bc = nx.betweenness_centrality(G, normalized=False)
+        gbc_singletons = [0, 0, 2, 2, 0]
+        assert list(bc.values()) == gbc_singletons
+
+        many_groups = [[node] for node in G]
+        results = nx.group_betweenness_centrality(G, many_groups, normalized=False)
+        assert results == gbc_singletons
+
     def test_group_betweenness_disconnected_graph(self):
         """
         Group betweenness centrality in a disconnected graph


### PR DESCRIPTION
This PR builds on #8879 and should be consider after that is merged.
Fixes #8559
Replaces #8666

This PR fixes the subtraction of path counts for shortest paths that start or end in the group (handling endpoints in the group). The current code handles a strongly connected directed graph, but not a general directed graph. So this adds the missing section of the if-structure for counting paths in directed graphs. The old code used a single workflow for directed and undirected cases when not fully connected. 

Two tests (that fail on main) are added in one commit and then the fix is in the next commit. One of the tests fails without #8879 which is why this builds on that. The code doesn't overlap, but the content does. :} 

I changed the name `scale` to `extra` because scaling usually is multiplying by a scalar whereas this subtracts the extra path counts. I also rewrote the nested for loop using comprehensions -- which is hopefully more readable in this case. Suggestions welcome!

Still to do:
- [x] test and fix the bug of skipping all 3 adjustments when any denominator is zero (should only skip the one with zero denominator).
- [ ] test and fix cases where not strongly connected directed graphs give KeyErrors.
- [ ] Discover the meaning of keyword `endpoints=True` and figure out how to make it meaningful, or remove that option.
- [ ] propagate these test changes to `prominent_group_*`, `group_degree_*` and `group_closeness_*`.