### PR TITLE
BUG: Group betweenness skips adjustments if any sigma is zero

### DIFF
--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -151,7 +151,7 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
                         if D[x][y] == D[x][v] + D[v][y]:
                             dxvy = sigma_m[x][v] * sigma_m[v][y] / sigma_m[x][y]
                         if D[v][y] == D[v][x] + D[x][y]:
-                            dvxy = sigma_m[v][x] * sigma[x][y] / sigma[v][y]
+                            dvxy = sigma_m[v][x] * sigma_m[x][y] / sigma_m[v][y]
                     sigma_m_v[x][y] = sigma_m[x][y] * (1 - dxvy)
                     PB_m_v[x][y] = PB_m[x][y] - PB_m[x][y] * dxvy
                     if y != v:

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -171,7 +171,6 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
                     if Dx[y] == Dx[v] + Dv[y] and sig_xy:
                         sig_xvy = sig_xv * sig_vy
                         PB_x[y] *= 1 - sig_xvy / sig_xy
-
                         sig_x[y] -= sig_xvy
                         if y == v:
                             # update sig_xv for future y-values

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -134,33 +134,48 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
         GBC_group = 0
         sigma_m = deepcopy(sigma)
         PB_m = deepcopy(PB)
-        sigma_m_v = deepcopy(sigma_m)
-        PB_m_v = deepcopy(PB_m)
         for v in group:
-            GBC_group += PB_m[v][v]
-            for x in group:
-                for y in group:
-                    dxvy = 0
-                    dxyv = 0
-                    dvxy = 0
-                    if not (
-                        sigma_m[x][y] == 0 or sigma_m[x][v] == 0 or sigma_m[v][y] == 0
-                    ):
-                        if D[x][v] == D[x][y] + D[y][v]:
-                            dxyv = sigma_m[x][y] * sigma_m[y][v] / sigma_m[x][v]
-                        if D[x][y] == D[x][v] + D[v][y]:
-                            dxvy = sigma_m[x][v] * sigma_m[v][y] / sigma_m[x][y]
-                        if D[v][y] == D[v][x] + D[x][y]:
-                            dvxy = sigma_m[v][x] * sigma_m[x][y] / sigma_m[v][y]
-                    sigma_m_v[x][y] = sigma_m[x][y] * (1 - dxvy)
-                    PB_m_v[x][y] = PB_m[x][y] - PB_m[x][y] * dxvy
-                    if y != v:
-                        PB_m_v[x][y] -= PB_m[x][v] * dxyv
-                    if x != v:
-                        PB_m_v[x][y] -= PB_m[v][y] * dvxy
-            sigma_m, sigma_m_v = sigma_m_v, sigma_m
-            PB_m, PB_m_v = PB_m_v, PB_m
+            # store lookups and set
+            Dv = D[v]
+            PB_v = PB_m[v]
+            sig_v = sigma_m[v]
+            group_in_Dv = group & Dv.keys()
 
+            GBC_group += PB_m[v][v]
+            for x in group_in_Dv:
+                # store lookups
+                Dx = D[x]
+                PB_x = PB_m[x]
+                sig_x = sigma_m[x]
+                sig_xv = sig_x[v]
+                sig_vx = sig_v[x]
+
+                # ensure y is in Dx otherwise v is not in path with x and y
+                for y in group_in_Dv & Dx.keys():
+                    # store lookups
+                    Dy = D[y]
+                    sig_y = sigma_m[y]
+                    sig_xy = sig_x[y]
+                    sig_vy = sig_v[y]
+
+                    # Order x-y-v
+                    if Dx[v] == Dx[y] + Dy[v] and sig_xv:
+                        if y != v:
+                            PB_x[y] -= PB_x[v] * sig_xy * sig_y[v] / sig_xv
+                    # Order v-x-y
+                    if Dv[y] == Dv[x] + Dx[y] and sig_vy:
+                        if x != v:
+                            # fraction of v->y paths that pass through x
+                            PB_x[y] -= PB_v[y] * sig_vx * sig_xy / sig_vy
+                    # order x-v-y
+                    if Dx[y] == Dx[v] + Dv[y] and sig_xy:
+                        sig_xvy = sig_xv * sig_vy
+                        PB_x[y] *= 1 - sig_xvy / sig_xy
+
+                        sig_x[y] -= sig_xvy
+                        if y == v:
+                            # update sig_xv for future y-values
+                            sig_xv -= sig_xvy
         # endpoints
         v, c = len(G), len(group)
         if not endpoints:

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -100,6 +100,15 @@ class TestGroupBetweennessCentrality:
         b_answer = 5.0
         assert b == b_answer
 
+    def test_group_betweenness_no_paths_through_group(self):
+        """
+        GBC sanity check when no paths pass through group (regression test for gh-8827)
+        """
+        # The non-group nodes 3, 4 and 5 have no shortest path between them that also
+        # has an interior node in C, so the group betweenness is 0.
+        G = nx.Graph([(0, 1), (0, 2), (0, 3), (0, 4), (1, 3), (2, 3), (3, 4), (4, 5)])
+        assert 0 == nx.group_betweenness_centrality(G, [0, 1, 2], normalized=False)
+
 
 class TestProminentGroup:
     np = pytest.importorskip("numpy")

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -125,6 +125,38 @@ class TestGroupBetweennessCentrality:
         G = nx.Graph([(0, 1), (0, 2), (0, 3), (0, 4), (1, 3), (2, 3), (3, 4), (4, 5)])
         assert 0 == nx.group_betweenness_centrality(G, [0, 1, 2], normalized=False)
 
+    def test_group_betweenness_directed_ground_truth(self):
+        """
+        GBC check against exhaustive counting for directed graph (see gh-8827)
+        """
+        G = nx.DiGraph(
+            [
+                (0, 6),
+                (1, 3),
+                (1, 6),
+                (2, 5),
+                (2, 6),
+                (2, 7),
+                (3, 1),
+                (3, 4),
+                (4, 0),
+                (4, 2),
+                (4, 5),
+                (4, 7),
+                (5, 1),
+                (5, 7),
+                (6, 0),
+                (6, 1),
+                (6, 7),
+                (7, 2),
+                (7, 4),
+                (7, 6),
+            ]
+        )
+
+        b = nx.group_betweenness_centrality(G, [1, 2, 3], normalized=False)
+        assert b == pytest.approx(8 / 3)
+
 
 class TestProminentGroup:
     np = pytest.importorskip("numpy")

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -65,6 +65,22 @@ class TestGroupBetweennessCentrality:
         b_answer = 0.0
         assert b == b_answer
 
+    def test_group_betweenness_many_groups(self):
+        """
+        Group betweenness centrality with single graph over many groups.
+        Also checks that singleton groups equal regular betweenness values.
+        """
+        G = nx.path_graph(5)
+        G.remove_edge(0, 1)
+
+        bc = nx.betweenness_centrality(G, normalized=False)
+        gbc_singletons = [0, 0, 2, 2, 0]
+        assert list(bc.values()) == gbc_singletons
+
+        many_groups = [[node] for node in G]
+        results = nx.group_betweenness_centrality(G, many_groups, normalized=False)
+        assert results == gbc_singletons
+
     def test_group_betweenness_disconnected_graph(self):
         """
         Group betweenness centrality in a disconnected graph


### PR DESCRIPTION
This PR builds on the group betweenness of the sigma typo #8879. That PR should be merged first. It doesn't interact with #8880 and so can be reviewed separately.

This fixes the if-logic in `group_betweeness_centrality` to no longer skip all 3 adjustments when considering a group node `v` when a denominator terms for any of the 3 is zero. Only the adjustment that has a zero divisor should be ignored.

Tests from #8666 are included and fixed.
Fixes #8827

The if-structure was getting long and repetitive and hard to read -- and it involved many lookups in the inner loop that only changed when an outer loop changed. So I restructured the nested loops. The outer loop must be over `v` so `PB_m[v][v]` is correctly updated when it is added to the total `GBC`. So the nesting stays the same.  But at each nesting level we now store the lookups that don't depend on the next inner level. At the core we have 3 if-clauses for the 3 kinds of adjustments that might be needed:  Order `x-v-y`, Order `v-x-y` and Order `x-y-v`. The adjustments are made inside each of the 3 if statements. I'm hoping that is easier to read than initializing the changes to 0, using the if to update them to nonzero and then applying the change in every case. Here whenever the change would have been zero, we just don't do the adjustment.

The extra dicts `sigma_m_v` and `PB_m_v` are not needed -- they duplicated `sigma_m` and `PB_m` in case we needed an old value before the updating overwrote it. That was written in the pseudo code of the article. But we had ordered the assignment statements so the extra copy was not needed. So I just removed them. We update the `*_m` dicts directly.

This fix allows the new tests to pass. So we are getting correct answers when we get answers now.
We still don't have the KeyErrors handled. Thats next.

Still to do:
- [ ] test and fix cases where not strongly connected directed graphs give KeyErrors.
- [ ] Discover the meaning of keyword `endpoints=True` and figure out how to make it meaningful, or remove that option.
- [ ] propagate these test changes to `prominent_group_*`, `group_degree_*` and `group_closeness_*`.