### PR TITLE
BUG: Handle KeyErrors in directed not strongly-connected group_betweenness_centrality

### DIFF
--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -116,7 +116,7 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
     """
     GBC = []  # initialize betweenness
     list_of_groups = True
-    #  check weather C contains one or many groups
+    # check whether C contains one or many groups
     if any(el in G for el in C):
         C = [C]
         list_of_groups = False
@@ -124,51 +124,55 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
     if set_v - G.nodes:  # element(s) of C not in G
         raise nx.NodeNotFound(f"The node(s) {set_v - G.nodes} are in C but not in G.")
 
-    # pre-processing
+    # pre-process dict-of-dicts: path btwn(PB), short path counts(sigma), distances(D)
     PB, sigma, D = _group_preprocessing(G, set_v, weight)
 
-    # the algorithm for each group
+    # Run the algorithm for each group
     for group in C:
         group = set(group)  # set of nodes in group
-        # initialize the matrices of the sigma and the PB
+        # initialize the matrices sigma_m and PB_m (path betweenness)
         GBC_group = 0
         sigma_m = deepcopy(sigma)
         PB_m = deepcopy(PB)
         for v in group:
-            # store lookups and set
+            # main point of this whole loop!
+            GBC_group += PB_m[v][v]
+
+            # store lookups
             Dv = D[v]
             PB_v = PB_m[v]
             sig_v = sigma_m[v]
-            group_in_Dv = group & Dv.keys()
 
-            GBC_group += PB_m[v][v]
-            for x in group_in_Dv:
-                # store lookups
+            for x in group:
+                # store lookups and set
                 Dx = D[x]
                 PB_x = PB_m[x]
                 sig_x = sigma_m[x]
                 sig_xv = sig_x[v]
                 sig_vx = sig_v[x]
+                x_in_Dv = x in Dv
+                v_in_Dx = v in Dx
 
-                # ensure y is in Dx otherwise v is not in path with x and y
-                for y in group_in_Dv & Dx.keys():
+                # ensure y is in Dx otherwise all 3 Orders will not occur
+                for y in group & Dx.keys():
                     # store lookups
                     Dy = D[y]
-                    sig_y = sigma_m[y]
                     sig_xy = sig_x[y]
                     sig_vy = sig_v[y]
+                    v_in_Dy = v in Dy
+                    y_in_Dv = y in Dv
 
-                    # Order x-y-v
-                    if Dx[v] == Dx[y] + Dy[v] and sig_xv:
+                    # Order x-y-v  If v_in_Dy then v_in_Dx for sure.
+                    if v_in_Dy and Dx[v] == Dx[y] + Dy[v] and sig_xv:
                         if y != v:
-                            PB_x[y] -= PB_x[v] * sig_xy * sig_y[v] / sig_xv
-                    # Order v-x-y
-                    if Dv[y] == Dv[x] + Dx[y] and sig_vy:
+                            PB_x[y] -= PB_x[v] * sig_xy * sigma_m[y][v] / sig_xv
+                    # Order v-x-y  If x_in_Dv then y_in_Dv for sure.
+                    if x_in_Dv and Dv[y] == Dv[x] + Dx[y] and sig_vy:
                         if x != v:
                             # fraction of v->y paths that pass through x
                             PB_x[y] -= PB_v[y] * sig_vx * sig_xy / sig_vy
                     # order x-v-y
-                    if Dx[y] == Dx[v] + Dv[y] and sig_xy:
+                    if v_in_Dx and y_in_Dv and Dx[y] == Dx[v] + Dv[y] and sig_xy:
                         sig_xvy = sig_xv * sig_vy
                         PB_x[y] *= 1 - sig_xvy / sig_xy
                         sig_x[y] -= sig_xvy

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -20,6 +20,15 @@ class TestGroupBetweennessCentrality:
         b_answer = 3.0
         assert b == b_answer
 
+    def test_group_betweenness_guard_against_keyerror(self):
+        """
+        Check for KeyErrors in D[u][v] inside group_betweenness_centrality
+        """
+        G = nx.path_graph(6, create_using=nx.DiGraph)
+        # y_in_Dx is enforced by the loop bounds. (KeyError if not enforced)
+        # Also checks v_in_Dy, y_in_Dv, x_in_Dv and v_in_Dx. Note: do not need x_in_Dy
+        assert 2 == nx.group_betweenness_centrality(G, [2, 3, 4], normalized=False)
+
     def test_group_betweenness_with_endpoints(self):
         """
         Group betweenness centrality for single node group


### PR DESCRIPTION
This PR tests and fixes KeyErrors in using the `D` dict-of-dicts for group_betweenness_centrality.
The first commit adds the test -- I was pleased to find that a path graph with the group being an
interior 3-path segment tested all the KeyErrors needed.

**The fix:**    (Note: I use e.g. `Dv = D[v]`, to pre-lookup and name the outer dicts)
D[x][y] is needed for all 3 cases where adjustment of counts occurs.
So I made the for-loop over `y` only loop over keys in `D[x]` (and in the group). 
The case `D[y][x]` is not used. We are looking for where `v` fits into a path from `x` to `y`.
So we don't care about `y` to `x`. Note that the loop will cover the `y` to `x` path
eventually with the names switched. So we do get that case in another iteration of the loop.

Of the remaining cases, `x_in_Dv` and `v_in_Dx` are stored in the middle loop (where x and v are known).
Then `y_in_Dv` and `v_in_Dy` are stored in the inner loop. Neither of these save much time -- but I found it
much easier to read `y_in_Dx` than `y in Dx` next to the rest of the multiple phrase if-condition. 
The underscores hold that operation together -- and there could be a very small help from pre-computing.

The resulting lines are like:
`if x_in_Dv and Dv[y] == Dv[x] + Dx[y] and sig_vy:`
A nearby comment points out that `y_in_Dv` must hold if `x_in_Dv`. The reason is that y is a descendant of x. So if x is a descendant of v, y is also a descendant of v. So we only need one `D` membership check in the first two cases and two checks in the third case. The `sig_vy` part of the if-condition ensures that we skip when division by zero would occur.

This treatment allows the tests to pass!

Also note that we recently included the example from #8666 by @amcandio as a test. It is passing here without KeyError (and with the correct value of `1` instead of `3`). That bug was already fixed before this PR. But that test raised a KeyError in #8854 and doesn't with this approach.

We still have on our list these two points:
- [ ] Discover the meaning of keyword `endpoints=True` and figure out how to make it meaningful, or remove that option.
- [ ] propagate these test changes to `prominent_group_*`, `group_degree_*` and `group_closeness_*`.