### PR TITLE
BUG: correct normalization of group betweenness centrality when endpoints is true

### DIFF
--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -43,12 +43,16 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
       A NetworkX graph.
 
     C : list or set or list of lists or list of sets
-      A group or a list of groups containing nodes which belong to G, for which group betweenness
-      centrality is to be calculated.
+      A group or a list of groups containing nodes which belong to G,
+      for which group betweenness centrality is to be calculated.
 
     normalized : bool, optional (default=True)
-      If True, group betweenness is normalized by `1/((|V|-|C|)(|V|-|C|-1))`
-      where `|V|` is the number of nodes in G and `|C|` is the number of nodes in C.
+      If True, group betweenness is normalized by $1/(N_{out}(N_{out}-1))$
+      where $N_{out}$ is the number of nodes in `G` that are not in `C`.
+      This ensures the reported value is between 0 and 1.
+      If `endpoints` is True, the normalization uses all nodes in `G`.
+      The reported value is then between $2N_{in}/(N-1)$ and 1 where $N_{in}$
+      is the number of nodes in `C` and $N$ the number of nodes in `G`.
 
     weight : None or string, optional (default=None)
       If None, all edge weights are considered equal.
@@ -56,17 +60,32 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
       The weight of an edge is treated as the length or distance between the two sides.
 
     endpoints : bool, optional (default=False)
-      If True include the endpoints in the shortest path counts.
+      By default, only node-pairs that are both not in `C` are counted for
+      group betweenness centrality. The count is how many non-`C` node-pairs have
+      nodes from `C` "between" them on a shortest path.
+
+      When ``endpoints=True``, we also count node-pairs with one or both nodes
+      in `C` while considering endpoint nodes as being between the node-pairs.
+      So we count paths that start in `C` whether or not they pass through
+      any other nodes in `C`. This adds centrality to large groups without any
+      reference to the connectivity of the group. The minimum normalized score
+      is $N_{in}(N_{in}-1)/(N(N-1))$ instead of 0. For that reason, this feature
+      is rarely used.
+
+      We don't currently support considering node-pairs with nodes in `C` without
+      also counting their endpoints. Nor do we support counting endpoints while
+      only considering node-pairs that are both not in `C`. This keyword indicates
+      both coutning endpoints of paths and allowing node-pairs in C.
 
     Raises
     ------
     NodeNotFound
-       If node(s) in C are not present in G.
+       If node(s) in `C` are not present in `G`.
 
     Returns
     -------
     betweenness : list of floats or float
-       If C is a single group then return a float. If C is a list with
+       If `C` is a single group then return a float. If `C` is a list with
        several groups then return a list of group betweenness centralities.
 
     See Also
@@ -75,11 +94,10 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
 
     Notes
     -----
-    Group betweenness centrality is described in [1]_ and its importance discussed in [3]_.
-    The initial implementation of the algorithm is mentioned in [2]_. This function uses
-    an improved algorithm presented in [4]_.
+    Group betweenness centrality is defined in [1]_ and discussed in [3]_.
+    The algorithm is described in [2]_ and is based on techniques mentioned in [4]_.
 
-    The number of nodes in the group must be a maximum of n - 2 where `n`
+    The number of nodes in the group must be a maximum of ``N - 2`` where ``N``
     is the total number of nodes in the graph.
 
     For weighted graphs the edge weights must be greater than zero.
@@ -123,6 +141,10 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
     set_v = {node for group in C for node in group}
     if set_v - G.nodes:  # element(s) of C not in G
         raise nx.NodeNotFound(f"The node(s) {set_v - G.nodes} are in C but not in G.")
+
+    # pre-process connectedness for no endpoints treatment
+    is_directed = G.is_directed()
+    connected = nx.is_strongly_connected(G) if is_directed else nx.is_connected(G)
 
     # pre-process dict-of-dicts: path btwn(PB), short path counts(sigma), distances(D)
     PB, sigma, D = _group_preprocessing(G, set_v, weight)
@@ -180,20 +202,24 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
                             # update sig_xv for future y-values
                             sig_xv -= sig_xvy
         # endpoints
-        N, c = len(G), len(group)
-        if not endpoints:
+        N = len(G)
+        if endpoints:
+            Nscale = N
+        else:  # No endpoints -- usual case
+            N_in = len(group)
+            N_out = Nscale = N - N_in
             # if the graph is connected then subtract the endpoints from
             # the count for all the nodes in the graph. else count how many
             # nodes are connected to the group's nodes and subtract that.
-            if nx.is_directed(G):
-                if nx.is_strongly_connected(G):
-                    extra = c * (2 * N - c - 1)
-                else:
-                    # count paths for group to or from anything
-                    reachables = ((u, v) for u in G for v in D[u] if v != u)
-                    extra = sum(1 for u, v in reachables if (u in group or v in group))
-            elif nx.is_connected(G):
-                extra = c * (2 * N - c - 1)
+            if connected:
+                # N_in * (N_out + N_in-1 + N_out) : in*out + in*(in-1) + out*in
+                # same as N_in * (N-1 + N_out) : in*(all-1) + out*in
+                # paper uses equiv: N_in * (2 * N - N_in - 1)
+                extra = N_in * (N - 1 + N_out)
+            elif is_directed:
+                # count paths for group to or from anything
+                reachables = ((u, v) for u in G for v in D[u] if v != u)
+                extra = sum(1 for u, v in reachables if (u in group or v in group))
             else:
                 # count paths for group to anything
                 # (use 2 if v not in group to shorten reachables)
@@ -202,14 +228,10 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
 
             GBC_group -= extra
 
-        # normalized
+        # scale down for normalized or by 2 for undirected
         if normalized:
-            N_out = N - c
-            scale = 1 / (N_out * (N_out - 1))
-            GBC_group *= scale
-
-        # If undirected than count only the undirected edges
-        elif not G.is_directed():
+            GBC_group /= Nscale * (Nscale - 1)
+        elif not is_directed:
             GBC_group /= 2
 
         GBC.append(GBC_group)
@@ -325,10 +347,10 @@ def prominent_group(
 
     Notes
     -----
-    Group betweenness centrality is described in [1]_ and its importance discussed in [3]_.
+    Group betweenness centrality is defined in [1]_ and discussed in [3]_.
     The algorithm is described in [2]_ and is based on techniques mentioned in [4]_.
 
-    The number of nodes in the group must be a maximum of ``n - 2`` where ``n``
+    The number of nodes in the group must be a maximum of ``N - 2`` where ``N``
     is the total number of nodes in the graph.
 
     For weighted graphs the edge weights must be greater than zero.
@@ -620,7 +642,7 @@ def group_closeness_centrality(G, S, weight=None):
     It is assumed that 1 / 0 is 0 (required in the case of directed graphs,
     or when a shortest path length is 0).
 
-    The number of nodes in the group must be a maximum of n - 1 where `n`
+    The number of nodes in the group must be a maximum of ``N - 1`` where ``N``
     is the total number of nodes in the graph.
 
     For directed graphs, the incoming distance is utilized here. To use the

--- a/networkx/algorithms/centrality/group.py
+++ b/networkx/algorithms/centrality/group.py
@@ -116,7 +116,7 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
     """
     GBC = []  # initialize betweenness
     list_of_groups = True
-    #  check weather C contains one or many groups
+    # check whether C contains one or many groups
     if any(el in G for el in C):
         C = [C]
         list_of_groups = False
@@ -124,51 +124,55 @@ def group_betweenness_centrality(G, C, normalized=True, weight=None, endpoints=F
     if set_v - G.nodes:  # element(s) of C not in G
         raise nx.NodeNotFound(f"The node(s) {set_v - G.nodes} are in C but not in G.")
 
-    # pre-processing
+    # pre-process dict-of-dicts: path btwn(PB), short path counts(sigma), distances(D)
     PB, sigma, D = _group_preprocessing(G, set_v, weight)
 
-    # the algorithm for each group
+    # Run the algorithm for each group
     for group in C:
         group = set(group)  # set of nodes in group
-        # initialize the matrices of the sigma and the PB
+        # initialize the matrices sigma_m and PB_m (path betweenness)
         GBC_group = 0
         sigma_m = deepcopy(sigma)
         PB_m = deepcopy(PB)
         for v in group:
-            # store lookups and set
+            # main point of this whole loop!
+            GBC_group += PB_m[v][v]
+
+            # store lookups
             Dv = D[v]
             PB_v = PB_m[v]
             sig_v = sigma_m[v]
-            group_in_Dv = group & Dv.keys()
 
-            GBC_group += PB_m[v][v]
-            for x in group_in_Dv:
-                # store lookups
+            for x in group:
+                # store lookups and set
                 Dx = D[x]
                 PB_x = PB_m[x]
                 sig_x = sigma_m[x]
                 sig_xv = sig_x[v]
                 sig_vx = sig_v[x]
+                x_in_Dv = x in Dv
+                v_in_Dx = v in Dx
 
-                # ensure y is in Dx otherwise v is not in path with x and y
-                for y in group_in_Dv & Dx.keys():
+                # ensure y is in Dx otherwise all 3 Orders will not occur
+                for y in group & Dx.keys():
                     # store lookups
                     Dy = D[y]
-                    sig_y = sigma_m[y]
                     sig_xy = sig_x[y]
                     sig_vy = sig_v[y]
+                    v_in_Dy = v in Dy
+                    y_in_Dv = y in Dv
 
-                    # Order x-y-v
-                    if Dx[v] == Dx[y] + Dy[v] and sig_xv:
+                    # Order x-y-v  If v_in_Dy then v_in_Dx for sure.
+                    if v_in_Dy and Dx[v] == Dx[y] + Dy[v] and sig_xv:
                         if y != v:
-                            PB_x[y] -= PB_x[v] * sig_xy * sig_y[v] / sig_xv
-                    # Order v-x-y
-                    if Dv[y] == Dv[x] + Dx[y] and sig_vy:
+                            PB_x[y] -= PB_x[v] * sig_xy * sigma_m[y][v] / sig_xv
+                    # Order v-x-y  If x_in_Dv then y_in_Dv for sure.
+                    if x_in_Dv and Dv[y] == Dv[x] + Dx[y] and sig_vy:
                         if x != v:
                             # fraction of v->y paths that pass through x
                             PB_x[y] -= PB_v[y] * sig_vx * sig_xy / sig_vy
                     # order x-v-y
-                    if Dx[y] == Dx[v] + Dv[y] and sig_xy:
+                    if v_in_Dx and y_in_Dv and Dx[y] == Dx[v] + Dv[y] and sig_xy:
                         sig_xvy = sig_xv * sig_vy
                         PB_x[y] *= 1 - sig_xvy / sig_xy
                         sig_x[y] -= sig_xvy

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -20,6 +20,15 @@ class TestGroupBetweennessCentrality:
         b_answer = 3.0
         assert b == b_answer
 
+    def test_group_betweenness_guard_against_keyerror(self):
+        """
+        Check for KeyErrors in D[u][v] inside group_betweenness_centrality
+        """
+        G = nx.path_graph(6, create_using=nx.DiGraph)
+        # y_in_Dx is enforced by the loop bounds. (KeyError if not enforced)
+        # Also checks v_in_Dy, y_in_Dv, x_in_Dv and v_in_Dx. Note: do not need x_in_Dy
+        assert 2 == nx.group_betweenness_centrality(G, [2, 3, 4], normalized=False)
+
     def test_group_betweenness_with_endpoints(self):
         """
         Group betweenness centrality for single node group

--- a/networkx/algorithms/centrality/tests/test_group.py
+++ b/networkx/algorithms/centrality/tests/test_group.py
@@ -29,17 +29,34 @@ class TestGroupBetweennessCentrality:
         # Also checks v_in_Dy, y_in_Dv, x_in_Dv and v_in_Dx. Note: do not need x_in_Dy
         assert 2 == nx.group_betweenness_centrality(G, [2, 3, 4], normalized=False)
 
-    def test_group_betweenness_with_endpoints(self):
+    @pytest.mark.parametrize("create_using", [nx.Graph, nx.DiGraph])
+    def test_group_betweenness_with_endpoints(self, create_using):
         """
-        Group betweenness centrality for single node group
+        Impact of endpoints on group betweenness centrality
         """
-        G = nx.path_graph(5)
+        G = nx.path_graph(5, create_using=create_using)
+        nx.add_path(G, [3, 2, 1])  # only affects DiGraph
         C = [1]
-        b = nx.group_betweenness_centrality(
-            G, C, weight=None, normalized=False, endpoints=True
-        )
-        b_answer = 7.0
-        assert b == b_answer
+        gbc = nx.group_betweenness_centrality(G, C, normalized=False, endpoints=False)
+        assert gbc == 3
+        egbc = nx.group_betweenness_centrality(G, C, normalized=False, endpoints=True)
+        assert egbc == (9 if G.is_directed() else 7)
+
+        C = [2]
+        gbc = nx.group_betweenness_centrality(G, C, normalized=False, endpoints=False)
+        assert gbc == (5 if G.is_directed() else 4)
+        egbc = nx.group_betweenness_centrality(G, C, normalized=False, endpoints=True)
+        assert egbc == (11 if G.is_directed() else 8)
+
+    @pytest.mark.parametrize("create_using", [nx.Graph, nx.DiGraph])
+    def test_group_betweenness_endpoints_normalized(self, create_using):
+        G = nx.path_graph(7, create_using=create_using)
+        C = [1, 3, 5]  # check group of length >2
+        ans = 0.5 if G.is_directed() else 1  # for DiGraph, only one way (half) cross C
+        gbc = nx.group_betweenness_centrality(G, C, normalized=True, endpoints=False)
+        assert gbc == ans
+        ngbc = nx.group_betweenness_centrality(G, C, normalized=True, endpoints=True)
+        assert ngbc == ans
 
     def test_group_betweenness_normalized(self):
         """
@@ -48,11 +65,39 @@ class TestGroupBetweennessCentrality:
         """
         G = nx.path_graph(5)
         C = [1, 3]
-        b = nx.group_betweenness_centrality(
-            G, C, weight=None, normalized=True, endpoints=False
-        )
-        b_answer = 1.0
-        assert b == b_answer
+        assert nx.group_betweenness_centrality(G, C, normalized=True) == 1
+
+    @pytest.mark.parametrize(
+        "create_using, gbc, ngbc",
+        [(nx.Graph, 6, 1), (nx.DiGraph, 7, 7 / 12)],
+    )
+    def test_group_betweenness_normalized_connected(self, create_using, gbc, ngbc):
+        """
+        Normalization for group with 3 nodes
+        """
+        G = nx.path_graph(7, create_using=create_using)
+        nx.add_path(G, [6, 5, 4])  # only affects DiGraph
+        C = [1, 3, 5]
+        assert nx.group_betweenness_centrality(G, C, normalized=False) == gbc
+        ngbc = pytest.approx(ngbc)
+        assert nx.group_betweenness_centrality(G, C, normalized=True) == ngbc
+        # undirected: 4*3/2=6 nongroup node-pairs, 6 reachable through C. 6/6=1
+        # directed: 4*2=12 nongroup node-pairs, 7 of them through C. 7/12=0.58333
+
+    @pytest.mark.parametrize(
+        "create_using, gbc, ngbc",
+        [(nx.Graph, 6, 6 / 15), (nx.DiGraph, 6, 6 / 30)],
+    )
+    def test_group_betweenness_normalized_disconnected(self, create_using, gbc, ngbc):
+        # disconnected
+        G = nx.path_graph(5, create_using=create_using)
+        nx.add_path(G, range(6, 11))
+        nx.add_path(G, [3, 2, 1])  # only affects DiGraph
+        C = [1, 3, 7, 9]
+        assert nx.group_betweenness_centrality(G, C, normalized=False) == gbc
+        assert nx.group_betweenness_centrality(G, C, normalized=True) == ngbc
+        # undirected: 6*5/2=15 nongroup node-pairs, 6 reachable through C. 6/15=0.4
+        # directed: 6*5=30 nongroup node-pairs. 6 reachable through C. 6/30=0.2
 
     def test_two_group_betweenness_value_zero(self):
         """


### PR DESCRIPTION
The keyword `endpoints` in `group_betweenness_centrality` does more than what "endpoints" does for `betweenness_centrality`.  This PR makes it more clear what `endpoints=True` implies and corrects a mistake in the normalization in this case.

In `betweenness_centrality` the `endpoints` keyword causes node-pairs (and their paths) to count as "passing through" the path's endpoints. So a node counts as "between" itself and any other node. [call this the **endpoints rule**]

In `group_betweenness_centrality` the keyword `endpoints=True` tells us to use **endpoints rule**, but also tells us to examine node-pairs from all nodes rather than only node-pairs from outside `C`. So paths that start or end in `C` are now counted. [call this **all_node_pairs rule**].

I think these two rules are orthogonal, but we haven't implemented all combinations. The default (`endpoints=False`) only considers node-pairs that are outside `C`. It doesn't use the **all_node_pairs rule**. Note that when we consider only paths with endpoints outside `C`, then it doesn't matter whether or not we include the endpoints. All the endpoints are not in `C` by design. So the **endpoints rule** is irrelevant when we don't use the **all_node_pairs rule**.

But if we do use the **all_node_pairs rule**, then we have to figure out how to count the node-pairs that start/end in `C`. Currently, our `endpoints` keyword turns on both **all_node_pairs rule** and **endpoints rule**. So every node-pair that involves a node from `C` counts as passing through `C`.  We don't even have to look beyond connectivity. If `C` has `N_{in}` nodes and is connected, we will add `N_{in}(N_{in}-1)` paths to the raw score. If `C` is not (strongly)connected, we have to count how many node-pairs are reachable. But we don't have to look at the shortest paths because we know an endpoint is in `C`. Even after normalizing, there is a positive minimum centrality score for the group based on its size even if no other paths pass through it. This is a strange way to measure betweenness.

Brandes argues that sometimes we want the original sender of the information to be included in the "between" category. After-all they know the information and have to do some work to send it. That's a good argument for the **endpoints rule**, but it doesn't do much to help us justify the **all_node_pairs rule**. None of the papers other than the Brandes paper use the **all_node_pairs rule**, so the **endpoints rule** is irrelevant.

The option missing from the discussion is to allow the **all_node_pairs rule** while turning off the **endpoints rule**.  So, we count paths between any node pairs if the interior of the path involves anode in `C`. Endpoints are not considered as "between" nodes on the path. But paths from/to nodes in `C` do get counted if another node from `C` lies on the shortest path.  I haven't seen this discussed anywhere. It comes up because it completes the set of options we could offer. It might model a group that is crucial to propagating information even within the group. We don't care about sending/receiving, only propagating. And we care about both within-group paths and paths from/to nodes outside the group. I'm not sure how hard this would be to do.

This PR does NOT implement any such system for group betweenness centrality. It just makes the docs more clear about what `endpoints=True` means. And it corrects the normalization for that case.

Normalization:  The normalization divides by the maximal number of node-pairs that could be counted. That is `N(N-1)` when using the **all_node_pairs rule** and `N_{out}(N_{out}-1)` otherwise. Current code uses the same factor whether endpoints is True or False. This PR changes the scaling for normalizing the `endpoints=True` case to `N(N-1)`. 

Still to do:
- [ ] propagate these test changes to `prominent_group_*`, `group_degree_*` and `group_closeness_*`.