### PR TITLE
DOC: Fix multiadjlist docstring examples

### DIFF
--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -365,43 +365,54 @@ def read_multiline_adjlist(
 
     Returns
     -------
-    G: NetworkX graph
+    G : NetworkX graph
 
     Examples
     --------
+    >>> from pathlib import Path
+    >>> import tempfile
+    >>> tmp_path = Path(tempfile.gettempdir())
+
     >>> G = nx.path_graph(4)
-    >>> nx.write_multiline_adjlist(G, "test.multi_adjlistP4")
-    >>> G = nx.read_multiline_adjlist("test.multi_adjlistP4")
+    >>> fpath = tmp_path / "test.multi_adjlistP4"
+    >>> nx.write_multiline_adjlist(G, fpath)
+    >>> H = nx.read_multiline_adjlist(fpath)
+
+    Data read from the file are interpreted as strings by default, regardless of
+    the node type of the original graph.
+
+    >>> G.edges
+    EdgeView([(0, 1), (1, 2), (2, 3)])
+    >>> H.edges
+    EdgeView([('0', '1'), ('1', '2'), ('2', '3')])
+
+    The node data can be converted to a specific type with the `nodetype`
+    parameter.
+
+    >>> H = nx.read_multiline_adjlist(fpath, nodetype=int)
+    >>> H.edges
+    EdgeView([(0, 1), (1, 2), (2, 3)])
+    >>> nx.utils.edges_equal(G.edges, H.edges)
+    True
+
+    Since nodes must be hashable, the function `nodetype` must return hashable
+    types (e.g. int, float, str, frozenset - or tuples of those, etc.)
+
+    The optional `create_using` parameter indicates the type of NetworkX graph
+    created. The default is ``nx.Graph``, an undirected graph. To read the data
+    as a directed graph use:
+
+    >>> H = nx.read_multiline_adjlist(fpath, create_using=nx.DiGraph)
+    >>> H.is_directed()
+    True
 
     The path can be a file or a string with the name of the file. If a
-    file s provided, it has to be opened in 'rb' mode.
+    file is provided, it has to be opened in 'rb' mode.
 
-    >>> fh = open("test.multi_adjlistP4", "rb")
-    >>> G = nx.read_multiline_adjlist(fh)
-
-    Filenames ending in .gz or .bz2 will be compressed.
-
-    >>> nx.write_multiline_adjlist(G, "test.multi_adjlistP4.gz")
-    >>> G = nx.read_multiline_adjlist("test.multi_adjlistP4.gz")
-
-    The optional nodetype is a function to convert node strings to nodetype.
-
-    For example
-
-    >>> G = nx.read_multiline_adjlist("test.multi_adjlistP4", nodetype=int)
-
-    will attempt to convert all nodes to integer type.
-
-    The optional edgetype is a function to convert edge data strings to
-    edgetype.
-
-    >>> G = nx.read_multiline_adjlist("test.multi_adjlistP4")
-
-    The optional create_using parameter is a NetworkX graph container.
-    The default is Graph(), an undirected graph.  To read the data as
-    a directed graph use
-
-    >>> G = nx.read_multiline_adjlist("test.multi_adjlistP4", create_using=nx.DiGraph)
+    >>> with open(fpath, "rb") as fh:
+    ...     H = nx.read_multiline_adjlist(fh, nodetype=int)
+    >>> H.edges
+    EdgeView([(0, 1), (1, 2), (2, 3)])
 
     Notes
     -----

--- a/networkx/readwrite/multiline_adjlist.py
+++ b/networkx/readwrite/multiline_adjlist.py
@@ -157,18 +157,46 @@ def write_multiline_adjlist(G, path, delimiter=" ", comments="#", encoding="utf-
 
     Examples
     --------
+    >>> from pathlib import Path
+    >>> import tempfile
+    >>> tmp_path = Path(tempfile.gettempdir())
+
     >>> G = nx.path_graph(4)
-    >>> nx.write_multiline_adjlist(G, "test.multi_adjlist")
+    >>> fpath = tmp_path / "test.multi_adjlist"
+    >>> nx.write_multiline_adjlist(G, fpath)
+
+    View the data as stored in the file, ignoring header lines which start with
+    the comment character ("#" by default):
+
+    >>> with open(fpath) as fh:
+    ...     lines_from_file = fh.readlines()
+    >>> print("".join(l for l in lines_from_file if not l.startswith("#")))
+    0 1
+    1 {}
+    1 1
+    2 {}
+    2 1
+    3 {}
+    3 0
+    <BLANKLINE>
 
     The path can be a file handle or a string with the name of the file. If a
     file handle is provided, it has to be opened in 'wb' mode.
 
-    >>> fh = open("test.multi_adjlist2", "wb")
-    >>> nx.write_multiline_adjlist(G, fh)
-
-    Filenames ending in .gz or .bz2 will be compressed.
-
-    >>> nx.write_multiline_adjlist(G, "test.multi_adjlist.gz")
+    >>> fpath = tmp_path / "test.multi_adjlist2"
+    >>> with open(fpath, "wb") as fh:
+    ...     nx.write_multiline_adjlist(G, fh)
+    >>> with open(fpath) as fh:
+    ...     lines_from_file = fh.readlines()
+    >>> print("".join(l for l in lines_from_file if not l.startswith("#")))
+    0 1
+    1 {}
+    1 1
+    2 {}
+    2 1
+    3 {}
+    3 0
+    <BLANKLINE>
 
     See Also
     --------


### PR DESCRIPTION
Update the multiline_adjlist docstring examples to use the `tempfile` pattern.

I made an effort here to match the updates to the `read/write_adjlist` docstrings as much as possible (see #8875).

There was one additional feature for `read_multiline_adjlist` that I pulled out of the examples related to the `edgetype` parameter. I did so because I don't think the code related to reading with a specified edge type is working properly. That's a separate issue/PR though!