### PR TITLE
fix: handle empty candidate sets in ISMAGS.largest_common_subgraph

### DIFF
--- a/networkx/algorithms/isomorphism/ismags.py
+++ b/networkx/algorithms/isomorphism/ismags.py
@@ -836,13 +836,16 @@ class ISMAGS:
 
         candidate_sets = self._get_node_color_candidate_sets(MONO_fits=operator.eq)
 
-        if any(candidate_sets.values()):
-            relevant_parts = self._sgn_partition[: self.N_node_colors]
-            to_be_mapped = {frozenset(n for p in relevant_parts for n in p)}
+        relevant_parts = self._sgn_partition[: self.N_node_colors]
+        to_be_mapped = {frozenset(n for p in relevant_parts for n in p)}
+
+        if any(to_be_mapped):
             yield from self._largest_common_subgraph(
                 candidate_sets, constraints, to_be_mapped
             )
         else:
+            # No subgraph node shares a color with any graph node, so there is
+            # no non-empty common subgraph to be found.
             return
 
     def analyze_subgraph_symmetry(self):

--- a/networkx/algorithms/isomorphism/tests/test_ismags.py
+++ b/networkx/algorithms/isomorphism/tests/test_ismags.py
@@ -634,6 +634,41 @@ class TestLargestCommonSubgraph:
         assert ismags._sgn_partition == [{1}, {0}, {2}]
         assert ismags._gn_partition == [{5}, set(), set(), {2}]
 
+    def test_no_common_colors(self):
+        # gh-8885: when no subgraph node shares a color with any graph node,
+        # largest_common_subgraph used to raise ValueError from an empty
+        # min() call instead of reporting that no common subgraph exists.
+        graph = nx.Graph()
+        graph.add_node(0)
+
+        subgraph = nx.Graph()
+        subgraph.add_node(0, attr1=0)
+
+        nodematch = nx.isomorphism.categorical_node_match(["attr1"], [None])
+        ismags = iso.ISMAGS(graph, subgraph, node_match=nodematch)
+        assert ismags.N_node_colors == 0
+
+        assert list(ismags.largest_common_subgraph(symmetry=True)) == []
+        assert list(ismags.largest_common_subgraph(symmetry=False)) == []
+
+    def test_no_common_colors_multi_node(self):
+        # Same as test_no_common_colors, but with several nodes on each side
+        # to make sure the guard covers non-trivial to_be_mapped sets too.
+        graph = nx.Graph([(0, 1), (1, 2)])
+        for n in graph:
+            graph.nodes[n]["attr1"] = "g"
+
+        subgraph = nx.Graph([(0, 1), (1, 2)])
+        for n in subgraph:
+            subgraph.nodes[n]["attr1"] = "sg"
+
+        nodematch = nx.isomorphism.categorical_node_match(["attr1"], [None])
+        ismags = iso.ISMAGS(graph, subgraph, node_match=nodematch)
+        assert ismags.N_node_colors == 0
+
+        assert list(ismags.largest_common_subgraph(symmetry=True)) == []
+        assert list(ismags.largest_common_subgraph(symmetry=False)) == []
+
 
 def is_isomorphic(G, SG, edge_match=None, node_match=None):
     return iso.ISMAGS(G, SG, node_match, edge_match).is_isomorphic()


### PR DESCRIPTION
fixes #8885

`largest_common_subgraph()` crashes with `ValueError: min() iterable argument is empty` when subgraph and graph dont share any node colors. the guard on line 839 was checking `any(candidate_sets.values())` wich is allways truthy because the values are singleton sets even when the inner frozenset is empty.

fixed it to check `any(to_be_mapped)` insted — if theres nothing to map, yield nothing and return. added two tests for the case where no colors overlap.