### PR TITLE
BUG: Hold the graph weakly in cached edge and degree views

### DIFF
--- a/networkx/classes/graph.py
+++ b/networkx/classes/graph.py
@@ -14,7 +14,7 @@ from functools import cached_property
 import networkx as nx
 from networkx import convert
 from networkx.classes.coreviews import AdjacencyView
-from networkx.classes.reportviews import DegreeView, EdgeView, NodeView
+from networkx.classes.reportviews import DegreeView, EdgeView, NodeView, _nbunch_iter
 
 __all__ = ["Graph"]
 
@@ -2049,33 +2049,4 @@ class Graph:
         or None, a :exc:`NetworkXError` is raised.  Also, if any object in
         nbunch is not hashable, a :exc:`NetworkXError` is raised.
         """
-        if nbunch is None:  # include all nodes via iterator
-            bunch = iter(self._adj)
-        elif nbunch in self:  # if nbunch is a single node
-            bunch = iter([nbunch])
-        else:  # if nbunch is a sequence of nodes
-
-            def bunch_iter(nlist, adj):
-                try:
-                    for n in nlist:
-                        if n in adj:
-                            yield n
-                except TypeError as err:
-                    exc, message = err, err.args[0]
-                    # capture error for non-sequence/iterator nbunch.
-                    if "iter" in message:
-                        exc = nx.NetworkXError(
-                            "nbunch is not a node or a sequence of nodes."
-                        )
-                    # capture single nodes that are not in the graph.
-                    if "object is not iterable" in message:
-                        exc = nx.NetworkXError(f"Node {nbunch} is not in the graph.")
-                    # capture error for unhashable node.
-                    if "hashable" in message:
-                        exc = nx.NetworkXError(
-                            f"Node {n} in sequence nbunch is not a valid node."
-                        )
-                    raise exc
-
-            bunch = bunch_iter(nbunch, self._adj)
-        return bunch
+        return _nbunch_iter(self._adj, nbunch)

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -191,6 +191,7 @@ Performance & pitfalls
   the precomputed degrees using ``degrees = dict(G.degree)``.
 """
 
+import weakref
 from abc import ABC
 from collections.abc import Mapping, Set
 
@@ -525,6 +526,31 @@ class DiDegreeView:
     >>> DVnbunch = G.degree(nbunch=(1, 2))
     >>> assert len(list(DVnbunch)) == 2  # iteration over nbunch only
     """
+
+    # See ``OutEdgeView._graph``: the graph is held weakly so that caching
+    # this view on the graph does not create a reference cycle.
+    @property
+    def _graph(self):
+        G = self._graph_ref()
+        if G is None:
+            raise ReferenceError(
+                "the graph this view was created from no longer exists"
+            )
+        return G
+
+    @_graph.setter
+    def _graph(self, G):
+        self._graph_ref = weakref.ref(G)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        del state["_graph_ref"]
+        state["_graph"] = self._graph  # a strong reference in the pickle
+        return state
+
+    def __setstate__(self, state):
+        self._graph = state.pop("_graph")  # rebuilds the weak reference
+        self.__dict__.update(state)
 
     def __init__(self, G, nbunch=None, weight=None):
         self._graph = G
@@ -1149,7 +1175,25 @@ class InMultiEdgeDataView(OutMultiEdgeDataView):
 class OutEdgeView(Set, Mapping, EdgeViewABC):
     """A EdgeView class for outward edges of a DiGraph"""
 
-    __slots__ = ("_adjdict", "_graph", "_nodes_nbrs")
+    __slots__ = ("_adjdict", "_graph_ref", "_nodes_nbrs")
+
+    # The graph caches this view (``G.edges`` is a ``cached_property``), so a
+    # strong ``_graph`` back-reference would make every graph whose views were
+    # ever read reclaimable only by the cyclic garbage collector. Hold the
+    # graph weakly instead: iteration and lookup only need ``_adjdict``, and
+    # the few paths that need the graph itself go through this property.
+    @property
+    def _graph(self):
+        G = self._graph_ref()
+        if G is None:
+            raise ReferenceError(
+                "the graph this view was created from no longer exists"
+            )
+        return G
+
+    @_graph.setter
+    def _graph(self, G):
+        self._graph_ref = weakref.ref(G)
 
     def __getstate__(self):
         return {"_graph": self._graph, "_adjdict": self._adjdict}

--- a/networkx/classes/reportviews.py
+++ b/networkx/classes/reportviews.py
@@ -223,6 +223,48 @@ __all__ = [
 ]
 
 
+def _dead_ref():
+    return None
+
+
+def _nbunch_iter(adj, nbunch=None):
+    """The body of ``Graph.nbunch_iter`` on an adjacency dict.
+
+    Views call this with the dict they hold so they never need the graph
+    object itself; ``Graph.nbunch_iter`` delegates here.
+    """
+    if nbunch is None:  # include all nodes via iterator
+        return iter(adj)
+    try:
+        single = nbunch in adj
+    except TypeError:
+        single = False
+    if single:  # if nbunch is a single node
+        return iter([nbunch])
+
+    def bunch_iter(nlist, adj):
+        try:
+            for n in nlist:
+                if n in adj:
+                    yield n
+        except TypeError as err:
+            exc, message = err, err.args[0]
+            # capture error for non-sequence/iterator nbunch.
+            if "iter" in message:
+                exc = nx.NetworkXError("nbunch is not a node or a sequence of nodes.")
+            # capture single nodes that are not in the graph.
+            if "object is not iterable" in message:
+                exc = nx.NetworkXError(f"Node {nbunch} is not in the graph.")
+            # capture error for unhashable node.
+            if "hashable" in message:
+                exc = nx.NetworkXError(
+                    f"Node {n} in sequence nbunch is not a valid node."
+                )
+            raise exc
+
+    return bunch_iter(nbunch, adj)
+
+
 # NodeViews
 class NodeView(Mapping, Set):
     """A NodeView class to act as G.nodes for a NetworkX Graph
@@ -540,12 +582,12 @@ class DiDegreeView:
 
     @_graph.setter
     def _graph(self, G):
-        self._graph_ref = weakref.ref(G)
+        self._graph_ref = weakref.ref(G) if G is not None else _dead_ref
 
     def __getstate__(self):
         state = self.__dict__.copy()
         del state["_graph_ref"]
-        state["_graph"] = self._graph  # a strong reference in the pickle
+        state["_graph"] = self._graph_ref()  # strong reference (or None) in the pickle
         return state
 
     def __setstate__(self, state):
@@ -556,22 +598,37 @@ class DiDegreeView:
         self._graph = G
         self._succ = G._succ if hasattr(G, "_succ") else G._adj
         self._pred = G._pred if hasattr(G, "_pred") else G._adj
-        self._nodes = self._succ if nbunch is None else list(G.nbunch_iter(nbunch))
+        self._nodes = (
+            self._succ if nbunch is None else list(_nbunch_iter(self._succ, nbunch))
+        )
         self._weight = weight
+
+    @classmethod
+    def _from_view(cls, view, nbunch, weight):
+        """A sibling view sharing ``view``'s dicts; needs no graph object."""
+        new = cls.__new__(cls)
+        new._graph_ref = view._graph_ref
+        new._succ = view._succ
+        new._pred = view._pred
+        new._nodes = (
+            new._succ if nbunch is None else list(_nbunch_iter(new._succ, nbunch))
+        )
+        new._weight = weight
+        return new
 
     def __call__(self, nbunch=None, weight=None):
         if nbunch is None:
             if weight == self._weight:
                 return self
-            return self.__class__(self._graph, None, weight)
+            return self._from_view(self, None, weight)
         try:
             if nbunch in self._nodes:
                 if weight == self._weight:
                     return self[nbunch]
-                return self.__class__(self._graph, None, weight)[nbunch]
+                return self._from_view(self, None, weight)[nbunch]
         except TypeError:
             pass
-        return self.__class__(self._graph, nbunch, weight)
+        return self._from_view(self, nbunch, weight)
 
     def __getitem__(self, n):
         weight = self._weight
@@ -908,7 +965,7 @@ class OutEdgeDataView(EdgeViewABC):
             self._nodes_nbrs = adjdict.items
         else:
             # dict retains order of nodes but acts like a set
-            nbunch = dict.fromkeys(viewer._graph.nbunch_iter(nbunch))
+            nbunch = dict.fromkeys(_nbunch_iter(adjdict, nbunch))
             self._nodes_nbrs = lambda: [(n, adjdict[n]) for n in nbunch]
         self._nbunch = nbunch
         self._data = data
@@ -1052,7 +1109,7 @@ class OutMultiEdgeDataView(OutEdgeDataView):
             self._nodes_nbrs = adjdict.items
         else:
             # dict retains order of nodes but acts like a set
-            nbunch = dict.fromkeys(viewer._graph.nbunch_iter(nbunch))
+            nbunch = dict.fromkeys(_nbunch_iter(adjdict, nbunch))
             self._nodes_nbrs = lambda: [(n, adjdict[n]) for n in nbunch]
         self._nbunch = nbunch
         self._data = data
@@ -1180,8 +1237,9 @@ class OutEdgeView(Set, Mapping, EdgeViewABC):
     # The graph caches this view (``G.edges`` is a ``cached_property``), so a
     # strong ``_graph`` back-reference would make every graph whose views were
     # ever read reclaimable only by the cyclic garbage collector. Hold the
-    # graph weakly instead: iteration and lookup only need ``_adjdict``, and
-    # the few paths that need the graph itself go through this property.
+    # graph weakly instead. Nothing in the view needs the graph object: it
+    # works from ``_adjdict`` alone, and ``_graph`` is kept only for pickling
+    # and for code that reaches through the view to its graph.
     @property
     def _graph(self):
         G = self._graph_ref()
@@ -1193,10 +1251,10 @@ class OutEdgeView(Set, Mapping, EdgeViewABC):
 
     @_graph.setter
     def _graph(self, G):
-        self._graph_ref = weakref.ref(G)
+        self._graph_ref = weakref.ref(G) if G is not None else _dead_ref
 
     def __getstate__(self):
-        return {"_graph": self._graph, "_adjdict": self._adjdict}
+        return {"_graph": self._graph_ref(), "_adjdict": self._adjdict}
 
     def __setstate__(self, state):
         self._graph = state["_graph"]

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -233,6 +233,25 @@ class BaseGraphTester:
         finally:
             gc.enable()
 
+    def test_views_of_temporary_graphs(self):
+        """A view stays usable when its graph was only a temporary.
+
+        In ``f().degree(weight=w)`` the graph is released as soon as
+        ``.degree`` returns, so the view must not need the graph object to
+        answer calls.
+        """
+        G = self.Graph([(0, 1), (1, 2)])
+        edges = [(0, 1), (1, 2)]
+        assert dict(self.Graph(edges).degree(weight="w")) == dict(G.degree(weight="w"))
+        assert dict(self.Graph(edges).degree([1])) == dict(G.degree([1]))
+        assert self.Graph(edges).degree(1, weight="w") == G.degree(1, weight="w")
+        assert list(self.Graph(edges).edges([1])) == list(G.edges([1]))
+        assert list(self.Graph(edges).edges(data=True, nbunch=[1])) == list(
+            G.edges(data=True, nbunch=[1])
+        )
+        assert dict(G.copy().degree(weight="w")) == dict(G.degree(weight="w"))
+        assert dict(G.subgraph([0, 1]).degree([0])) == {0: 1}
+
     def test_cached_views_survive_pickle_and_deepcopy(self):
         G = self.Graph()
         G.add_edge(0, 1)

--- a/networkx/classes/tests/test_graph.py
+++ b/networkx/classes/tests/test_graph.py
@@ -1,3 +1,4 @@
+import copy
 import gc
 import pickle
 import platform
@@ -202,6 +203,53 @@ class BaseGraphTester:
         assert id(G.nodes) == id(old_nodes)
         G._node = {}
         assert id(G.nodes) != id(old_nodes)
+
+    def test_views_do_not_create_reference_cycles(self):
+        """Reading the cached views must not make the graph collector-only.
+
+        The views hold the graph weakly (see reportviews), so a graph whose
+        views have been read is still reclaimed by reference counting alone.
+        """
+        gc.disable()
+        try:
+            G = self.Graph()
+            G.add_edges_from([(0, 1), (1, 2)])
+            for name in (
+                "nodes",
+                "adj",
+                "edges",
+                "in_edges",
+                "out_edges",
+                "degree",
+                "in_degree",
+                "out_degree",
+            ):
+                getattr(G, name, None)
+            G.number_of_edges()  # size() reads self.degree
+            str(G)  # __str__ reads number_of_edges()
+            ref = weakref.ref(G)
+            del G
+            assert ref() is None
+        finally:
+            gc.enable()
+
+    def test_cached_views_survive_pickle_and_deepcopy(self):
+        G = self.Graph()
+        G.add_edge(0, 1)
+        _ = G.edges  # populate the caches before copying
+        _ = G.degree
+        D = copy.deepcopy(G)
+        assert D.edges._graph is D
+        assert D.degree._graph is D  # not G
+        D.add_edge(1, 2)
+        assert D.number_of_edges() == G.number_of_edges() + 1
+        assert D.degree(2) == 1
+        if "<locals>" in self.Graph.__qualname__:
+            pytest.skip("pickle cannot serialize a class defined in a function")
+        H = pickle.loads(pickle.dumps(G, -1))
+        assert H.edges._graph is H
+        assert H.degree._graph is H
+        assert graphs_equal(G, H)
 
     def test_attributes_cached(self):
         G = self.K3.copy()

--- a/networkx/classes/tests/test_reportviews.py
+++ b/networkx/classes/tests/test_reportviews.py
@@ -1417,6 +1417,25 @@ def test_cache_dict_get_set_state(graph):
     deepcopy(G)
 
 
+@pytest.mark.parametrize(
+    "graph_class", [nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph]
+)
+def test_unpickled_views_are_callable(graph_class):
+    # Views hold their graph weakly. An unpickled view, or a view of a graph
+    # that no longer exists, must still answer nbunch/weight calls and pickle.
+    G = graph_class([(0, 1), (1, 2)])
+    ev = pickle.loads(pickle.dumps(G.edges, -1))
+    assert list(ev([1])) == list(G.edges([1]))
+    assert list(ev.data("w", nbunch=[1])) == list(G.edges.data("w", nbunch=[1]))
+    dv = pickle.loads(pickle.dumps(G.degree, -1))
+    assert dict(dv(weight="w")) == dict(G.degree(weight="w"))
+    assert dv(1) == G.degree(1)
+    # the graph is a temporary here: gone before pickling even starts
+    ev = pickle.loads(pickle.dumps(graph_class([(0, 1), (1, 2)]).edges, -1))
+    assert list(ev([1])) == list(G.edges([1]))
+    pickle.dumps(ev, -1)
+
+
 def test_edge_views_inherit_from_EdgeViewABC():
     all_edge_view_classes = (v for v in dir(nx.reportviews) if "Edge" in v)
     for eview_class in all_edge_view_classes:


### PR DESCRIPTION
We ran into https://github.com/networkx/networkx/discussions/7697 in one of our services too!
This was raised in https://github.com/networkx/networkx/issues/6235 too and unsetting the cached_property was the solution in the dowstream package, but I want to bring this up again and just wanted to understand if we can just use something like `weakref` to avoid depending on the cyclic garbage collector in CPython to clean up networkx graphs. A quick example to show the cyclic issue

```python
>>> import gc, weakref, networkx as nx
>>> gc.disable()
>>> G = nx.DiGraph([(0, 1)])
>>> r = weakref.ref(G)
>>> G.number_of_edges()
>>> del G
>>> print(r() is None)
```

will lead to `False` on main branch and `True` after this change.

A claude generated minimal reproduction which kind of matches our issues in task graphs that holds arrays in graph nodes.

```python
import gc, resource, sys, numpy as np, networkx as nx
mb = (1 << 20) if sys.platform == "darwin" else 1024
state, resident = [], []
for i in range(40):
    G = nx.path_graph(5)                                # a small task graph...
    G.graph["payload"] = np.full(30_000_000 // 8, 1.0)  # ...carrying 30 MB (untracked: invisible to the GC counters)
    G.number_of_edges()                                 # any view read: G is now in a cycle with its cached view
    state.extend([i] for i in range(4000))              # surviving allocations (a growing accumulator); the young sweeps they trigger promote G
    for _ in range(100_000): tmp = [0]                  # the rest of the work allocates and discards -> nets to zero on the GC counters
    resident.append(sum(isinstance(o, nx.Graph) for o in gc.get_objects()) - 1)
print("dead graphs resident, every 5th iteration:", resident[::5], "| final:", resident[-1])
print("automatic gen-2 sweeps:", gc.get_stats()[2]["collections"], "| peak RSS: %d MB" % (resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / mb))
```

| | dead graphs resident, every 5th iteration | final | gen-2 sweeps | peak RSS |
|---|---|---|---|---|
| `main`, 3.13 (= 3.14.5+) | `[0, 5, 5, 5, 5, 5, 5, 10]` | 9 | 0 | 415 MB |
| `main`, 3.12 | `[0, 3, 2, 4, 7, 9, 0, 3]` | 5 | 2 | 448 MB |
| this PR | `[0, 0, 0, 0, 0, 0, 0, 0]` | 0 | 0 | 95 MB |


#3011 and #5614 should also have some more context.