### PR TITLE
ENH: Speed up connectivity checks in random_reference and lattice_reference

### DIFF
--- a/networkx/algorithms/smallworld.py
+++ b/networkx/algorithms/smallworld.py
@@ -71,8 +71,6 @@ def random_reference(G, niter=1, connectivity=True, seed=None):
 
     from networkx.utils import cumulative_distribution, discrete_sequence
 
-    local_conn = nx.connectivity.local_edge_connectivity
-
     G = G.copy()
     keys, degrees = zip(*G.degree())  # keys, degree
     cdf = cumulative_distribution(degrees)  # cdf of degree
@@ -106,7 +104,7 @@ def random_reference(G, niter=1, connectivity=True, seed=None):
                 G.remove_edge(c, d)
 
                 # Check if the graph is still connected
-                if connectivity and local_conn(G, a, b) == 0:
+                if connectivity and not nx.has_path(G, a, b):
                     # Not connected, revert the swap
                     G.remove_edge(a, d)
                     G.remove_edge(c, b)
@@ -172,8 +170,6 @@ def lattice_reference(G, niter=5, D=None, connectivity=True, seed=None):
 
     from networkx.utils import cumulative_distribution, discrete_sequence
 
-    local_conn = nx.connectivity.local_edge_connectivity
-
     if len(G) < 4:
         raise nx.NetworkXError("Graph has fewer than four nodes.")
     if len(G.edges) < 2:
@@ -230,7 +226,7 @@ def lattice_reference(G, niter=5, D=None, connectivity=True, seed=None):
                     G.remove_edge(c, d)
 
                     # Check if the graph is still connected
-                    if connectivity and local_conn(G, a, b) == 0:
+                    if connectivity and not nx.has_path(G, a, b):
                         # Not connected, revert the swap
                         G.remove_edge(a, d)
                         G.remove_edge(c, b)


### PR DESCRIPTION
The motivation for this change is to speed up `nx.random_reference` and `nx.lattice_reference`.

Currently, connectivity after an edge swap is checked using `nx.local_edge_connectivity(G, a, b)==0`, where `(a, b)` is one of the edges selected for the swap. However, only reachability between nodes `a` and `b` needs to be checked here; therefore `nx.has_path` is sufficient for this purpose.

In a simple local benchmark ([benchmark.py](https://github.com/user-attachments/files/31742730/benchmark.py)), replacing `nx.local_edge_connectivity` with `nx.has_path` made `nx.random_reference` about 548× faster and `nx.lattice_reference` about 45× faster on average.

- random_reference: 12.6030 s -> 0.0230 s
- lattice_reference: 4.1919 s -> 0.0929 s

I also confirmed that the current implementation and this modification generate identical graphs for five different random seeds by comparing hashes of their edge lists.

The code after this change passes the tests in `test_smallworld.py`.