### PR TITLE
DOC: Fix gml docstring examples

### DIFF
--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -877,12 +877,44 @@ def write_gml(G, path, stringizer=None):
 
     Examples
     --------
-    >>> G = nx.path_graph(5)
-    >>> nx.write_gml(G, "test_path5.gml")
+    >>> from pathlib import Path
+    >>> import tempfile
+    >>> tmp_path = Path(tempfile.gettempdir())
+
+    >>> fpath = tmp_path / "test_path3.gml"
+    >>> G = nx.path_graph(3)
+    >>> nx.write_gml(G, fpath)
+
+    >>> with open(fpath) as fh:
+    ...     print(fh.read())
+    graph [
+      node [
+        id 0
+        label "0"
+      ]
+      node [
+        id 1
+        label "1"
+      ]
+      node [
+        id 2
+        label "2"
+      ]
+      edge [
+        source 0
+        target 1
+      ]
+      edge [
+        source 1
+        target 2
+      ]
+    ]
+    <BLANKLINE>
 
     Filenames ending in .gz or .bz2 will be compressed.
 
-    >>> nx.write_gml(G, "test_path5.gml.gz")
+    >>> fpath = tmp_path / "test_path5.gml.gz"
+    >>> nx.write_gml(G, fpath)
     """
     for line in generate_gml(G, stringizer):
         path.write((line + "\n").encode("ascii"))

--- a/networkx/readwrite/gml.py
+++ b/networkx/readwrite/gml.py
@@ -161,19 +161,24 @@ def read_gml(path, label="label", destringizer=None):
 
     Examples
     --------
+    >>> from pathlib import Path
+    >>> import tempfile
+    >>> tmp_path = Path(tempfile.gettempdir())
+
     >>> G = nx.path_graph(4)
-    >>> nx.write_gml(G, "test_path4.gml")
+    >>> fpath = tmp_path / "test_path4.gml"
+    >>> nx.write_gml(G, fpath)
 
     GML values are interpreted as strings by default:
 
-    >>> H = nx.read_gml("test_path4.gml")
+    >>> H = nx.read_gml(fpath)
     >>> H.nodes
     NodeView(('0', '1', '2', '3'))
 
     When a `destringizer` is provided, GML values are converted to the provided type.
     For example, integer nodes can be recovered as shown below:
 
-    >>> J = nx.read_gml("test_path4.gml", destringizer=int)
+    >>> J = nx.read_gml(fpath, destringizer=int)
     >>> J.nodes
     NodeView((0, 1, 2, 3))
 


### PR DESCRIPTION
The final set of updates to readwrite docstring examples. This is the last in the series of updates that fully removes all of the auto-generated file stubs from running the doctests! The failures due to dangling file handles were already fully fixed as of #8887.