### PR TITLE
BUG: Fix vf2 handling of isomorphism_iter with isolated subgraph nodes

### DIFF
--- a/networkx/algorithms/isomorphism/isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/isomorphvf2.py
@@ -316,6 +316,17 @@ class GraphMatcher:
         """Generator over isomorphisms between G1 and G2."""
         # Declare that we are looking for a graph-graph isomorphism.
         self.test = "graph"
+
+        # Check global properties
+        if self.G1.order() != self.G2.order():
+            return
+
+        # Check local properties
+        d1 = sorted(d for n, d in self.G1.degree)
+        d2 = sorted(d for n, d in self.G2.degree)
+        if d1 != d2:
+            return
+
         self.initialize()
         yield from self.match()
 

--- a/networkx/algorithms/isomorphism/tests/test_common.py
+++ b/networkx/algorithms/isomorphism/tests/test_common.py
@@ -520,6 +520,21 @@ def test_graph_input_order(morphism):
 
 
 @pytest.mark.parametrize("Gclass", graph_classes)
+@pytest.mark.parametrize("iso_ic, iso_iter", morphic_and_mapping)
+def test_full_graph_or_subgraph_isomorphisms_iter(Gclass, iso_ic, iso_iter):
+    # motivated by gh-8891 which reported subgraph_iso from iso_iter
+    # so is_isomorphic was False while isomorphisms_iter yielded mappings
+    # only when both have isolated nodes
+    G1 = nx.empty_graph(2, create_using=Gclass)
+    G2 = nx.empty_graph(1, create_using=Gclass)
+
+    any_mappings = bool(list(iso_iter(G1, G2)))
+    subgraph_or_mono = "SG" in iso_ic.__name__
+    assert iso_ic(G1, G2) == any_mappings
+    assert any_mappings == subgraph_or_mono
+
+
+@pytest.mark.parametrize("Gclass", graph_classes)
 @pytest.mark.parametrize("G", solo_graphs)
 @pytest.mark.parametrize("symmetry", [True, False])
 @pytest.mark.parametrize("iso_ic, iso_iter", morphic_and_mapping)

--- a/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
+++ b/networkx/algorithms/isomorphism/tests/test_isomorphvf2.py
@@ -62,11 +62,10 @@ class TestWikipediaExample:
         assert gm.subgraph_is_monomorphic()
         assert gm.subgraph_is_isomorphic()
 
-        mapping = list(gm.mapping.items())
         # this mapping is only one of the 48 possibilities
         all_mappings = list(gm.isomorphisms_iter())
         assert len(all_mappings) == numb_maps
-        assert dict(mapping) in all_mappings
+        assert gm.mapping in all_mappings
 
     @pytest.mark.parametrize("graph_class", [nx.Graph, nx.DiGraph])
     def test_subgraph(self, graph_class):
@@ -384,6 +383,26 @@ def test_isomorphism_iter2():
         gm = iso.GraphMatcher(g1, g1)
         s = len(list(gm.isomorphisms_iter()))
         assert s == 2 * L
+
+
+@pytest.mark.parametrize(
+    "is_directed, matcher", [(nx.Graph, iso.GraphMatcher), (nx.Graph, iso.GraphMatcher)]
+)
+def test_isomorphisms_iter3(is_directed, matcher):
+    # motivated by gh-8891 which reported subgraph isomorphisms
+    G1 = nx.empty_graph(2, create_using=is_directed)
+    G2 = nx.empty_graph(1, create_using=is_directed)
+    gm = matcher(G1, G2)
+
+    # Check: G1 is subgraph isomorphic to G2, but not isomorphic
+    assert not gm.is_isomorphic()
+    assert gm.subgraph_is_isomorphic()
+    assert gm.subgraph_is_monomorphic()
+
+    # check that morphism_iter matches is_morphic
+    assert not list(gm.isomorphisms_iter())
+    assert list(gm.subgraph_isomorphisms_iter())
+    assert list(gm.subgraph_monomorphisms_iter())
 
 
 def test_multiple():


### PR DESCRIPTION
Fixes #8891 

This is a corner case when subgraph has an isolated node and graph is subgraph isomorphic (and not isomorphic) to subgraph. The `is_isomorphic` method correctly returned False, but `isomorphisms_iter` generated mappings.

Added two tests (one for vf2 and one in `test_common.py` for all algorithms.