### PR TITLE
DOC: Fix Parameters indentation in generate_gexf

### DIFF
--- a/networkx/readwrite/gexf.py
+++ b/networkx/readwrite/gexf.py
@@ -162,14 +162,14 @@ def generate_gexf(G, encoding="utf-8", prettyprint=True, version="1.2draft"):
     Parameters
     ----------
     G : graph
-    A NetworkX graph
+       A NetworkX graph
     encoding : string (optional, default: 'utf-8')
-    Encoding for text data.
+       Encoding for text data.
     prettyprint : bool (optional, default: True)
-    If True use line breaks and indenting in output XML.
+       If True use line breaks and indenting in output XML.
     version : string (default: 1.2draft)
-    Version of GEFX File Format (see http://gexf.net/schema.html)
-    Supported values: "1.1draft", "1.2draft"
+       Version of GEFX File Format (see http://gexf.net/schema.html)
+       Supported values: "1.1draft", "1.2draft"
 
     Yields
     ------


### PR DESCRIPTION
The Parameters section of `generate_gexf` never had its description lines indented, so numpydoc reads each description as another parameter name. The [rendered docs](https://networkx.org/documentation/stable/reference/readwrite/generated/networkx.readwrite.gexf.generate_gexf.html) list nine parameters instead of four, and none of the real ones show a description.

<img width="648" height="601" alt="docs_generate_gexf" src="https://github.com/user-attachments/assets/6c40704b-d91e-4d6a-a8d9-8d2f34cc2076" />

Indenting the five lines to match `write_gexf` further up the file fixes the parse. Whitespace only, so `git diff -w` comes back empty.

AI assistance was used on this PR (Claude Opus, via Claude Code) to find the mis-parsed docstring and make the change. I checked the before and after parse myself.
