### PR TITLE
BUG: Fix _hits_numpy inf/NaN when eigh returns negated eigenvector

### DIFF
--- a/networkx/algorithms/link_analysis/hits_alg.py
+++ b/networkx/algorithms/link_analysis/hits_alg.py
@@ -293,6 +293,13 @@ def _hits_numpy(G, normalized=True):
     A = adj_ary.T @ adj_ary
     e, ev = np.linalg.eigh(A)
     a = ev[:, np.argmax(e)]  # eigenvector corresponding to the maximum eigenvalue
+    # Eigenvectors are only defined up to sign. Orient so the largest-magnitude
+    # entry is positive before scaling (avoids divide-by-zero when all entries
+    # are non-positive, which can happen after the switch to np.linalg.eigh).
+    if h[np.argmax(np.abs(h))] < 0:
+        h = -h
+    if a[np.argmax(np.abs(a))] < 0:
+        a = -a
     if normalized:
         h /= h.sum()
         a /= a.sum()

--- a/networkx/algorithms/link_analysis/tests/test_hits.py
+++ b/networkx/algorithms/link_analysis/tests/test_hits.py
@@ -41,6 +41,16 @@ class TestHITS:
         for n in G:
             assert a[n] == pytest.approx(G.a[n], abs=1e-4)
 
+    def test_hits_numpy_normalized_false_finite(self):
+        # Regression for gh-8898: eigh can return a negated dominant
+        # eigenvector; scaling by max() must not produce inf/NaN.
+        G = nx.path_graph(3)
+        hubs, authorities = _hits_numpy(G, normalized=False)
+        assert all(np.isfinite(v) for v in hubs.values())
+        assert all(np.isfinite(v) for v in authorities.values())
+        assert all(v >= 0 for v in hubs.values())
+        assert all(v >= 0 for v in authorities.values())
+
     @pytest.mark.parametrize(
         "hits_alg",
         (nx.hits, partial(nx.hits, method="svd"), _hits_python, _hits_svd),


### PR DESCRIPTION
After #8859 switched `_hits_numpy` from `np.linalg.eig` to `np.linalg.eigh`, the dominant eigenvector can come back with the opposite global sign. For graphs like `path_graph(3)`, that means every entry is non-positive, so `h.max()` / `a.max()` is `0` and `normalized=False` produces `inf`/`NaN`.

This PR flips the hub and authority eigenvectors when the largest-magnitude entry is negative, then keeps the existing max-scaling. That keeps HITS scores non-negative and avoids the divide-by-zero. (Using `np.abs(h).max()` alone would also avoid NaNs, but would leave negative scores.)

Fixes #8898

### AI disclosure
AI tools were used to help draft the patch and regression test. I reviewed the issue and related code (including #8859), verified the failure on `path_graph(3)`, ran the hits test suite locally, and take responsibility for the change.

### Test plan
- [x] Added regression test `test_hits_numpy_normalized_false_finite` for `path_graph(3)` with `normalized=False`
- [x] `pytest networkx/algorithms/link_analysis/tests/test_hits.py` (11 passed)